### PR TITLE
refactor: record the rust toolchain version to the DESCRIPTION file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,7 +50,6 @@ Config/Needs/website:
     pkgload,
     yaml
 Config/Needs/dev:
-    brio,
     devtools,
     dplyr,
     RcppTOML,
@@ -114,3 +113,4 @@ Collate:
 Config/rextendr/version: 0.3.1
 VignetteBuilder: knitr
 Config/polars/LibVersion: 0.34.0
+Config/polars/RustToolchainVersion: nightly-2023-10-12

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 SHELL := /bin/bash
 VENV := .venv
 
-RUST_TOOLCHAIN_VERSION := nightly-2023-10-12
+RUST_TOOLCHAIN_VERSION := $(shell Rscript -e 'read.dcf("DESCRIPTION", fields = "Config/polars/RustToolchainVersion", all = TRUE)[1, 1] |> cat()')
 
 MANIFEST_PATH := src/rust/Cargo.toml
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -142,9 +142,10 @@ the Rust toolchain (Rust `r RcppTOML::parseTOML("src/rust/Cargo.toml")$package$"
 Please check the <https://github.com/r-rust/hellorust> repository for about Rust code in R packages.
 
 ```{r, include = FALSE}
-rust_toolchain_version = brio::read_file("Makefile") |>
-  stringr::str_extract(r"((?<=RUST_TOOLCHAIN_VERSION).*nightly.*(?=\n))") |>
-  stringr::str_extract(r"(nightly.*)")
+rust_toolchain_version = read.dcf(
+  "DESCRIPTION",
+  fields = "Config/polars/RustToolchainVersion", all = TRUE
+)[1, 1]
 ```
 
 During source installation, some environment variables can be set to enable Rust features and profile changes.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,15 @@ install.packages(
 
 ### Build from source
 
+For source installation, pre-built Rust libraries may be available if
+the environment variable `NOT_CRAN` is set to `"true"`. (Or, set
+`LIBR_POLARS_BUILD` to `"false"`)
+
+``` r
+Sys.setenv(NOT_CRAN = "true")
+install.packages("polars", repos = "https://rpolars.r-universe.dev")
+```
+
 Otherwise, the Rust library will be built from source. the Rust
 toolchain (Rust 1.73 or later) must be configured.
 


### PR DESCRIPTION
I want to create a vignette about the installation and this PR is needed for to get the toolchain version from within the package.