### PR TITLE
chore: rename the crate and lib to r-polars

### DIFF
--- a/inst/misc/Makevars_symlinking
+++ b/inst/misc/Makevars_symlinking
@@ -1,8 +1,8 @@
 LIBDIR = ./rust/target/release
-STATLIB = $(LIBDIR)/libpolars.a
+STATLIB = $(LIBDIR)/libr_polars.a
 PKG_LIBS = -L$(LIBDIR) -lrpolars
 CARGO_MANIFEST ?= ./rust/Cargo.toml
-CARGO_RELEASE = /Users/sorenwelling/Documents/projs/r-polars/src/rust/target/release/libpolars.a
+CARGO_RELEASE = /Users/sorenwelling/Documents/projs/r-polars/src/rust/target/release/libr_polars.a
 
 all: C_clean
 
@@ -10,13 +10,13 @@ $(SHLIB): $(STATLIB)
 
 $(STATLIB):
   cargo build --lib --release --manifest-path=$(CARGO_MANIFEST)
-if [ -s "./rust/target/release/libpolars.a" ]; \
+if [ -s "./rust/target/release/libr_polars.a" ]; \
 then \
 echo "dir was there" ; \
 else \
 echo "dir was not there" ; \
 mkdir -p ./rust/target/release ; \
-ln -s $(CARGO_RELEASE) ./rust/target/release/libpolars.a ; \
+ln -s $(CARGO_RELEASE) ./rust/target/release/libr_polars.a ; \
 fi;
 echo "done"
 

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,9 +1,9 @@
 LIBDIR = ./rust/target/release
-STATLIB = $(LIBDIR)/libpolars.a
-PKG_LIBS = -L$(LIBDIR) -lpolars
+STATLIB = $(LIBDIR)/libr_polars.a
+PKG_LIBS = -L$(LIBDIR) -lr_polars
 RPOLARS_RUST_SOURCE ?= ./rust
 RPOLARS_CARGO_CLEAN_DEPS ?= nope
-rpolars_ext_binary = "$(RPOLARS_RUST_SOURCE)/target/release/libpolars.a"
+rpolars_ext_binary = "$(RPOLARS_RUST_SOURCE)/target/release/libr_polars.a"
 
 all: C_clean
 
@@ -17,7 +17,7 @@ $(STATLIB):
 		echo "no, file is NOT there: "; \
 		mkdir -p ./rust/target/release ; \
 		echo "trying to symlink in $(rpolars_ext_binary)"; \
-		ln -s $(rpolars_ext_binary) ./rust/target/release/libpolars.a ; \
+		ln -s $(rpolars_ext_binary) ./rust/target/release/libr_polars.a ; \
 	fi
 
 	if [ "${RPOLARS_CARGO_CLEAN_DEPS}" == "true" ]; then \

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -5,11 +5,11 @@ TOOLCHAIN ?= stable-msvc
 
 TARGET_DIR = ./rust/target
 LIBDIR = $(TARGET_DIR)/$(TARGET)/release
-STATLIB = $(LIBDIR)/libpolars.a
-PKG_LIBS = -L$(LIBDIR) -lpolars -lws2_32 -ladvapi32 -luserenv -lbcrypt -lole32 -lntdll -lpsapi -liphlpapi -lpdh -lpowrprof -loleaut32 -lnetapi32 -lsecur32 -t
+STATLIB = $(LIBDIR)/libr_polars.a
+PKG_LIBS = -L$(LIBDIR) -lr_polars -lws2_32 -ladvapi32 -luserenv -lbcrypt -lole32 -lntdll -lpsapi -liphlpapi -lpdh -lpowrprof -loleaut32 -lnetapi32 -lsecur32 -t
 RPOLARS_RUST_SOURCE ?= ./rust
 RPOLARS_CARGO_CLEAN_DEPS ?= nope
-rpolars_ext_binary = "$(RPOLARS_RUST_SOURCE)/target/$(TARGET)/release/libpolars.a"
+rpolars_ext_binary = "$(RPOLARS_RUST_SOURCE)/target/$(TARGET)/release/libr_polars.a"
 
 all: C_clean
 
@@ -34,7 +34,7 @@ $(STATLIB):
 	else \
 		echo "binary not built here, trying to symlink in $(rpolars_ext_binary)"; \
 		mkdir -p $(LIBDIR) ; \
-		ln -s $(rpolars_ext_binary) $(LIBDIR)/libpolars.a ; \
+		ln -s $(rpolars_ext_binary) $(LIBDIR)/libr_polars.a ; \
 	fi
 
 	# CRAN might even need more files to be gone, delete them here...

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -1563,21 +1563,6 @@ dependencies = [
 
 [[package]]
 name = "polars"
-version = "0.1.0"
-dependencies = [
- "extendr-api",
- "flume",
- "jemallocator",
- "mimalloc",
- "polars 0.27.2",
- "polars-core",
- "rayon",
- "smartstring",
- "state",
-]
-
-[[package]]
-name = "polars"
 version = "0.27.2"
 source = "git+https://github.com/pola-rs/polars.git?rev=01126f2524108ac8fe567e1dbb24a74ca9ec39e7#01126f2524108ac8fe567e1dbb24a74ca9ec39e7"
 dependencies = [
@@ -1795,6 +1780,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-polars"
+version = "0.1.0"
+dependencies = [
+ "extendr-api",
+ "flume",
+ "jemallocator",
+ "mimalloc",
+ "polars",
+ "polars-core",
+ "rayon",
+ "smartstring",
+ "state",
 ]
 
 [[package]]

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = 'polars'   # r-polars
+name = 'r-polars'   # r-polars
 version = '0.1.0' # this version no is not used
 edition = '2021'
 


### PR DESCRIPTION
Related to #149

Rename the internal Rust crate from `polars` to `r-polars` for clarity.