### PR TITLE
[WIP] Start implementing `reduce()` and `fold()`

### DIFF
--- a/R/extendr-wrappers.R
+++ b/R/extendr-wrappers.R
@@ -35,6 +35,10 @@ concat_list <- function(exprs) .Call(wrap__concat_list, exprs)
 
 concat_str <- function(dotdotdot, separator) .Call(wrap__concat_str, dotdotdot, separator)
 
+fold <- function(acc, lambda, exprs) .Call(wrap__fold, acc, lambda, exprs)
+
+reduce <- function(lambda, exprs) .Call(wrap__reduce, lambda, exprs)
+
 r_date_range_lazy <- function(start, end, every, closed, time_unit, time_zone, explode) .Call(wrap__r_date_range_lazy, start, end, every, closed, time_unit, time_zone, explode)
 
 as_struct <- function(exprs) .Call(wrap__as_struct, exprs)

--- a/R/functions__lazy.R
+++ b/R/functions__lazy.R
@@ -937,7 +937,6 @@ pl$rolling_corr = function(a, b, window_size, min_periods = NULL, ddof = 1) {
 pl$fold = function(acc, lambda, exprs) {
   l_expr = lapply(as.list(exprs), wrap_e)
   pra = do.call(construct_ProtoExprArray, l_expr)
-  browser()
   unwrap(fold(acc, lambda, pra))
 }
 

--- a/R/functions__lazy.R
+++ b/R/functions__lazy.R
@@ -907,3 +907,53 @@ pl$rolling_corr = function(a, b, window_size, min_periods = NULL, ddof = 1) {
   }
   .pr$Expr$rolling_corr(a, b, window_size, min_periods, ddof) |> unwrap("in pl$rolling_corr()")
 }
+
+
+
+#' Accumulate over multiple columns horizontally / rowwise with a left fold
+#'
+#' @description
+#' `pl$fold()` and `pl$reduce()` allows one to do rowwise operations. The only
+#' difference between them is that `pl$fold()` has an additional argument (`acc`)
+#' that contains the value that will be initialized when the fold starts.
+#'
+#' @name pl_reduce
+#'
+#' @param lambda Function to apply over the accumulator and the value.
+#' @param exprs Expressions to aggregate over. May also be a wildcard expression.
+#'
+#' @return An expression that will be applied rowwise
+#'
+#' @examples
+#' df = pl$DataFrame(mtcars)
+#'
+#' # Make the rowwise sum of all columns and add 1 to it
+#' df$with_columns(
+#'   pl$fold(
+#'     acc = pl$lit(1), lambda = \(acc, x) acc + x, exprs = pl$col("mpg", "drat")
+#'   )
+#' )
+
+pl$fold = function(acc, lambda, exprs) {
+  l_expr = lapply(as.list(exprs), wrap_e)
+  pra = do.call(construct_ProtoExprArray, l_expr)
+  browser()
+  unwrap(fold(acc, lambda, pra))
+}
+
+
+#' @examples
+#' df = pl$DataFrame(mtcars)
+#'
+#' # Make the rowwise sum of all columns and add 1 to it
+#' df$with_columns(
+#'   pl$reduce(
+#'      lambda = \(acc, x) acc + x, exprs = pl$col("mpg", "drat")
+#'   )
+#' )
+
+pl$reduce = function(lambda, exprs) {
+  l_expr = lapply(as.list(exprs), wrap_e)
+  pra = do.call(construct_ProtoExprArray, l_expr)
+  unwrap(reduce(lambda, pra))
+}

--- a/src/rust/src/rlib.rs
+++ b/src/rust/src/rlib.rs
@@ -283,8 +283,8 @@ fn polars_features() -> List {
 fn fold(acc: &Expr, lambda: Robj, exprs: &ProtoExprArray) -> RResult<Expr> {
     use crate::utils::extendr_concurrent::{InitCell, ThreadCom};
     use polars::prelude::Series;
- 
-    // `fold_exprs()` takes two inputs ("acc" and "exprs"). I must run an R process that 
+
+    // `fold_exprs()` takes two inputs ("acc" and "exprs"). I must run an R process that
     // will convert the R function that is passed ("lambda") in a function that takes two
     // Series and returns a Series.
     // Took some code from the implementation of `map()` but here I need to pass two inputs,
@@ -294,7 +294,7 @@ fn fold(acc: &Expr, lambda: Robj, exprs: &ProtoExprArray) -> RResult<Expr> {
 
 
     //find a way not to push lambda everytime to main thread handler
-    //safety only accessed in main thread, can be temp owned by other threads 
+    //safety only accessed in main thread, can be temp owned by other threads
     let probj = ParRObj(lambda);
     type foo = InitCell<std::sync::RwLock<Option<ThreadCom<(ParRObj, Series, Series), Series>>>>;
     static FOO: foo = InitCell::new();
@@ -311,7 +311,7 @@ fn fold(acc: &Expr, lambda: Robj, exprs: &ProtoExprArray) -> RResult<Expr> {
 
         //wrap as series
         Ok(Some(s))
-    };  
+    };
 
     let exprs = exprs.to_vec("select");
     Ok(fold_exprs(acc.clone().into(), f, exprs).into())
@@ -321,7 +321,7 @@ fn fold(acc: &Expr, lambda: Robj, exprs: &ProtoExprArray) -> RResult<Expr> {
 fn reduce(lambda: Robj, exprs: &ProtoExprArray) -> RResult<Expr> {
     use crate::utils::extendr_concurrent::{InitCell, ThreadCom};
     use polars::prelude::*;
-     
+
     // The code below takes one input and runs the lambda function with this input in R.
     // I need to find a way to pass two inputs to thread_com.send()
     // For now, when I run pl$fold() from R, I get "Error in (function (acc, x) : argument
@@ -329,7 +329,7 @@ fn reduce(lambda: Robj, exprs: &ProtoExprArray) -> RResult<Expr> {
     // ("acc") in tread_com.send()
 
     //find a way not to push lambda everytime to main thread handler
-    //safety only accessed in main thread, can be temp owned by other threads 
+    //safety only accessed in main thread, can be temp owned by other threads
     let probj = ParRObj(lambda);
     type foo = InitCell<std::sync::RwLock<Option<ThreadCom<(ParRObj, Series, Series), Series>>>>;
     static FOO: foo = InitCell::new();
@@ -348,9 +348,7 @@ fn reduce(lambda: Robj, exprs: &ProtoExprArray) -> RResult<Expr> {
 
         //wrap as series
         Ok(Some(s))
-    };  
-
-    let hello = &f;
+    };
 
     let exprs = exprs.to_vec("select");
     Ok(reduce_exprs(f, exprs).into())


### PR DESCRIPTION
I started to look into how to implement those two functions but for now I run into a panic in a sub-thread:

```r
df = pl$DataFrame(mtcars)

df$with_columns(
  pl$fold(
     acc = pl$lit(1), lambda = \(acc, x) acc, exprs = pl$col("mpg", "drat")
  )
)
```
```r
Error: Execution halted with the following contexts
0: In R: in $with_columns()
0: During function call [df$with_columns(pl$reduce(lambda = function(acc, x) acc, exprs = pl$col("mpg",
"drat")))]
1: A polars sub-thread panicked. See panic msg, which is likely more informative than this error: Any { .. }
```
and I can't find a way to get the panic message. Also, this error comes from `concurrent_handler()` in Rust but I don't understand when this function is actually called.

---

@sorhawell this is mostly me dabbling with Rust so this might be completely off. Let me know if you want to rewrite that from scratch, otherwise I'd greatly appreciate some pointers on this if you have the time 😄 
