### PR TITLE
Expand `path` in `pl$lazy_csv_reader`

### DIFF
--- a/R/csv.R
+++ b/R/csv.R
@@ -83,6 +83,8 @@ lazy_csv_reader = function(
 
   #capture all args and modify some to match lower level function
   args = as.list(environment())
+  
+  args[["path"]] = path.expand(path)
 
   #overwrite_dtype: convert named list of DataType's to DataTypeVector obj
   if(!is.null(args$overwrite_dtype)) {


### PR DESCRIPTION
1-line commit to ensure that `pl$lazy_csv_reader` and friends expand paths.

``` r
library(polars)
write.csv(airquality, "~/Downloads/air.csv")

pl$csv_reader("~/Downloads/air.csv")
# Error: in rlazy_csv_reader: Io(Os { code: 2, kind: NotFound, message: "No such file or directory" }) 
#  when calling :
```
