### PR TITLE
try preload nanoarrow before building polars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,8 @@ requirements-rs:
 
 .PHONY: build
 build: ## Compile polars R package and generate Rd files
-	Rscript -e 'rextendr::document()'
+	Rscript -e 'if(!(require(arrow)&&require(nanoarrow))) warning("could not load arrow/nanoarrow, igonore changes to nanoarrow.Rd");rextendr::document()'
+
 
 .PHONY: all
 all: build test README.md ## build -> test -> Update README.md


### PR DESCRIPTION
this PR replaces #202 

loads nanoarrow and arrow in `make build` inorder for roxygen2 render nanoarrow.Rd correctly