### PR TITLE
Use `altdoc` dev version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ Suggests:
     tibble,
     withr
 Config/Needs/website:
-    altdoc,
+    etiennebacher/altdoc,
     here,
     magrittr,
     pkgload,


### PR DESCRIPTION
Cf #298 

@eitsupi is this enough to use the dev version of `altdoc`?