### PR TITLE
Accept lists in `select()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@ for demonstration purposes (#240).
 - Polars is internally moving away from string errors to a new error-type called `RPolarsErr` both on rust- and R-side. Final error messages should look very similar (#233).
 - LazyFrame_columns, _schema, _dtypes implemented. Improvements to internal `RPolarsErr`. Also `RPolarsErr` will now print each context of the error on a separate line (#250).
 - Add helpful reference landing page at `polars.github.io/reference_home` (#223, #264).
+- `select()` now accepts lists of expressions. For example, `<DataFrame>$select(l_expr)`
+  works with `l_expr = list(pl$col("a"))` (#265).
 
 # polars 0.6.1
 ## What's changed

--- a/R/dataframe__frame.R
+++ b/R/dataframe__frame.R
@@ -691,15 +691,19 @@ DataFrame_sort = function(
 }
 
 
-#' perform select on DataFrame
+#' Select and modify columns of a DataFrame
 #' @name DataFrame_select
-#' @description  related to dplyr `mutate()` However discards unmentioned columns as data.table `.()`.
+#' @description Related to dplyr `mutate()`. However, it discards unmentioned
+#' columns (like `.()` in `data.table`).
 #'
-#' @param ... expresssions or strings defining columns to select(keep) in context the DataFrame
+#' @param ... Columns to keep. Those can be expressions (e.g `pl$col("a")`),
+#' column names  (e.g `"a"`), or list containing expressions or column names
+#' (e.g `list(pl$col("a"))`).
 #'
 #' @aliases select
 #' @keywords  DataFrame
-#' #' pl$DataFrame(iris)$select(
+#' @examples
+#' pl$DataFrame(iris)$select(
 #'   pl$col("Sepal.Length")$abs()$alias("abs_SL"),
 #'   (pl$col("Sepal.Length")+2)$alias("add_2_SL")
 #' )

--- a/R/expr__expr.R
+++ b/R/expr__expr.R
@@ -577,8 +577,7 @@ construct_ProtoExprArray = function(...) {
   args = list2(...)
 
   # deal with list of expressions
-  is_list = unlist(lapply(args, is.list))
-  if (length(is_list) > 0) is_list = which(is_list)
+  is_list = which(vapply(args, is.list, FUN.VALUE = logical(1L)))
   for (i in seq_along(is_list)) {
     tmp = unlist(args[[is_list[i]]], recursive = FALSE)
     args[[is_list[i]]] = NULL

--- a/R/expr__expr.R
+++ b/R/expr__expr.R
@@ -575,6 +575,19 @@ Expr_is_not_null = "use_extendr_wrapper"
 construct_ProtoExprArray = function(...) {
   pra = ProtoExprArray$new()
   args = list2(...)
+
+  # deal with list of expressions
+  is_list = unlist(lapply(args, \(x) {
+    class(x) == "list"
+  }))
+  if (length(is_list) > 0) is_list = which(is_list)
+  for (i in seq_along(is_list)) {
+    tmp = unlist(args[[is_list[i]]], recursive = FALSE)
+    args[[is_list[i]]] = NULL
+    args = append(tmp, args)
+  }
+  args = Filter(Negate(is.null), args)
+
   arg_names = names(args)
 
 

--- a/R/expr__expr.R
+++ b/R/expr__expr.R
@@ -577,9 +577,7 @@ construct_ProtoExprArray = function(...) {
   args = list2(...)
 
   # deal with list of expressions
-  is_list = unlist(lapply(args, \(x) {
-    class(x) == "list"
-  }))
+  is_list = unlist(lapply(args, is.list))
   if (length(is_list) > 0) is_list = which(is_list)
   for (i in seq_along(is_list)) {
     tmp = unlist(args[[is_list[i]]], recursive = FALSE)

--- a/man/DataFrame_select.Rd
+++ b/man/DataFrame_select.Rd
@@ -3,19 +3,23 @@
 \name{DataFrame_select}
 \alias{DataFrame_select}
 \alias{select}
-\title{perform select on DataFrame}
+\title{Select and modify columns of a DataFrame}
 \usage{
 DataFrame_select(...)
 }
 \arguments{
-\item{...}{expresssions or strings defining columns to select(keep) in context the DataFrame}
+\item{...}{Columns to keep. Those can be expressions (e.g \code{pl$col("a")}),
+column names  (e.g \code{"a"}), or list containing expressions or column names
+(e.g \code{list(pl$col("a"))}).}
 }
 \description{
-related to dplyr \code{mutate()} However discards unmentioned columns as data.table \code{.()}.
+Related to dplyr \code{mutate()}. However, it discards unmentioned
+columns (like \code{.()} in \code{data.table}).
 }
-\keyword{#'}
-\keyword{(pl$col("Sepal.Length")+2)$alias("add_2_SL")}
-\keyword{)}
+\examples{
+pl$DataFrame(iris)$select(
+  pl$col("Sepal.Length")$abs()$alias("abs_SL"),
+  (pl$col("Sepal.Length")+2)$alias("add_2_SL")
+)
+}
 \keyword{DataFrame}
-\keyword{pl$DataFrame(iris)$select(}
-\keyword{pl$col("Sepal.Length")$abs()$alias("abs_SL"),}

--- a/tests/testthat/test-dataframe.R
+++ b/tests/testthat/test-dataframe.R
@@ -185,6 +185,7 @@ test_that("select with list of exprs", {
   expect_equal(x3$columns, c("mpg", "hp"))
   expect_equal(x4$columns, c("mpg", "hp"))
   expect_equal(x5$columns, c("mpg", "hp"))
+  expect_equal(x6$columns, c("mpg", "hp"))
 })
 
 test_that("map unity", {

--- a/tests/testthat/test-dataframe.R
+++ b/tests/testthat/test-dataframe.R
@@ -166,6 +166,27 @@ test_that("Select with p$col", {
   expect_equal(z$columns, c("mpg", "hp"))
 })
 
+test_that("select with list of exprs", {
+  l_expr = list(pl$col("mpg"), pl$col("hp"))
+  l_expr2 = list(pl$col("mpg", "hp"))
+  l_expr3 = list(pl$col("mpg"))
+  l_expr4 = list(c("mpg", "hp"))
+  l_expr5 = list("mpg", "hp")
+
+  x1 = pl$DataFrame(mtcars)$select(l_expr)
+  x2 = pl$DataFrame(mtcars)$select(l_expr2)
+  x3 = pl$DataFrame(mtcars)$select(l_expr3, pl$col("hp"))
+  x4 = pl$DataFrame(mtcars)$select(pl$col("hp"), l_expr3)
+  x5 = pl$DataFrame(mtcars)$select(l_expr4)
+  x6 = pl$DataFrame(mtcars)$select(l_expr5)
+
+  expect_equal(x1$columns, c("mpg", "hp"))
+  expect_equal(x2$columns, c("mpg", "hp"))
+  expect_equal(x3$columns, c("mpg", "hp"))
+  expect_equal(x4$columns, c("mpg", "hp"))
+  expect_equal(x5$columns, c("mpg", "hp"))
+})
+
 test_that("map unity", {
   x = pl$
     DataFrame(iris)$

--- a/tests/testthat/test-lazy.R
+++ b/tests/testthat/test-lazy.R
@@ -587,4 +587,5 @@ test_that("select with list of exprs", {
   expect_equal(x3$columns, c("mpg", "hp"))
   expect_equal(x4$columns, c("mpg", "hp"))
   expect_equal(x5$columns, c("mpg", "hp"))
+  expect_equal(x6$columns, c("mpg", "hp"))
 })

--- a/tests/testthat/test-lazy.R
+++ b/tests/testthat/test-lazy.R
@@ -567,3 +567,24 @@ test_that("schema", {
   expect_true(lf$dtypes[[1]] == lf$collect()$dtypes[[1]])
   expect_identical(lf$columns, lf$collect()$columns)
 })
+
+test_that("select with list of exprs", {
+  l_expr = list(pl$col("mpg"), pl$col("hp"))
+  l_expr2 = list(pl$col("mpg", "hp"))
+  l_expr3 = list(pl$col("mpg"))
+  l_expr4 = list(c("mpg", "hp"))
+  l_expr5 = list("mpg", "hp")
+
+  x1 = pl$LazyFrame(mtcars)$select(l_expr)
+  x2 = pl$LazyFrame(mtcars)$select(l_expr2)
+  x3 = pl$LazyFrame(mtcars)$select(l_expr3, pl$col("hp"))
+  x4 = pl$LazyFrame(mtcars)$select(pl$col("hp"), l_expr3)
+  x5 = pl$LazyFrame(mtcars)$select(l_expr4)
+  x6 = pl$LazyFrame(mtcars)$select(l_expr5)
+
+  expect_equal(x1$columns, c("mpg", "hp"))
+  expect_equal(x2$columns, c("mpg", "hp"))
+  expect_equal(x3$columns, c("mpg", "hp"))
+  expect_equal(x4$columns, c("mpg", "hp"))
+  expect_equal(x5$columns, c("mpg", "hp"))
+})


### PR DESCRIPTION
Related to #259 (I couldn't deprecate `construct_ProtoExprArray` though so no problem to close this PR if you want to do it all at once in another PR).

New behaviour:
``` r
library(polars)
l_expr = list(
  pl$col("a"),
  pl$col("b")
)

pl$DataFrame(a = 1:3, b = 1:3, c = 1:3)$select(l_expr)
#> shape: (3, 2)
#> ┌─────┬─────┐
#> │ a   ┆ b   │
#> │ --- ┆ --- │
#> │ i32 ┆ i32 │
#> ╞═════╪═════╡
#> │ 1   ┆ 1   │
#> │ 2   ┆ 2   │
#> │ 3   ┆ 3   │
#> └─────┴─────┘
pl$DataFrame(a = 1:3, b = 1:3, c = 1:3)$select(l_expr, "c")
#> shape: (3, 3)
#> ┌─────┬─────┬─────┐
#> │ a   ┆ b   ┆ c   │
#> │ --- ┆ --- ┆ --- │
#> │ i32 ┆ i32 ┆ i32 │
#> ╞═════╪═════╪═════╡
#> │ 1   ┆ 1   ┆ 1   │
#> │ 2   ┆ 2   ┆ 2   │
#> │ 3   ┆ 3   ┆ 3   │
#> └─────┴─────┴─────┘
```


