### PR TITLE
R 4.2 -> 4.3 for r-universe binaries

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -113,7 +113,7 @@ relevant for developers, or users of unsupported operating systems).
 Speeding up your workflow? On Ubuntu, install polars + arrow from binaries and resolve
 system dependencies reliably and quickly with r2u ([see link for configuration](https://eddelbuettel.github.io/r2u/)).
 ```r
-rp = c("https://rpolars.r-universe.dev/bin/linux/jammy/4.2", "https://cloud.r-project.org")
+rp = c("https://rpolars.r-universe.dev/bin/linux/jammy/4.3", "https://cloud.r-project.org")
 install.packages(c("polars", "arrow"), repos = rp)
 ```
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ binaries and resolve system dependencies reliably and quickly with r2u
 ([see link for configuration](https://eddelbuettel.github.io/r2u/)).
 
 ``` r
-rp = c("https://rpolars.r-universe.dev/bin/linux/jammy/4.2", "https://cloud.r-project.org")
+rp = c("https://rpolars.r-universe.dev/bin/linux/jammy/4.3", "https://cloud.r-project.org")
 install.packages(c("polars", "arrow"), repos = rp)
 ```
 


### PR DESCRIPTION
Installation of binaries from r-universe now prefers a '4.3' path for the current R release.