### PR TITLE
feat: `rownames` option of `as_polars_df`

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -681,3 +681,10 @@ make_profile_plot = function(data, truncate_nodes) {
   }
   plot
 }
+
+
+# Copied from the tibble package
+# https://github.com/tidyverse/tibble/blob/e78ea46caea5e89cbffa5887c11050335ab23896/R/rownames.R#L116-L118
+raw_rownames = function(x) {
+  .row_names_info(x, 0L) %||% .set_row_names(.row_names_info(x, 2L))
+}

--- a/man/as_polars_df.Rd
+++ b/man/as_polars_df.Rd
@@ -16,7 +16,7 @@ as_polars_df(x, ...)
 
 \method{as_polars_df}{default}(x, ...)
 
-\method{as_polars_df}{data.frame}(x, ...)
+\method{as_polars_df}{data.frame}(x, ..., rownames = NULL)
 
 \method{as_polars_df}{RPolarsDataFrame}(x, ...)
 
@@ -49,6 +49,13 @@ as_polars_df(x, ...)
 \item{x}{Object to convert to a polars DataFrame.}
 
 \item{...}{Additional arguments passed to methods.}
+
+\item{rownames}{How to treat existing row names of a data frame:
+\itemize{
+\item \code{NULL}: Remove row names. This is the default.
+\item A string: The name of a new column, which will contain the row names.
+If \code{x} already has a column with that name, the existing column will be removed.
+}}
 
 \item{n_rows}{Number of rows to fetch. Defaults to \code{Inf}, meaning all rows.}
 
@@ -110,10 +117,13 @@ whether the number of rows to fetch is infinite or not.
 }
 \examples{
 \dontshow{if (requireNamespace("arrow", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
-at = arrow::as_arrow_table(mtcars)
+# Convert the row names of a data frame to a column
+as_polars_df(mtcars, rownames = "car")
 
 # Convert an arrow Table to a polars LazyFrame
-lf = as_polars_df(at)$lazy()
+lf = as_polars_df(
+  arrow::as_arrow_table(mtcars)
+)$lazy()
 
 # Collect all rows
 as_polars_df(lf)

--- a/src/rust/src/lazy/dsl.rs
+++ b/src/rust/src/lazy/dsl.rs
@@ -1,7 +1,7 @@
 use crate::concurrent::RFnSignature;
 use crate::rdatatype::{
     literal_to_any_value, new_rank_method, new_rolling_cov_options, parse_fill_null_strategy,
-    robj_to_timeunit, RPolarsDataTypeVector, RPolarsDataType,
+    robj_to_timeunit, RPolarsDataType, RPolarsDataTypeVector,
 };
 use crate::robj_to;
 use crate::rpolarserr::{

--- a/src/rust/src/rlib.rs
+++ b/src/rust/src/rlib.rs
@@ -1,4 +1,4 @@
-use crate::lazy::dsl::{RPolarsProtoExprArray, RPolarsExpr};
+use crate::lazy::dsl::{RPolarsExpr, RPolarsProtoExprArray};
 use crate::rdataframe::RPolarsDataFrame;
 use crate::robj_to;
 use crate::rpolarserr::{rdbg, RResult};


### PR DESCRIPTION
Similar to `tibble::as_tibble`'s `rownames` argument.
However, it differs in that it implicitly overwrites existing column (`as_tibble` holds two columns have same name, and `tibble::rownames_to_column` raise an error).