### PR TITLE
Minor styling

### DIFF
--- a/docs/docs/stylesheets/extra.css
+++ b/docs/docs/stylesheets/extra.css
@@ -16,7 +16,7 @@ pre.r-example {
 }
 
 .md-typeset code {
-  font-size: 0.8rem;
+  font-size: inherit;
 }
 
 .md-typeset h2 > code {


### PR DESCRIPTION
Currently, code appears too big in some places, such as argument description: 

![image](https://github.com/pola-rs/r-polars/assets/52219252/6e0b67fd-7a24-4368-a376-efb566416270)
