### PR TITLE
ci: use pak's sys reqs installation

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -11,25 +11,6 @@ inputs:
 runs:
   using: composite
   steps:
-      - name: Install ubuntu SYSTEM REQUIREMENTS
-        if: runner.os == 'Linux'
-        shell: bash
-        run: |
-          sudo apt-get update \
-          && sudo apt-get install -y \
-            libfontconfig1-dev \
-            libfreetype6-dev \
-            libfribidi-dev \
-            libharfbuzz-dev \
-            libcurl4-openssl-dev \
-            libgit2-dev \
-            libicu-dev \
-            libjpeg-dev \
-            libpng-dev \
-            libtiff-dev \
-            libxml2-dev \
-            libssl-dev
-
       - name: Update Rust
         if: inputs.rust-nightly != 'true' && env.RPOLARS_FULL_FEATURES != 'true'
         shell: bash

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -108,9 +108,6 @@ jobs:
         with:
           extra-packages: any::rcmdcheck
           needs: check
-          pak-version: devel
-        env:
-          CI: false
 
       - name: Build lib
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,8 +63,6 @@ jobs:
         with:
           extra-packages: any::rcmdcheck
           needs: dev
-        env:
-          CI: false
 
       - name: Build lib
         if: matrix.config.target == ''


### PR DESCRIPTION
Recent versions of `pak` install system dependencies by default, so setting `CI: false` was meaningless. (See r-lib/rig#184)
And, installing system dependencies by pak does not seem to cause any harm, so we can leave the default settings to simplify configuration.