### PR TITLE
Use `maintain_order = TRUE` in README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -146,8 +146,11 @@ encapsulated in the `DataFrame` object itself. For example, we can chain the
 column of the dataset:
 
 ```{r}
-dat$groupby("cyl")$mean()
+dat$groupby("cyl", maintain_order = TRUE)$mean()
 ```
+
+Note that we use `maintain_order = TRUE` so that `polars` always keeps the groups
+in the same order as they are in the original data.
 
 [The **polars** vignette](https://rpolars.github.io/articles/polars/)
 contains many more examples of how to use the package to:

--- a/README.md
+++ b/README.md
@@ -169,18 +169,21 @@ chain the `$groupby()` and the `$mean()` methods to compute group-wise
 means for each column of the dataset:
 
 ``` r
-dat$groupby("cyl")$mean()
+dat$groupby("cyl", maintain_order = TRUE)$mean()
 #> shape: (3, 11)
 #> ┌─────┬───────────┬────────────┬────────────┬─────┬──────────┬──────────┬──────────┬──────────┐
 #> │ cyl ┆ mpg       ┆ disp       ┆ hp         ┆ ... ┆ vs       ┆ am       ┆ gear     ┆ carb     │
 #> │ --- ┆ ---       ┆ ---        ┆ ---        ┆     ┆ ---      ┆ ---      ┆ ---      ┆ ---      │
 #> │ f64 ┆ f64       ┆ f64        ┆ f64        ┆     ┆ f64      ┆ f64      ┆ f64      ┆ f64      │
 #> ╞═════╪═══════════╪════════════╪════════════╪═════╪══════════╪══════════╪══════════╪══════════╡
-#> │ 4.0 ┆ 26.663636 ┆ 105.136364 ┆ 82.636364  ┆ ... ┆ 0.909091 ┆ 0.727273 ┆ 4.090909 ┆ 1.545455 │
 #> │ 6.0 ┆ 19.742857 ┆ 183.314286 ┆ 122.285714 ┆ ... ┆ 0.571429 ┆ 0.428571 ┆ 3.857143 ┆ 3.428571 │
+#> │ 4.0 ┆ 26.663636 ┆ 105.136364 ┆ 82.636364  ┆ ... ┆ 0.909091 ┆ 0.727273 ┆ 4.090909 ┆ 1.545455 │
 #> │ 8.0 ┆ 15.1      ┆ 353.1      ┆ 209.214286 ┆ ... ┆ 0.0      ┆ 0.142857 ┆ 3.285714 ┆ 3.5      │
 #> └─────┴───────────┴────────────┴────────────┴─────┴──────────┴──────────┴──────────┴──────────┘
 ```
+
+Note that we use `maintain_order = TRUE` so that `polars` always keeps
+the groups in the same order as they are in the original data.
 
 [The **polars** vignette](https://rpolars.github.io/articles/polars/)
 contains many more examples of how to use the package to:


### PR DESCRIPTION
Close #189. 

@sorhawell before merging, do we highlight `maintain_order` somewhere in the docs? (cf suggestion in #189)
