### PR TITLE
ci: add release-lib workflow to upload binary libraries to GitHub releases

### DIFF
--- a/.github/workflows/release-lib.yaml
+++ b/.github/workflows/release-lib.yaml
@@ -144,6 +144,7 @@ jobs:
           mkdir -p tools
           tar -xzf "libs/${ARTIFACT_NAME}" -C "tools"
           rm -rf "libs"
+          echo "LIBR_POLARS_PATH=$(pwd)/tools/${LIB_NAME}.a" >>"$GITHUB_ENV"
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/release-lib.yaml
+++ b/.github/workflows/release-lib.yaml
@@ -34,9 +34,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             target: aarch64-unknown-linux-gnu
           - os: macos-latest
             target: x86_64-apple-darwin
@@ -69,19 +69,6 @@ jobs:
           sudo apt-get install -y gcc-aarch64-linux-gnu
           echo 'CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc' >>"$GITHUB_ENV"
 
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          r-version: release
-          use-public-rspm: true
-          Ncpus: 2
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: any::rcmdcheck
-          needs: dev
-        env:
-          CI: false
-
       - name: build lib
         env:
           NOT_CRAN: "true"
@@ -93,6 +80,7 @@ jobs:
           ARTIFACT_NAME="${LIB_NAME}-${LIB_VERSION}-${TARGET}.tar.gz"
           if [[ ${{ runner.os }} == 'Windows' ]]; then
             pushd ..
+            Rscript -e 'install.packages("pkgbuild", repos = "https://cloud.r-project.org")'
             Rscript -e 'pkgbuild::compile_dll()' # Linker of Rtools is needed here.
             popd
           else

--- a/.github/workflows/release-lib.yaml
+++ b/.github/workflows/release-lib.yaml
@@ -1,0 +1,210 @@
+name: release-lib
+on:
+  push:
+    tags:
+      - "lib-v*"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/release-lib.yaml
+      - src/rust/**
+      - src/Makevars*
+      - tools/**
+      - "!tools/lib-sums.tsv"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  LIB_NAME: libr_polars
+  RPOLARS_FULL_FEATURES: "true"
+  RPOLARS_PROFILE: release-optimized
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-20.04
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-20.04
+            target: aarch64-unknown-linux-gnu
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: macos-latest
+            target: aarch64-apple-darwin
+          - os: windows-latest
+            target: x86_64-pc-windows-gnu
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: prep Rust
+        working-directory: src/rust
+        run: |
+          LIB_VERSION="$(cargo metadata --format-version=1 --no-deps | jq --raw-output '.packages[0].version')"
+          echo "LIB_VERSION=${LIB_VERSION}" >>"$GITHUB_ENV"
+
+      - uses: ./.github/actions/setup
+        with:
+          rust-nightly: "true"
+          target: "${{ matrix.target }}"
+
+      - name: Set for arm64 Linux
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          echo 'CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc' >>"$GITHUB_ENV"
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: release
+          use-public-rspm: true
+          Ncpus: 2
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: dev
+        env:
+          CI: false
+
+      - name: build lib
+        env:
+          NOT_CRAN: "true"
+          TARGET: ${{ matrix.target }}
+          RPOLARS_PROFILE: ${{ env.RPOLARS_PROFILE }}
+        working-directory: src
+        run: |
+          LIB_PATH="$(pwd)/rust/target/${TARGET}/${RPOLARS_PROFILE}/${LIB_NAME}.a"
+          ARTIFACT_NAME="${LIB_NAME}-${LIB_VERSION}-${TARGET}.tar.gz"
+          if [[ ${{ runner.os }} == 'Windows' ]]; then
+            pushd ..
+            Rscript -e 'pkgbuild::compile_dll()' # Linker of Rtools is needed here.
+            popd
+          else
+            make -f Makevars.in "${LIB_PATH}"
+          fi
+          tar -czf "../${ARTIFACT_NAME}" -C "rust/target/${TARGET}/${RPOLARS_PROFILE}" "${LIB_NAME}.a"
+          echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >>"$GITHUB_ENV"
+
+      - name: upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: libs
+          path: ${{ env.ARTIFACT_NAME }}
+
+  test:
+    needs: build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - windows-latest
+          - ubuntu-latest
+        r:
+          - oldrel-1
+          - release
+          - devel
+        exclude:
+          - os: macos-latest
+            r: devel
+          - os: macos-latest
+            r: oldrel-1
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: libs
+          path: libs
+
+      - name: prep Rust
+        working-directory: src/rust
+        run: |
+          LIB_VERSION="$(cargo metadata --format-version=1 --no-deps | jq --raw-output '.packages[0].version')"
+          echo "LIB_VERSION=${LIB_VERSION}" >>"$GITHUB_ENV"
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            echo "LIB_TARGET=x86_64-pc-windows-gnu" >>"$GITHUB_ENV"
+          else
+            echo "LIB_TARGET=$(rustc -vV | grep host | cut -d' ' -f2)" >>"$GITHUB_ENV"
+          fi
+          rm "$(rustup which cargo)"
+
+      - name: prep lib
+        run: |
+          ARTIFACT_NAME="${LIB_NAME}-${LIB_VERSION}-${LIB_TARGET}.tar.gz"
+          tar -xzf "libs/${ARTIFACT_NAME}" -C "tools"
+          rm -rf "libs"
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.r }}
+          use-public-rspm: true
+          Ncpus: "2"
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::devtools
+          needs: check
+
+      - name: R test
+        shell: Rscript {0}
+        env:
+          NOT_CRAN: "true"
+        run: |
+          devtools::install_local()
+          testthat::test_dir("tests")
+
+  release:
+    needs:
+      - build
+      - test
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: libs
+          path: libs
+
+      - name: create checksums
+        working-directory: libs
+        run: |
+          sha256sum * >"../sha256sums.txt"
+          md5sum * >"../md5sums.txt"
+
+      - name: create release
+        uses: softprops/action-gh-release@v1
+        with:
+          prerelease: true
+          files: |
+            libs/*
+            sha256sums.txt
+            md5sums.txt

--- a/.github/workflows/release-lib.yaml
+++ b/.github/workflows/release-lib.yaml
@@ -164,7 +164,7 @@ jobs:
         env:
           NOT_CRAN: "true"
         run: |
-          devtools::install_local()
+          devtools::install_local(force = TRUE)
           testthat::test_dir("tests")
 
   release:

--- a/.github/workflows/release-lib.yaml
+++ b/.github/workflows/release-lib.yaml
@@ -141,6 +141,7 @@ jobs:
       - name: prep lib
         run: |
           ARTIFACT_NAME="${LIB_NAME}-${LIB_VERSION}-${LIB_TARGET}.tar.gz"
+          mkdir -p tools
           tar -xzf "libs/${ARTIFACT_NAME}" -C "tools"
           rm -rf "libs"
 

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -1808,7 +1808,7 @@ dependencies = [
 
 [[package]]
 name = "r-polars"
-version = "0.1.0"
+version = "0.33.0"
 dependencies = [
  "either",
  "extendr-api",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = 'r-polars'     # r-polars
-version = '0.1.0'     # this version no is not used
-edition = '2021'
+name = "r-polars"
+version = "0.33.0"
+edition = "2021"
 rust-version = "1.70"
+publish = false
 
 [lib]
 crate-type = ['staticlib']
-
 
 [features]
 default = []


### PR DESCRIPTION
Part of #408
This PR adds a new workflow to upload binary libraries to GitHub releases.
These binaries will be used "R source package with Rust library binary" installation.

Copied from <https://github.com/eitsupi/prqlr/blob/97cc6522adc7ea3c9d7273a67737e226ab6b597a/.github/workflows/release-lib.yml>

After this is merged, I will update our existing release workflow to not do Rust builds by rewriting it.
(We should have done a library release before doing the release, so we can use that binary libraries to build the R binary package)