### PR TITLE
DO NOT MERGE: Fast roll prototype

### DIFF
--- a/R/extendr-wrappers.R
+++ b/R/extendr-wrappers.R
@@ -27,6 +27,8 @@ concat_list <- function(exprs) .Call(wrap__concat_list, exprs)
 
 concat_str <- function(dotdotdot, separator) .Call(wrap__concat_str, dotdotdot, separator)
 
+fast_roll_mean_f64 <- function(s, width) .Call(wrap__fast_roll_mean_f64, s, width)
+
 fold <- function(acc, lambda, exprs) .Call(wrap__fold, acc, lambda, exprs)
 
 reduce <- function(lambda, exprs) .Call(wrap__reduce, lambda, exprs)

--- a/R/extendr-wrappers.R
+++ b/R/extendr-wrappers.R
@@ -27,8 +27,6 @@ concat_list <- function(exprs) .Call(wrap__concat_list, exprs)
 
 concat_str <- function(dotdotdot, separator) .Call(wrap__concat_str, dotdotdot, separator)
 
-fast_roll_mean_f64 <- function(s, width) .Call(wrap__fast_roll_mean_f64, s, width)
-
 fold <- function(acc, lambda, exprs) .Call(wrap__fold, acc, lambda, exprs)
 
 reduce <- function(lambda, exprs) .Call(wrap__reduce, lambda, exprs)
@@ -120,6 +118,20 @@ enable_string_cache <- function() .Call(wrap__enable_string_cache)
 disable_string_cache <- function() .Call(wrap__disable_string_cache)
 
 using_string_cache <- function() .Call(wrap__using_string_cache)
+
+fast_roll_sum_f64 <- function(s, width) .Call(wrap__fast_roll_sum_f64, s, width)
+
+fast_roll_mean_f64 <- function(s, width) .Call(wrap__fast_roll_mean_f64, s, width)
+
+fast_roll_mean_f32 <- function(s, width) .Call(wrap__fast_roll_mean_f32, s, width)
+
+fast_roll_sum_i64 <- function(s, width) .Call(wrap__fast_roll_sum_i64, s, width)
+
+fast_roll_mean_i64 <- function(s, width) .Call(wrap__fast_roll_mean_i64, s, width)
+
+fast_roll_mean_i32 <- function(s, width) .Call(wrap__fast_roll_mean_i32, s, width)
+
+fast_roll_mean_f64_non_macro <- function(s, width) .Call(wrap__fast_roll_mean_f64_non_macro, s, width)
 
 DataFrame <- new.env(parent = emptyenv())
 

--- a/man/as_polars_df.Rd
+++ b/man/as_polars_df.Rd
@@ -101,7 +101,7 @@ Takes not effect for Array or ChunkedArray}
 \code{\link[=as_polars_df]{as_polars_df()}} is a generic function that converts an R object to a
 polars DataFrame. It is basically a wrapper for \link[=pl_DataFrame]{pl$DataFrame()},
 but has special implementations for Apache Arrow-based objects such as
-polars \link[=LazyFrame_class]{LazyFrame} and \link[arrow:Table-class]{arrow::Table}.
+polars \link[=LazyFrame_class]{LazyFrame} and \link[arrow:Table]{arrow::Table}.
 }
 \details{
 For \link[=LazyFrame_class]{LazyFrame} objects, this function is a shortcut for

--- a/src/rust/src/fast_roll.rs
+++ b/src/rust/src/fast_roll.rs
@@ -1,0 +1,210 @@
+use crate::robj_to;
+use crate::rpolarserr::{polars_to_rpolars_err, RResult};
+use crate::series::Series;
+use extendr_api::prelude::*;
+use pl::IntoSeries;
+use polars::prelude as pl;
+use polars::prelude::ChunkedCollectInferIterExt;
+use polars_core::utils::CustomIterTools;
+
+// functions to aggregate over windows
+#[inline(always)]
+fn window_agg_mean<T>(rsum: T, width_t: T) -> T
+where
+    T: std::ops::Div<Output = T>,
+{
+    rsum / width_t
+}
+
+#[inline(always)]
+fn window_agg_sum<T>(rsum: T, _: T) -> T
+where
+    T: std::ops::Div<Output = T>,
+{
+    rsum
+}
+
+// macro to roll any type and agg_funciton
+#[macro_export]
+macro_rules! fastroll {
+    ($agg_fun:expr, $type:ty, $chunked_f:ident, $chunked_type:ident, $s_in:expr, $width:expr) => {
+        (|| -> RResult<Series> {
+            let s = $s_in;
+            let s = robj_to!(Series, s)?;
+            let width = $width;
+            let width = robj_to!(usize, width)?;
+            let width_t = width as $type;
+
+            let ca = s.0.$chunked_f().map_err(polars_to_rpolars_err)?;
+            let ca_cloned = ca.clone();
+            let mut ca_iter_front = ca.into_iter();
+            let mut ca_iter_back = ca_cloned.into_iter();
+            let mut rsum = <$type>::default(); // the window sum
+            let mut ncount: u64 = 0; // the window null count
+            let burn_in = width - 1; // remaining values to fill up window first time
+
+            // fill up window first
+            for _i in 0..burn_in {
+                match ca_iter_front.next() {
+                    None => (),
+                    Some(None) => ncount += 1,
+                    Some(Some(value)) => rsum += value,
+                };
+            }
+
+            let window_value_iter = ca_iter_front.map(|front_value| {
+                // 1 add front value into window
+                match front_value {
+                    None => ncount += 1,
+                    Some(value) => rsum += value,
+                };
+
+                // 2 compute window value
+                let window_value = match ncount {
+                    0 => Some($agg_fun(rsum, width_t)),
+                    _ => None, // window contains one or more Nulls
+                };
+
+                // 3 drop back value from window
+                match ca_iter_back
+                    .next()
+                    .expect("iter_back cannot be depleted before front")
+                {
+                    None => ncount -= 1,
+                    Some(value) => rsum -= value,
+                };
+
+                window_value
+            });
+
+            // SAFETY: new trusted length is always correct.
+            let window_value_iter =
+                unsafe { window_value_iter.trust_my_length(s.len() as usize - burn_in as usize) };
+
+            // pad first burn_in elements as missing
+            let padded_window_value_iter = std::iter::repeat(None)
+                .take(burn_in)
+                .chain(window_value_iter);
+
+            let ca_out: pl::ChunkedArray<pl::$chunked_type> =
+                padded_window_value_iter.collect_ca_trusted("roll!");
+
+            Ok(Series(ca_out.into_series()))
+        })()
+    };
+}
+
+#[extendr]
+fn fast_roll_sum_f64(s: Robj, width: Robj) -> RResult<Series> {
+    fastroll!(window_agg_sum, f64, f64, Float64Type, s, width)
+}
+#[extendr]
+fn fast_roll_mean_f64(s: Robj, width: Robj) -> RResult<Series> {
+    fastroll!(window_agg_mean, f64, f64, Float64Type, s, width)
+}
+
+#[extendr]
+fn fast_roll_mean_f32(s: Robj, width: Robj) -> RResult<Series> {
+    fastroll!(window_agg_mean, f64, f64, Float64Type, s, width)
+}
+
+#[extendr]
+fn fast_roll_sum_i64(s: Robj, width: Robj) -> RResult<Series> {
+    fastroll!(window_agg_sum, i64, i64, Int64Type, s, width)
+}
+
+#[extendr]
+fn fast_roll_mean_i64(s: Robj, width: Robj) -> RResult<Series> {
+    fastroll!(window_agg_mean, i64, i64, Int64Type, s, width)
+}
+
+#[extendr]
+fn fast_roll_mean_i32(s: Robj, width: Robj) -> RResult<Series> {
+    fastroll!(window_agg_mean, i32, i32, Int32Type, s, width)
+}
+
+#[extendr]
+fn fast_roll_mean_f64_non_macro(s: Robj, width: Robj) -> RResult<Series> {
+    let s = robj_to!(Series, s)?;
+    let width = robj_to!(usize, width)?;
+    let width_t = width as f64;
+
+    let ca = s.0.f64().map_err(polars_to_rpolars_err)?;
+    let ca_cloned = ca.clone();
+
+    let mut ca_iter_front = ca.into_iter();
+    let mut ca_iter_back = ca_cloned.into_iter();
+    let mut rsum: f64 = 0.0; // the window sum
+    let mut ncount: u64 = 0; // the window null count
+    let burn_in = width - 1; // remaining values to fill up window first time
+
+    //rprintln!("\n size hint iterator {:?}", ca_iter_front.size_hint());
+
+    for _i in 0..burn_in {
+        //rprintln!("\n burn-in {}", _i);
+        match ca_iter_front.next() {
+            None => (),
+            Some(None) => ncount += 1,
+            Some(Some(value)) => rsum += value,
+        };
+    }
+
+    //rprintln!("\n size hint iterator {:?}", ca_iter_front.size_hint());
+
+    use polars::prelude::ChunkedCollectInferIterExt;
+    let window_value_iter = ca_iter_front.map(|front_value| {
+        //rprintln!("\n front-value {:?}", front_value);
+        // 1 add front value into window
+        match front_value {
+            None => ncount += 1,
+            Some(value) => rsum += value,
+        };
+
+        // 2 compute window value
+        let window_value = match ncount {
+            0 => Some(rsum / width_t),
+            _ => None, // window contains one or more Nulls
+        };
+        //rprintln!("window-value {:?}", window_value);
+
+        // 3 drop back value from window
+
+        //rprintln!("back-value {:?}", back_value);
+        match ca_iter_back
+            .next()
+            // well maybe if width =1 ,check for that
+            .expect("iter_back cannot be depleted before front ")
+        {
+            None => ncount -= 1,
+            Some(value) => rsum -= value,
+        };
+
+        window_value
+    });
+    use polars_core::utils::CustomIterTools;
+    let window_value_iter =
+        unsafe { window_value_iter.trust_my_length(s.len() as usize - burn_in as usize) };
+
+    //rprintln!("\n size hint iterator {:?}", window_value_iter.size_hint());
+
+    let padded_window_value_iter = std::iter::repeat(None)
+        .take(burn_in)
+        .chain(window_value_iter);
+
+    let ca_out: pl::ChunkedArray<pl::Float64Type> =
+        padded_window_value_iter.collect_ca_trusted("roll!");
+
+    Ok(Series(ca_out.into_series()))
+}
+
+extendr_module! {
+    mod fast_roll;
+
+    fn fast_roll_sum_f64;
+    fn fast_roll_mean_f64;
+    fn fast_roll_mean_f32;
+    fn fast_roll_sum_i64;
+    fn fast_roll_mean_i64;
+    fn fast_roll_mean_i32;
+    fn fast_roll_mean_f64_non_macro;
+}

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -17,6 +17,7 @@ pub mod concat;
 pub mod conversion;
 pub mod conversion_r_to_s;
 pub mod conversion_s_to_r;
+pub mod fast_roll;
 pub mod info;
 pub mod rbackground;
 pub mod rdataframe;
@@ -53,6 +54,7 @@ extendr_module! {
     use series;
     use info;
     use rstringcache;
+    use fast_roll;
 }
 
 #[cfg(feature = "sql")]
@@ -68,4 +70,5 @@ extendr_module! {
     use sql;
     use info;
     use rstringcache;
+    use fast_roll;
 }

--- a/src/rust/src/rlib.rs
+++ b/src/rust/src/rlib.rs
@@ -9,6 +9,7 @@ use crate::utils::robj_to_rchoice;
 use crate::RFnSignature;
 use crate::CONFIG;
 use extendr_api::prelude::*;
+use pl::IntoSeries;
 use polars::prelude as pl;
 use std::result::Result;
 
@@ -76,6 +77,74 @@ fn concat_str(dotdotdot: Robj, separator: Robj) -> RResult<Expr> {
         robj_to!(str, separator)?,
     )
     .into())
+}
+
+#[extendr]
+fn fast_roll_mean_f64(s: Robj, width: Robj) -> RResult<Series> {
+    let s = robj_to!(Series, s)?;
+    let width = robj_to!(usize, width)?;
+
+    let ca = s.0.f64().map_err(polars_to_rpolars_err)?;
+    let ca_cloned = ca.clone();
+    let mut v_out: Vec<f64> = Vec::with_capacity(s.0.len());
+
+    let mut ca_iter_front = ca.into_iter();
+    let mut ca_iter_back = ca_cloned.into_iter();
+    let mut rsum: f64 = 0.0;
+    let mut ncount: u64 = 0;
+
+    //dbg!(&ca);
+    // fill up window with first ´width`` elements
+    for _i in 0..(width - 1) {
+        //dbg!(&_i);
+        match ca_iter_front.next().flatten() {
+            None => ncount += 1,
+            Some(value) => rsum += value,
+        }
+    }
+
+    //dbg!(&ca);
+    // safety: no out of bounds can happen
+    // ca_inter_front() has less or equal elements left than the capacity of v_out
+    unsafe {
+        let mut ptr_out = v_out.as_mut_ptr();
+        let ptr_start = ptr_out as usize;
+        let mut safe_stop = 0;
+        while let Some(nullable_val) = ca_iter_front.next() {
+            //dbg!(&nullable_val);
+            safe_stop += 1;
+            if safe_stop > 100 {
+                //dbg!(safe_stop);
+                break;
+            }
+            match nullable_val {
+                None => ncount += 1,
+                Some(value) => rsum += value,
+            }
+            if ncount == 0 {
+                std::ptr::write(ptr_out, rsum / width as f64);
+            } else {
+                std::ptr::write(ptr_out, -42.0);
+            }
+            ptr_out = ptr_out.wrapping_add(1);
+
+            let nullable_val2 = ca_iter_back
+                .next()
+                .expect("iter_back cannot deplete before iter_front()");
+            match nullable_val2 {
+                None => ncount -= 1,
+                Some(value) => rsum -= value,
+            }
+            //dbg!(ptr_out as usize, &ptr_start, ptr_out as usize - ptr_start);
+        }
+
+        v_out.set_len((ptr_out as usize - ptr_start) / std::mem::size_of::<f64>())
+    }
+
+    let ca_out: pl::ChunkedArray<pl::Float64Type> =
+        polars::chunked_array::ChunkedArray::from_vec("roll!", v_out);
+
+    Ok(Series(ca_out.into_series()))
 }
 
 #[extendr]
@@ -300,8 +369,12 @@ extendr_module! {
     fn sum_horizontal;
     fn coalesce_exprs;
 
+
+
     fn concat_list;
     fn concat_str;
+
+    fn fast_roll_mean_f64;
 
     fn fold;
     fn reduce;


### PR DESCRIPTION
This was a prototype to re-implement fast rolling for polars. I mistakenly thought polars rolling was worse. rolling sum, mean .... is only 2x slower than data.table.

This simple prototype happend to be as fast data.table thus 2x faster than native rust-polars. I don't know why the rust-polars implementation is slower. It seems it has bit more run-time branching.

I will not move forward with maintaining a separate rolling implementation in r-polars.