### PR TITLE
fix: `polars_info()` shows features correctly

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,7 @@ for demonstration purposes (#240).
 - Add helpful reference landing page at `polars.github.io/reference_home` (#223, #264).
 - rust-polars' `simd` feature is now disabled by default. To enable it, set the environment variable
   `RPOLARS_ALL_FEATURES` to `true` when build r-polars (#262).
-- A new function `polars_info()` will tell which features enabled (#271).
+- A new function `polars_info()` will tell which features enabled (#271, #285).
 - `select()` now accepts lists of expressions. For example, `<DataFrame>$select(l_expr)`
   works with `l_expr = list(pl$col("a"))` (#265).
 - `<DataFrame>$glimpse()` is a fast `str()`-like view of a `DataFrame` (#277).

--- a/src/rust/src/info.rs
+++ b/src/rust/src/info.rs
@@ -8,7 +8,7 @@ struct FeatureInfo {
 impl FeatureInfo {
     fn new() -> FeatureInfo {
         FeatureInfo {
-            simd: cfg!(target_feature = "simd"),
+            simd: cfg!(feature = "simd"),
         }
     }
     fn to_r(&self) -> List {


### PR DESCRIPTION
https://github.com/pola-rs/r-polars/pull/271#issuecomment-1614721193

We should use `feature` here, not `target_feature`.

Now it works fine.

```r
> polars_info()
R Polars package version: 0.6.1.9000

Features:         
simd TRUE
```