### PR TITLE
Issue Some methods execute `LazyFrame$collect()` #146

### DIFF
--- a/R/s3_methods.R
+++ b/R/s3_methods.R
@@ -20,7 +20,9 @@ dim.DataFrame = function(x, ...) x$shape
 
 #' @export
 #' @noRd
-dim.LazyFrame = function(x, ...) x$collect()$shape
+dim.LazyFrame = function(x, ...) {
+    stop("The lazy data frame must be collected before calling this function: `dim(x$collect())`", call. = FALSE)
+}
 
 #' @export
 #' @noRd
@@ -32,7 +34,9 @@ length.Series = function(x, ...) x$len()
 
 #' @export
 #' @noRd
-length.LazyFrame = function(x, ...) x$collect()$width
+length.LazyFrame = function(x, ...) {
+    stop("The lazy data frame must be collected before using calling this function: `length(x$collect())`", call. = FALSE)
+}
 
 #' The Number of Rows of a DataFrame 
 #' @param x DataFrame
@@ -44,7 +48,9 @@ nrow.DataFrame = function(x) x$height
 #' @param x LazyFrame
 #' @return Integer
 #' @export
-nrow.LazyFrame = function(x) x$collect()$height
+nrow.LazyFrame = function(x) {
+    stop("The lazy data frame must be collected before using calling this function: `nrow(x$collect())`", call. = FALSE)
+}
 
 #' The Number of Columns of a DataFrame 
 #' @param x DataFrame
@@ -62,12 +68,12 @@ ncol.LazyFrame = function(x) x$collect()$height
 #' @noRd
 names.DataFrame = function(x) x$columns
 
-# TODO: inefficient to collect, but attribute is missing
 #' @export
 #' @noRd
-names.LazyFrame = function(x) x$collect()$columns
+names.LazyFrame = function(x) {
+    stop("The lazy data frame must be collected before using calling this function: `names(x$collect())`", call. = FALSE)
+}
 
-# TODO: inefficient to collect, but attribute is missing
 #' @export
 #' @noRd
 as.data.frame.LazyFrame = function(x, ...) x$collect()$to_data_frame(...)
@@ -76,7 +82,6 @@ as.data.frame.LazyFrame = function(x, ...) x$collect()$to_data_frame(...)
 #' @noRd
 as.matrix.DataFrame = function(x, ...) as.matrix(x$to_data_frame(...))
 
-# TODO: inefficient to collect, but attribute is missing
 #' @export
 #' @noRd
 as.matrix.LazyFrame = function(x, ...) as.matrix(x$collect()$to_data_frame(...))

--- a/tests/testthat/test-s3_methods.R
+++ b/tests/testthat/test-s3_methods.R
@@ -40,11 +40,17 @@ patrick::with_parameters_test_that("inspection",
         d = pl$DataFrame(mtcars)
         x = FUN(mtcars)
         y = FUN(d)
-        z = FUN(d$lazy())
         if (inherits(y, "DataFrame")) y = y$to_data_frame()
-        if (inherits(z, "LazyFrame")) z = z$collect()$to_data_frame()
         expect_equal(x, y, ignore_attr = TRUE)
-        expect_equal(x, z, ignore_attr = TRUE)
+        if (.test_name %in% c("length", "nrow", "ncol", "names")) {
+          expect_error(FUN(d$lazy()))
+        } else if (.test_name == "as.matrix") {
+          z = FUN(d$lazy())
+          expect_equal(x, z, ignore_attr = TRUE)
+        } else {
+          z = FUN(d$lazy())$collect()$to_data_frame()
+          expect_equal(x, z, ignore_attr = TRUE)
+        }
     },
     .cases = make_cases()
 )


### PR DESCRIPTION
#146

The only S3 methods which now call collect are `as.data.frame()` and `as.matrix()`. In those cases, the user makes an explicit choice to bring everything in memory as R objects, so it seems fine to me.

In all other cases, an informative error is raised.