### PR TITLE
build: add devcontainer.json for to support Dev Containers

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -16,3 +16,4 @@
 ^\.venv$
 ^Makefile$
 ^src/\.cargo$
+^\.devcontainer$

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+	"image": "ghcr.io/rocker-org/devcontainer/r-ver:4",
+	"features": {
+		"ghcr.io/devcontainers/features/rust:1": {}
+	},
+	"postCreateCommand": {
+		"requirements": "make requirements"
+	}
+}


### PR DESCRIPTION
Same as pola-rs/polars#9690, pola-rs/polars#9697

This definitely works well on amd64 machines (I use it all the time), but be aware that if we use it on an arm64 machine, it will cause source installation of the `arrow` package and take a long time to build.