### PR TITLE
disable docs deployment if not DEPLOY_DOCS key is present in github SECRETS

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -63,7 +63,7 @@ jobs:
       - uses: webfactory/ssh-agent@v0.6.0
         env: 
           DEPLOY_DOCS: ${{ secrets.DEPLOY_DOCS  }}
-        if: ${{ (github.event_name != 'pull_request') && (env.DEPLOY_DOCS != '') }} 
+        if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'sorhawell') }} 
         with:
           ssh-private-key: ${{ secrets.DEPLOY_DOCS }}
 
@@ -71,7 +71,7 @@ jobs:
       - name: Build site and deploy to GitHub pages
         env: 
           DEPLOY_DOCS: ${{ secrets.DEPLOY_DOCS  }}
-        if: ${{ (github.event_name != 'pull_request') && (env.DEPLOY_DOCS != '') }} 
+        if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'sorhawell') }} 
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           clean: true

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -61,13 +61,17 @@ jobs:
         run: make docs
 
       - uses: webfactory/ssh-agent@v0.6.0
-        if: ${{ (github.event_name != 'pull_request') && (secrets.DEPLOY_DOCS != "") }} 
+        env: 
+          DEPLOY_DOCS: ${{ secrets.DEPLOY_DOCS  }}
+        if: ${{ (github.event_name != 'pull_request') && (env.DEPLOY_DOCS != "") }} 
         with:
           ssh-private-key: ${{ secrets.DEPLOY_DOCS }}
 
         # https://www.mkdocs.org/user-guide/deploying-your-docs/
       - name: Build site and deploy to GitHub pages
-        if: ${{ (github.event_name != 'pull_request') && (secrets.DEPLOY_DOCS != "") }}
+        env: 
+          DEPLOY_DOCS: ${{ secrets.DEPLOY_DOCS  }}
+        if: ${{ (github.event_name != 'pull_request') && (env.DEPLOY_DOCS != "") }} 
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           clean: true

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -63,7 +63,7 @@ jobs:
       - uses: webfactory/ssh-agent@v0.6.0
         env: 
           DEPLOY_DOCS: ${{ secrets.DEPLOY_DOCS  }}
-        if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'sorhawell') }} 
+        if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'pola-rs') }} 
         with:
           ssh-private-key: ${{ secrets.DEPLOY_DOCS }}
 
@@ -71,7 +71,7 @@ jobs:
       - name: Build site and deploy to GitHub pages
         env: 
           DEPLOY_DOCS: ${{ secrets.DEPLOY_DOCS  }}
-        if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'sorhawell') }} 
+        if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'pola-rs') }} 
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           clean: true

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -63,7 +63,7 @@ jobs:
       - uses: webfactory/ssh-agent@v0.6.0
         env: 
           DEPLOY_DOCS: ${{ secrets.DEPLOY_DOCS  }}
-        if: ${{ (github.event_name != 'pull_request') && (env.DEPLOY_DOCS != "") }} 
+        if: ${{ (github.event_name != 'pull_request') && (env.DEPLOY_DOCS != '') }} 
         with:
           ssh-private-key: ${{ secrets.DEPLOY_DOCS }}
 
@@ -71,7 +71,7 @@ jobs:
       - name: Build site and deploy to GitHub pages
         env: 
           DEPLOY_DOCS: ${{ secrets.DEPLOY_DOCS  }}
-        if: ${{ (github.event_name != 'pull_request') && (env.DEPLOY_DOCS != "") }} 
+        if: ${{ (github.event_name != 'pull_request') && (env.DEPLOY_DOCS != '') }} 
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           clean: true


### PR DESCRIPTION
Any fork having a branch called main will currently try to deploy docs without the DEPLOY_DOCS key and fail.
That is annoying for any external developer.

This PR aborts deploying docs if not DEPLOY_DOCS key are actively stored in fork repo.