### PR TITLE
feat!: add `simd` feature and remove `polars/simd` from the default feature

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  RPOLARS_ALL_FEATURES: "true"
+
 jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -20,6 +20,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  RPOLARS_ALL_FEATURES: "true"
+
 jobs:
   documentation:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  RPOLARS_ALL_FEATURES: "true"
+
 jobs:
   build:
     runs-on: ${{ matrix.config.os }}

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@ for demonstration purposes (#240).
 - Polars is internally moving away from string errors to a new error-type called `RPolarsErr` both on rust- and R-side. Final error messages should look very similar (#233).
 - LazyFrame_columns, _schema, _dtypes implemented. Improvements to internal `RPolarsErr`. Also `RPolarsErr` will now print each context of the error on a separate line (#250).
 - Add helpful reference landing page at `polars.github.io/reference_home` (#223).
+- rust-polars' `simd` feature is now disabled by default. To enable it, set the environment variable
+  `RPOLARS_ALL_FEATURES` to `true` when build r-polars (#262).
 
 # polars 0.6.1
 ## What's changed

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,10 +7,9 @@
 for demonstration purposes (#240).
 - Polars is internally moving away from string errors to a new error-type called `RPolarsErr` both on rust- and R-side. Final error messages should look very similar (#233).
 - LazyFrame_columns, _schema, _dtypes implemented. Improvements to internal `RPolarsErr`. Also `RPolarsErr` will now print each context of the error on a separate line (#250).
-- Add helpful reference landing page at `polars.github.io/reference_home` (#223).
+- Add helpful reference landing page at `polars.github.io/reference_home` (#223, #264).
 - rust-polars' `simd` feature is now disabled by default. To enable it, set the environment variable
   `RPOLARS_ALL_FEATURES` to `true` when build r-polars (#262).
-- Add helpful reference landing page at `polars.github.io/reference_home` (#223, #264).
 
 # polars 0.6.1
 ## What's changed

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,3 +1,5 @@
+BUILD_COMMAND = cargo build --lib --release --manifest-path="$(RPOLARS_RUST_SOURCE)/Cargo.toml"
+
 LIBDIR = ./rust/target/release
 STATLIB = $(LIBDIR)/libr_polars.a
 PKG_LIBS = -L$(LIBDIR) -lr_polars
@@ -10,7 +12,11 @@ all: C_clean
 $(SHLIB): $(STATLIB)
 
 $(STATLIB):
-	cargo build --lib --release --manifest-path="$(RPOLARS_RUST_SOURCE)/Cargo.toml"
+	if [ "$(RPOLARS_ALL_FEATURES)" == "true" ]; then \
+		$(BUILD_COMMAND) --all-features; \
+	else \
+		$(BUILD_COMMAND); \
+	fi;
 	if [ -f "$(STATLIB)" ]; then \
 		echo "file is there: "; \
 	else \

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,4 +1,5 @@
 TARGET = $(subst 64,x86_64,$(subst 32,i686,$(WIN)))-pc-windows-gnu
+BUILD_COMMAND = cargo build --target=$(TARGET) --lib --release --manifest-path="$(RPOLARS_RUST_SOURCE)/Cargo.toml"
 
 TARGET_DIR = ./rust/target
 LIBDIR = $(TARGET_DIR)/$(TARGET)/release
@@ -20,7 +21,11 @@ $(STATLIB):
 	echo "RPOLARS_RUST_SOURCE is set to $(RPOLARS_RUST_SOURCE)"
 	export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
 		export LIBRARY_PATH="$${LIBRARY_PATH};$(CURDIR)/$(TARGET_DIR)/libgcc_mock" && \
-		cargo build --target=$(TARGET) --lib --release --manifest-path="$(RPOLARS_RUST_SOURCE)/Cargo.toml"
+		if [ "$(RPOLARS_ALL_FEATURES)" == "true" ]; then \
+			$(BUILD_COMMAND) --all-features; \
+		else \
+			$(BUILD_COMMAND); \
+		fi;
 
 	# when RPOLARS_RUST_SOURCE is defined rust binary is compiled there
 	# if binary is not here, it can be symlinked instead.

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -3,9 +3,12 @@ name = 'r-polars' # r-polars
 version = '0.1.0' # this version no is not used
 edition = '2021'
 
-
 [lib]
 crate-type = ['staticlib']
+
+[features]
+default = []
+simd = ["polars/simd"]
 
 [workspace]
 # prevents package from thinking it's in the workspace
@@ -41,7 +44,6 @@ features = [
   "json",
   "dynamic_groupby",
   "zip_with",
-  "simd",
   "lazy",
   "strings",
   "temporal",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = 'r-polars'   # r-polars
+name = 'r-polars' # r-polars
 version = '0.1.0' # this version no is not used
 edition = '2021'
 
 
 [lib]
-crate-type = [ 'staticlib' ]
+crate-type = ['staticlib']
 
 [workspace]
 # prevents package from thinking it's in the workspace
@@ -16,7 +16,9 @@ mimalloc = { version = "0.1.34", default-features = false }
 jemallocator = { version = "0.5.0", features = ["disable_initial_exec_tls"] }
 
 [dependencies]
-extendr-api = {git = "https://github.com/rpolars/extendr", branch = "errorhandling", default-features = false, features= ["result_list"]}
+extendr-api = { git = "https://github.com/rpolars/extendr", branch = "errorhandling", default-features = false, features = [
+  "result_list",
+] }
 #extendr-api = {path = "../../../extendr/extendr-api", default-features = false, features= ["result_list"]}
 
 flume = "0.10.14"
@@ -26,7 +28,7 @@ smartstring = "1.0.1"
 serde_json = "*"
 thiserror = "1.0.40"
 indenter = "0.3.3"
-polars-core = {git = "https://github.com/pola-rs/polars.git",  rev = "e973f6386a28f16136fb8ba5a737103f95911861", default_features= false}
+polars-core = { git = "https://github.com/pola-rs/polars.git", rev = "e973f6386a28f16136fb8ba5a737103f95911861", default_features = false }
 
 
 #try to trigger new hashFiles hash value
@@ -121,7 +123,7 @@ features = [
   "string_from_radix",
   "meta",
   "approx_unique",
-  ]
+]
 default-features = false
 git = "https://github.com/pola-rs/polars.git"
 rev = "e973f6386a28f16136fb8ba5a737103f95911861"


### PR DESCRIPTION
Related to #80 and #90

Enable/disable `simd` by environment variable at build time.
`simd` is disabled by default for CRAN releases.