### PR TITLE
Fix describe colon

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -97,5 +97,5 @@ Collate:
     'translation.R'
     'vctrs.R'
     'zzz.R'
-Config/rextendr/version: 0.3.1
+Config/rextendr/version: 0.3.1.9000
 VignetteBuilder: knitr

--- a/R/dataframe__frame.R
+++ b/R/dataframe__frame.R
@@ -1464,12 +1464,12 @@ DataFrame_describe = function(percentiles = c(.25, .75)) {
 
           # compute aggregates
           df_aggs = do.call(self$select, largs)
-          e_col_row_names = pl$lit(df_aggs$columns)$str$split(":")
+          e_col_row_names = pl$lit(df_aggs$columns)$str$splitn(":", 2)
 
           # pivotize
           df_pivot = pl$select(
-            e_col_row_names$arr$first()$alias("rowname"),
-            e_col_row_names$arr$last()$alias("colname"),
+            e_col_row_names$struct$field("field_0")$alias("rowname"),
+            e_col_row_names$struct$field("field_1")$alias("colname"),
             pl$lit(unlist(as.data.frame(df_aggs)))$alias("value")
           )$pivot(
             values = "value", index = "rowname", columns = "colname"

--- a/man/nanoarrow.Rd
+++ b/man/nanoarrow.Rd
@@ -16,13 +16,13 @@
 \alias{as_record_batch_reader.DataFrame}
 \title{polars to nanoarrow and arrow}
 \usage{
-as_nanoarrow_array_stream.DataFrame(x, ..., schema = NULL)
+\method{as_nanoarrow_array_stream}{DataFrame}(x, ..., schema = NULL)
 
-infer_nanoarrow_schema.DataFrame(x, ...)
+\method{infer_nanoarrow_schema}{DataFrame}(x, ...)
 
-as_arrow_table.DataFrame(x, ...)
+\method{as_arrow_table}{DataFrame}(x, ...)
 
-as_record_batch_reader.DataFrame(x, ..., schema = NULL)
+\method{as_record_batch_reader}{DataFrame}(x, ..., schema = NULL)
 }
 \arguments{
 \item{x}{a polars DataFrame}

--- a/tests/testthat/test-dataframe.R
+++ b/tests/testthat/test-dataframe.R
@@ -965,6 +965,15 @@ test_that("describe", {
     pl$DataFrame(mtcars)$describe(perc = numeric())$to_list(),
     pl$DataFrame(mtcars)$describe(perc = NULL)$to_list()
   )
+
+  #names using internal separator ":" in column names, should also just work.
+  df = pl$DataFrame("foo:bar:jazz" = 1, pl$Series(2,name = ""), "foobar" = 3)
+  expect_identical(
+    df$describe()$columns,
+    c("describe", df$columns)
+  )
+
+
 })
 
 test_that("glimpse", {


### PR DESCRIPTION
internally $describe() uses `:` as separtor between ´agg.fun.name` and `column.name`. Column names with `:` would get split and only last part would remain. This is fixed by using ´$splitn(":",2)` internally.

add a unit test

chore:
revert nanoarrow.Rd
rextendr 0.3.1 -> 0.3.1.9000 or should that be 0.3.1? I'm fine with either.