### PR TITLE
fix collect(collect_in_background=TRUE)

### DIFF
--- a/R/lazyframe__lazy.R
+++ b/R/lazyframe__lazy.R
@@ -315,7 +315,7 @@ LazyFrame_collect = function(
   }
 
   collect_f = if (isTRUE(collect_in_background)) {
-    .pr$LazyFrame$collect_background
+    \(...) Ok(.pr$LazyFrame$collect_in_background(...))
   } else {
     .pr$LazyFrame$collect
   }
@@ -338,6 +338,8 @@ LazyFrame_collect = function(
 #' @title Collect a Lazy Query in background
 #' @description Collect runs non-blocking in a detached thread
 #' @details
+#'
+#' Can also be used via `$colllect(collect_in_background = TRUE)`.
 #'
 #' This function immediately returns an [RThreadHandle][RThreadHandle_RThreadHandle_class].
 #' Use [`<RThreadHandle>$is_finished()`][RThreadHandle_is_finished] to see if done.

--- a/R/rust_result.R
+++ b/R/rust_result.R
@@ -56,7 +56,7 @@ Err = function(x) {
 #' @param f a closure that takes the err part as input
 #' @return same R object wrapped in a Err-result
 map_err = function(x, f) {
-  if (is_err(x)) x$err <- f(x$err)
+  if (is_err(x)) x$err = f(x$err)
   x
 }
 
@@ -65,7 +65,7 @@ map_err = function(x, f) {
 #' @param f a closure that takes the ok part as input
 #' @return same R object wrapped in a Err-result
 map = function(x, f) {
-  if (is_ok(x)) x$ok <- f(x$ok)
+  if (is_ok(x)) x$ok = f(x$ok)
   x
 }
 

--- a/man/LazyFrame_collect_in_background.Rd
+++ b/man/LazyFrame_collect_in_background.Rd
@@ -13,6 +13,8 @@ RThreadHandle, a future-like thread handle for the task
 Collect runs non-blocking in a detached thread
 }
 \details{
+Can also be used via \verb{$colllect(collect_in_background = TRUE)}.
+
 This function immediately returns an \link[=RThreadHandle_RThreadHandle_class]{RThreadHandle}.
 Use \code{\link[=RThreadHandle_is_finished]{<RThreadHandle>$is_finished()}} to see if done.
 Use \code{\link[=RThreadHandle_join]{<RThreadHandle>$join()}} to wait and get the final result.

--- a/tests/testthat/test-rbackground.R
+++ b/tests/testthat/test-rbackground.R
@@ -4,6 +4,10 @@ test_that("Test collecting LazyFrame in background", {
   compute = lf$select(pl$col("x") * pl$col("y"))
   res_bg = compute$collect_in_background()$join()
   expect_equal(res_bg$to_data_frame(), compute$collect()$to_data_frame())
+
+  # via collect(collect_in_background = TRUE)
+  res_bg = compute$collect(collect_in_background = TRUE)$join()
+  expect_equal(res_bg$to_data_frame(), compute$collect()$to_data_frame())
 })
 
 test_that("Test using $map() in background", {


### PR DESCRIPTION
`collect(collect_in_background = TRUE)`  referred to old removed implementation.

fix + unit test + style some `<-`

no news because bug was introduced in this 9000 version and has not been released