### PR TITLE
chore: install nanoarrow from cran (#72)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,6 @@ Suggests:
     nycflights13,
     patrick,
     bit64
-Remotes: nanoarrow=github::apache/arrow-nanoarrow/r
 Config/testthat/edition: 3
 Collate: 
     'utils.R'


### PR DESCRIPTION
r-univese cannot find nanoarrow on github, try push the commit to runiverse

https://github.com/r-universe/rpolars/actions/runs/4392816596/jobs/7692815192#step:3:512