### PR TITLE
test extendr rprintln supports `%`-char

### DIFF
--- a/R/extendr-wrappers.R
+++ b/R/extendr-wrappers.R
@@ -57,6 +57,8 @@ test_robj_to_i64 <- function(robj) .Call(wrap__test_robj_to_i64, robj)
 
 test_robj_to_u32 <- function(robj) .Call(wrap__test_robj_to_u32, robj)
 
+test_print_string <- function(s) invisible(.Call(wrap__test_print_string, s))
+
 RPolarsErr <- new.env(parent = emptyenv())
 
 RPolarsErr$new <- function() .Call(wrap__RPolarsErr__new)

--- a/src/rust/src/rlib.rs
+++ b/src/rust/src/rlib.rs
@@ -300,4 +300,5 @@ extendr_module! {
     fn test_robj_to_usize;
     fn test_robj_to_i64;
     fn test_robj_to_u32;
+    fn test_print_string;
 }

--- a/src/rust/src/rlib.rs
+++ b/src/rust/src/rlib.rs
@@ -270,6 +270,11 @@ fn test_robj_to_u32(robj: Robj) -> RResult<String> {
     robj_to!(u32, robj).map(rdbg)
 }
 
+#[extendr]
+fn test_print_string(s: String) {
+    rprintln!("{}", s);
+}
+
 extendr_module! {
     mod rlib;
     fn concat_df;

--- a/tests/testthat/test-extendr.R
+++ b/tests/testthat/test-extendr.R
@@ -1,6 +1,6 @@
 test_that("extendr rprintln! supports %", {
   expect_identical(
-    capture.output(test_print_string("123%%321")),
+    capture.output(test_print_string("123%%321")), ## would return 123%321 if not escaped right
     "123%%321"
   )
 })

--- a/tests/testthat/test-extendr.R
+++ b/tests/testthat/test-extendr.R
@@ -1,0 +1,6 @@
+test_that("extendr rprintln! supports %", {
+  expect_identical(
+    capture.output(test_print_string("123%%321")),
+    "123%%321"
+  )
+})


### PR DESCRIPTION
Related to #258