### PR TITLE
pak::local_install_deps(upgrade = FALSE) for ensure binary install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ requirements: requirements-r requirements-py requirements-rs ## Install all proj
 .PHONY: requirements-r
 requirements-r:
 	Rscript -e 'install.packages("pak", repos = sprintf("https://r-lib.github.io/p/pak/stable/%s/%s/%s", .Platform$$pkgType, R.Version()$$os, R.Version()$$arch))'
-	Rscript -e 'pak::repo_add(extendr = "https://extendr.r-universe.dev"); pak::local_install_deps(dependencies = c("all", "Config/Needs/dev", "Config/Needs/website"))'
+	Rscript -e 'pak::repo_add(extendr = "https://extendr.r-universe.dev"); pak::local_install_deps(dependencies = c("all", "Config/Needs/dev", "Config/Needs/website"), upgrade = FALSE)'
 
 .venv:
 	python3 -m venv $(VENV)


### PR DESCRIPTION
make requirements-r calls

`pak::local_install_deps(dependencies = c("all", "Config/Needs/dev", "Config/Needs/website"))`

however `upgrade=TRUE` will implicitly try compile any +100 dev dependencies of CRAN does not have the binary yet. This is a problem on a macbook because various packages do not easily compile on any version, e.g. take httpuv where best fix is not manually modify makevars file.

https://github.com/rstudio/httpuv/issues/325

I suggest setting upgrade = FALSE. This will not only prefer binaries, but also only upgrade if strictly required (which is not ideal I guess). It seems pak provides no middle ground like, "prefer latest binary for any package".


If a better solution exists, we should just ditch this PR.