### PR TITLE
chore: bump dev packages and fix test

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Suggests:
     tibble,
     withr
 Config/Needs/website:
-    etiennebacher/altdoc,
+    altdoc,
     here,
     magrittr,
     pkgload,
@@ -81,5 +81,5 @@ Collate:
     'translation.R'
     'vctrs.R'
     'zzz.R'
-Config/rextendr/version: 0.2.0.9000
+Config/rextendr/version: 0.3.0
 VignetteBuilder: knitr

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ requirements: requirements-r requirements-py requirements-rs ## Install all proj
 .PHONY: requirements-r
 requirements-r:
 	Rscript -e 'install.packages("pak", repos = sprintf("https://r-lib.github.io/p/pak/stable/%s/%s/%s", .Platform$$pkgType, R.Version()$$os, R.Version()$$arch))'
-	Rscript -e 'pak::repo_add(extendr = "https://extendr.r-universe.dev"); pak::local_install_deps(dependencies = c("all", "Config/Needs/dev", "Config/Needs/website"), upgrade = FALSE)'
+	Rscript -e 'pak::local_install_deps(dependencies = c("all", "Config/Needs/dev", "Config/Needs/website"), upgrade = FALSE)'
 
 .venv:
 	python3 -m venv $(VENV)

--- a/tests/testthat/_snaps/knitr.md
+++ b/tests/testthat/_snaps/knitr.md
@@ -16,17 +16,14 @@
       pl$DataFrame(df)
       ```
       
-      ```
-      ## shape: (3, 2)
-      ## ┌─────┬─────┐
-      ## │ a   ┆ b   │
-      ## │ --- ┆ --- │
-      ## │ i32 ┆ str │
-      ## ╞═════╪═════╡
-      ## │ 1   ┆ a   │
-      ## │ 2   ┆ b   │
-      ## │ 3   ┆ c   │
-      ## └─────┴─────┘
+      ```{=html}
+      <div><style>
+      .dataframe > thead > tr > th,
+      .dataframe > tbody > tr > td {
+        text-align: right;
+      }
+      </style>
+      <small>shape: (3, 2)</small><table border="1" class="dataframe"><thead><tr><th>a</th><th>b</th></tr><tr><td>i32</td><td>str</td></tr></thead><tbody><tr><td>1</td><td>&quot;a&quot;</td></tr><tr><td>2</td><td>&quot;b&quot;</td></tr><tr><td>3</td><td>&quot;c&quot;</td></tr></tbody></table></div>
       ```
 
 ---


### PR DESCRIPTION
Minor changes to address the following three recently CRAN released packages.

- altdoc
- knitr
- rextendr

Currently the test is broken by the new version of knitr, so this PR needs to be merged.