### PR TITLE
fix: fix read_* functions when the package is not loaded

### DIFF
--- a/R/csv.R
+++ b/R/csv.R
@@ -165,7 +165,7 @@ pl$read_csv = function(
     parse_dates = FALSE,
     reuse_downloaded = TRUE) {
   mc = match.call()
-  mc[[1]] = quote(pl$scan_csv)
+  mc[[1]] = get("pl", envir = asNamespace("polars"))$scan_csv
   eval.parent(mc)$collect()
 }
 

--- a/R/parquet.R
+++ b/R/parquet.R
@@ -91,7 +91,7 @@ pl$read_parquet = function(
     row_count_offset = 0L,
     low_memory = FALSE) {
   mc = match.call()
-  mc[[1]] = quote(pl$scan_parquet)
+  mc[[1]] = get("pl", envir = asNamespace("polars"))$scan_parquet
   eval.parent(mc)$collect()
 }
 


### PR DESCRIPTION
This PR fixes the error `Error in eval(expr, p) : object 'pl' not found` when execute the read functions e.g. `polars::pl$read_csv(path)`.