### PR TITLE
chore: install nanoarrow from cran

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,6 @@ Suggests:
     nycflights13,
     patrick,
     bit64
-Remotes: nanoarrow=github::apache/arrow-nanoarrow/r
 Config/testthat/edition: 3
 Collate: 
     'utils.R'


### PR DESCRIPTION
nanoarrow is now on CRAN.