### PR TITLE
test: switch to use the new release version of `testthat`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,12 +37,10 @@ Suggests:
     pillar,
     rlang,
     rmarkdown,
-    testthat (>= 3.0.0),
+    testthat (>= 3.2.1),
     tibble,
     tools,
     withr
-Remotes:
-    r-lib/testthat
 Config/Needs/website:
     altdoc (>= 0.2.2),
     here,


### PR DESCRIPTION
We have been using the edge version of `testthat` since https://github.com/pola-rs/r-polars/pull/455#discussion_r1380464052, but `testthat` 3.2.1 is now on CRAN.
So we can switch to that.