### PR TITLE
Fix doc ordering and usage section

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,7 @@ Config/Needs/website:
     Genentech/rd2markdown@c4fb386,
     magrittr,
     Rd2md,
-    stringr
+    stringr,
     tinkr,
     yaml
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,7 @@ Config/Needs/website:
     Rd2md,
     stringr
     tinkr,
-    yaml,
+    yaml
 Config/testthat/edition: 3
 Collate: 
     'utils.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,13 +31,14 @@ Suggests:
     rmarkdown,
     withr
 Config/Needs/website:
+    cli,
     etiennebacher/altdoc,
     Genentech/rd2markdown@c4fb386,
-    yaml,
     magrittr,
-    cli,
-    tinkr,
+    Rd2md,
     stringr
+    tinkr,
+    yaml,
 Config/testthat/edition: 3
 Collate: 
     'utils.R'

--- a/docs/mkdocs.orig.yml
+++ b/docs/mkdocs.orig.yml
@@ -28,6 +28,7 @@ markdown_extensions:
   - pymdownx.highlight:
       anchor_linenums: yes
   - pymdownx.superfences
+  - def_list
 repo_url: https://github.com/pola-rs/r-polars
 repo_name: r-polars
 plugins:


### PR DESCRIPTION
Mentioned in #182:

* fix ordering (previously the description came after the "Returns" section)
* fix usage section, e.g `DataFrame_shift_and_fill(fill_value, periods = 1)()` -> `<DataFrame>$shift_and_fill(fill_value, periods = 1)`. 

*Note:* I had to hardcode the usage of `pl$DataFrame()` in `docs/make-docs.R` because it doesn't appear in the Rd file because of the `$`.

Small preview:

![image](https://user-images.githubusercontent.com/52219252/235114307-a0d8f47a-de55-4f86-a437-e677cfa60bd6.png)

![image](https://user-images.githubusercontent.com/52219252/235114395-d3dccd98-73ff-464d-ace1-444d0909d049.png)
