### PR TITLE
Update LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,21 @@
-YEAR: 2023
-COPYRIGHT HOLDER: polars authors (polars the R package)
+MIT License
+
+Copyright (c) 2022 Søren Havelund Welling
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2023 polars authors (polars the R package)
+Copyright (c) 2022 Søren Havelund Welling
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Hi all,

I was reviewing the repositories in the Polars organization for license files. I found that the open source license in this repo is non-standard:

`LICENSE` containing only copyright - but no full name included
`LICENSE.md` with an MIT license, again with no name included.

I set the year to 2022 (year of the first commit) and the name to the original author @sorhawell . Of course there have been excellent contributions by many authors since then, but I believe this is the correct way to go about it with regards to licensing. Though I am not sure (not a lawyer). 

The `LICENSE` file is automatically picked up by GitHub. I am not sure the Markdown file is needed, but I don't want to break anything so I left it intact.