### PR TITLE
bump polars to 0.6.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: polars
 Title: Polars ported to R
-Version: 0.5.0.9003
+Version: 0.6.0
 Depends: R (>= 4.1.0)
 Imports: utils, codetools
 Authors@R:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# polars (development version)
+# polars 0.6.0
 
 ## BREAKING CHANGES
 


### PR DESCRIPTION
I checked with github autogen and it seems all PR's are mentioned in NEWS except, PR's updating the news it self (#108, #118) and a refactor of internal conversion (`robj_to!(u8, ...)` #115 ) which I guess should be omitted.