### PR TITLE
rpolars_style 0.1.1: fix styler `<<-`   and style all files 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,7 +55,6 @@ Config/Needs/dev:
     RcppTOML,
     readr,
     rextendr,
-    robinlovelace/styler.equals,
     spelling,
     stringr,
     styler

--- a/R/Field.R
+++ b/R/Field.R
@@ -113,7 +113,7 @@ RField.property_setters$datatype = function(self, value) {
   }
 
   # if(is.null(func)) pstop(err= paste("no setter method for",name)))
-  if (polars_optenv$strictly_immutable) self <- .pr$RField$clone(self)
+  if (polars_optenv$strictly_immutable) self = .pr$RField$clone(self)
   func = RField.property_setters[[name]]
   func(self, value)
   self

--- a/R/after-wrappers.R
+++ b/R/after-wrappers.R
@@ -23,7 +23,7 @@ build_debug_print = FALSE
 #' @return env of pure function calls to rust
 #'
 extendr_method_to_pure_functions = function(env, class_name = NULL) {
-  if (is.null(class_name)) class_name <- as.character(sys.call()[2])
+  if (is.null(class_name)) class_name = as.character(sys.call()[2])
   e = as.environment(lapply(env, function(f) {
     if (!is.function(f)) {
       return(f)

--- a/R/expr__datetime.R
+++ b/R/expr__datetime.R
@@ -130,7 +130,7 @@ ExprDT_round = function(every, offset = NULL) {
 #' expr = pl$lit(as.Date("2021-01-01"))$dt$combine(3600 * 1.5E6 + 123, tu = "us")
 #' expr$cast(pl$Datetime(tu = "us", tz = "GMT"))$to_r()
 ExprDT_combine = function(tm, tu = "us") {
-  if (inherits(tm, "PTime")) tu <- "ns" # PTime implicitly gets converted to "ns"
+  if (inherits(tm, "PTime")) tu = "ns" # PTime implicitly gets converted to "ns"
   if (!is_string(tu)) stop("combine: input tu is not a string, [%s ]", str_string(tu))
   unwrap(.pr$Expr$dt_combine(self, wrap_e(tm), tu))
 }

--- a/R/expr__expr.R
+++ b/R/expr__expr.R
@@ -135,7 +135,7 @@ wrap_elist_result = function(elist, str_to_lit = TRUE) {
   element_i = 0L
   result(
     {
-      if (!is.list(elist) && length(elist) == 1L) elist <- list(elist)
+      if (!is.list(elist) && length(elist) == 1L) elist = list(elist)
       lapply(elist, \(e) {
         element_i <<- element_i + 1L
         wrap_e(e, str_to_lit)
@@ -887,7 +887,7 @@ Expr_map_elements = function(f, return_type = NULL, strict_return_type = TRUE, a
 }
 
 Expr_apply = function(f, return_type = NULL, strict_return_type = TRUE,
-                       allow_fail_eval = FALSE, in_background = FALSE) {
+                      allow_fail_eval = FALSE, in_background = FALSE) {
   warning("$apply() is deprecated and will be removed in 0.13.0. Use $map_elements() instead.", call. = FALSE)
   if (in_background) {
     return(.pr$Expr$map_elements_in_background(self, f, return_type))
@@ -2273,8 +2273,8 @@ Expr_inspect = function(fmt = "{}") {
   # check fmt and create something to print before and after printing Series.
   if (!is_string(fmt)) stop("Inspect: arg fmt is not a string (length=1)")
   strs = strsplit(fmt, split = "\\{\\}")[[1L]]
-  if (identical(strs, "")) strs <- c("", "")
-  if (length(strs) == 1 && grepl("\\{\\}$", fmt)) strs <- c(strs, "")
+  if (identical(strs, "")) strs = c("", "")
+  if (length(strs) == 1 && grepl("\\{\\}$", fmt)) strs = c(strs, "")
   if (length(strs) != 2L || length(gregexpr("\\{\\}", fmt)[[1L]]) != 1L) {
     result(stop(paste0(
       "Inspect: failed to parse arg fmt [", fmt, "] ",
@@ -2334,10 +2334,10 @@ prepare_rolling_window_args = function(
     min_periods = NULL # : int | None = None,
     ) { # ->tuple[str, int]:
   if (is.numeric(window_size)) {
-    if (is.null(min_periods)) min_periods <- as.numeric(window_size)
+    if (is.null(min_periods)) min_periods = as.numeric(window_size)
     window_size = paste0(as.character(floor(window_size)), "i")
   }
-  if (is.null(min_periods)) min_periods <- 1
+  if (is.null(min_periods)) min_periods = 1
   list(window_size = window_size, min_periods = min_periods)
 }
 
@@ -3559,7 +3559,7 @@ Expr_peak_max = function() {
 #'   sum_a_offset1 = pl$sum("a")$rolling(index_column = "dt", period = "2d", offset = "1d")
 #' )
 Expr_rolling = function(index_column, period, offset = NULL,
-                         closed = "right", check_sorted = TRUE) {
+                        closed = "right", check_sorted = TRUE) {
   if (is.null(offset)) {
     offset = paste0("-", period)
   }

--- a/R/expr__list.R
+++ b/R/expr__list.R
@@ -393,10 +393,9 @@ ExprList_tail = function(n = 5L) {
 #'
 #' df2$to_list()
 ExprList_to_struct = function(
-    n_field_strategy = c("first_non_null","max_width"),
+    n_field_strategy = c("first_non_null", "max_width"),
     name_generator = NULL,
-    upper_bound = 0
-) {
+    upper_bound = 0) {
   .pr$Expr$list_to_struct(self, n_field_strategy, name_generator, upper_bound) |>
     unwrap("in <List>$to_struct():")
 }

--- a/R/extendr-wrappers.R
+++ b/R/extendr-wrappers.R
@@ -11,1257 +11,1333 @@
 #' @useDynLib polars, .registration = TRUE
 NULL
 
-all_horizontal <- function(dotdotdot) .Call(wrap__all_horizontal, dotdotdot)
+all_horizontal = function(dotdotdot) .Call(wrap__all_horizontal, dotdotdot)
 
-any_horizontal <- function(dotdotdot) .Call(wrap__any_horizontal, dotdotdot)
+any_horizontal = function(dotdotdot) .Call(wrap__any_horizontal, dotdotdot)
 
-min_horizontal <- function(dotdotdot) .Call(wrap__min_horizontal, dotdotdot)
+min_horizontal = function(dotdotdot) .Call(wrap__min_horizontal, dotdotdot)
 
-max_horizontal <- function(dotdotdot) .Call(wrap__max_horizontal, dotdotdot)
+max_horizontal = function(dotdotdot) .Call(wrap__max_horizontal, dotdotdot)
 
-sum_horizontal <- function(dotdotdot) .Call(wrap__sum_horizontal, dotdotdot)
+sum_horizontal = function(dotdotdot) .Call(wrap__sum_horizontal, dotdotdot)
 
-coalesce_exprs <- function(exprs) .Call(wrap__coalesce_exprs, exprs)
+coalesce_exprs = function(exprs) .Call(wrap__coalesce_exprs, exprs)
 
-concat_list <- function(exprs) .Call(wrap__concat_list, exprs)
+concat_list = function(exprs) .Call(wrap__concat_list, exprs)
 
-concat_str <- function(dotdotdot, separator) .Call(wrap__concat_str, dotdotdot, separator)
+concat_str = function(dotdotdot, separator) .Call(wrap__concat_str, dotdotdot, separator)
 
-fold <- function(acc, lambda, exprs) .Call(wrap__fold, acc, lambda, exprs)
+fold = function(acc, lambda, exprs) .Call(wrap__fold, acc, lambda, exprs)
 
-reduce <- function(lambda, exprs) .Call(wrap__reduce, lambda, exprs)
+reduce = function(lambda, exprs) .Call(wrap__reduce, lambda, exprs)
 
-r_date_range_lazy <- function(start, end, every, closed, time_unit, time_zone, explode) .Call(wrap__r_date_range_lazy, start, end, every, closed, time_unit, time_zone, explode)
+r_date_range_lazy = function(start, end, every, closed, time_unit, time_zone, explode) .Call(wrap__r_date_range_lazy, start, end, every, closed, time_unit, time_zone, explode)
 
-as_struct <- function(exprs) .Call(wrap__as_struct, exprs)
+as_struct = function(exprs) .Call(wrap__as_struct, exprs)
 
-struct_ <- function(exprs, eager, schema) .Call(wrap__struct_, exprs, eager, schema)
+struct_ = function(exprs, eager, schema) .Call(wrap__struct_, exprs, eager, schema)
 
-rb_list_to_df <- function(r_batches, names) .Call(wrap__rb_list_to_df, r_batches, names)
+rb_list_to_df = function(r_batches, names) .Call(wrap__rb_list_to_df, r_batches, names)
 
-dtype_str_repr <- function(dtype) .Call(wrap__dtype_str_repr, dtype)
+dtype_str_repr = function(dtype) .Call(wrap__dtype_str_repr, dtype)
 
-new_arrow_stream <- function() .Call(wrap__new_arrow_stream)
+new_arrow_stream = function() .Call(wrap__new_arrow_stream)
 
-arrow_stream_to_df <- function(robj_str) .Call(wrap__arrow_stream_to_df, robj_str)
+arrow_stream_to_df = function(robj_str) .Call(wrap__arrow_stream_to_df, robj_str)
 
-arrow_stream_to_series <- function(robj_str) .Call(wrap__arrow_stream_to_series, robj_str)
+arrow_stream_to_series = function(robj_str) .Call(wrap__arrow_stream_to_series, robj_str)
 
-export_df_to_arrow_stream <- function(robj_df, robj_str) .Call(wrap__export_df_to_arrow_stream, robj_df, robj_str)
+export_df_to_arrow_stream = function(robj_df, robj_str) .Call(wrap__export_df_to_arrow_stream, robj_df, robj_str)
 
-mem_address <- function(robj) .Call(wrap__mem_address, robj)
+mem_address = function(robj) .Call(wrap__mem_address, robj)
 
-clone_robj <- function(robj) .Call(wrap__clone_robj, robj)
+clone_robj = function(robj) .Call(wrap__clone_robj, robj)
 
-test_robj_to_usize <- function(robj) .Call(wrap__test_robj_to_usize, robj)
+test_robj_to_usize = function(robj) .Call(wrap__test_robj_to_usize, robj)
 
-test_robj_to_f64 <- function(robj) .Call(wrap__test_robj_to_f64, robj)
+test_robj_to_f64 = function(robj) .Call(wrap__test_robj_to_f64, robj)
 
-test_robj_to_i64 <- function(robj) .Call(wrap__test_robj_to_i64, robj)
+test_robj_to_i64 = function(robj) .Call(wrap__test_robj_to_i64, robj)
 
-test_robj_to_u32 <- function(robj) .Call(wrap__test_robj_to_u32, robj)
+test_robj_to_u32 = function(robj) .Call(wrap__test_robj_to_u32, robj)
 
-test_robj_to_i32 <- function(robj) .Call(wrap__test_robj_to_i32, robj)
+test_robj_to_i32 = function(robj) .Call(wrap__test_robj_to_i32, robj)
 
-test_print_string <- function(s) invisible(.Call(wrap__test_print_string, s))
+test_print_string = function(s) invisible(.Call(wrap__test_print_string, s))
 
-test_robj_to_expr <- function(robj) .Call(wrap__test_robj_to_expr, robj)
+test_robj_to_expr = function(robj) .Call(wrap__test_robj_to_expr, robj)
 
-test_wrong_call_pl_lit <- function(robj) .Call(wrap__test_wrong_call_pl_lit, robj)
+test_wrong_call_pl_lit = function(robj) .Call(wrap__test_wrong_call_pl_lit, robj)
 
-test_robj_to_rchoice <- function(robj) .Call(wrap__test_robj_to_rchoice, robj)
+test_robj_to_rchoice = function(robj) .Call(wrap__test_robj_to_rchoice, robj)
 
-concat_lf <- function(l, rechunk, parallel, to_supertypes) .Call(wrap__concat_lf, l, rechunk, parallel, to_supertypes)
+concat_lf = function(l, rechunk, parallel, to_supertypes) .Call(wrap__concat_lf, l, rechunk, parallel, to_supertypes)
 
-concat_lf_diagonal <- function(l, rechunk, parallel, to_supertypes) .Call(wrap__concat_lf_diagonal, l, rechunk, parallel, to_supertypes)
+concat_lf_diagonal = function(l, rechunk, parallel, to_supertypes) .Call(wrap__concat_lf_diagonal, l, rechunk, parallel, to_supertypes)
 
-concat_df_horizontal <- function(l) .Call(wrap__concat_df_horizontal, l)
+concat_df_horizontal = function(l) .Call(wrap__concat_df_horizontal, l)
 
-concat_series <- function(l, rechunk, to_supertypes) .Call(wrap__concat_series, l, rechunk, to_supertypes)
+concat_series = function(l, rechunk, to_supertypes) .Call(wrap__concat_series, l, rechunk, to_supertypes)
 
-new_from_csv <- function(path, has_header, separator, comment_char, quote_char, skip_rows, dtypes, null_values, ignore_errors, cache, infer_schema_length, n_rows, encoding, low_memory, rechunk, skip_rows_after_header, row_count_name, row_count_offset, try_parse_dates, eol_char, raise_if_empty, truncate_ragged_lines) .Call(wrap__new_from_csv, path, has_header, separator, comment_char, quote_char, skip_rows, dtypes, null_values, ignore_errors, cache, infer_schema_length, n_rows, encoding, low_memory, rechunk, skip_rows_after_header, row_count_name, row_count_offset, try_parse_dates, eol_char, raise_if_empty, truncate_ragged_lines)
+new_from_csv = function(path, has_header, separator, comment_char, quote_char, skip_rows, dtypes, null_values, ignore_errors, cache, infer_schema_length, n_rows, encoding, low_memory, rechunk, skip_rows_after_header, row_count_name, row_count_offset, try_parse_dates, eol_char, raise_if_empty, truncate_ragged_lines) .Call(wrap__new_from_csv, path, has_header, separator, comment_char, quote_char, skip_rows, dtypes, null_values, ignore_errors, cache, infer_schema_length, n_rows, encoding, low_memory, rechunk, skip_rows_after_header, row_count_name, row_count_offset, try_parse_dates, eol_char, raise_if_empty, truncate_ragged_lines)
 
-import_arrow_ipc <- function(path, n_rows, cache, rechunk, row_name, row_count, memmap) .Call(wrap__import_arrow_ipc, path, n_rows, cache, rechunk, row_name, row_count, memmap)
+import_arrow_ipc = function(path, n_rows, cache, rechunk, row_name, row_count, memmap) .Call(wrap__import_arrow_ipc, path, n_rows, cache, rechunk, row_name, row_count, memmap)
 
-new_from_ndjson <- function(path, infer_schema_length, batch_size, n_rows, low_memory, rechunk, row_count_name, row_count_offset) .Call(wrap__new_from_ndjson, path, infer_schema_length, batch_size, n_rows, low_memory, rechunk, row_count_name, row_count_offset)
+new_from_ndjson = function(path, infer_schema_length, batch_size, n_rows, low_memory, rechunk, row_count_name, row_count_offset) .Call(wrap__new_from_ndjson, path, infer_schema_length, batch_size, n_rows, low_memory, rechunk, row_count_name, row_count_offset)
 
-new_from_parquet <- function(path, n_rows, cache, parallel, rechunk, row_name, row_count, use_statistics, low_memory, hive_partitioning) .Call(wrap__new_from_parquet, path, n_rows, cache, parallel, rechunk, row_name, row_count, use_statistics, low_memory, hive_partitioning)
+new_from_parquet = function(path, n_rows, cache, parallel, rechunk, row_name, row_count, use_statistics, low_memory, hive_partitioning) .Call(wrap__new_from_parquet, path, n_rows, cache, parallel, rechunk, row_name, row_count, use_statistics, low_memory, hive_partitioning)
 
-test_rpolarserr <- function() .Call(wrap__test_rpolarserr)
+test_rpolarserr = function() .Call(wrap__test_rpolarserr)
 
-setup_renv <- function() .Call(wrap__setup_renv)
+setup_renv = function() .Call(wrap__setup_renv)
 
-set_global_rpool_cap <- function(c) .Call(wrap__set_global_rpool_cap, c)
+set_global_rpool_cap = function(c) .Call(wrap__set_global_rpool_cap, c)
 
-get_global_rpool_cap <- function() .Call(wrap__get_global_rpool_cap)
+get_global_rpool_cap = function() .Call(wrap__get_global_rpool_cap)
 
-handle_background_request <- function(server_name) .Call(wrap__handle_background_request, server_name)
+handle_background_request = function(server_name) .Call(wrap__handle_background_request, server_name)
 
-test_rbackgroundhandler <- function(lambda, arg) .Call(wrap__test_rbackgroundhandler, lambda, arg)
+test_rbackgroundhandler = function(lambda, arg) .Call(wrap__test_rbackgroundhandler, lambda, arg)
 
-test_rthreadhandle <- function() .Call(wrap__test_rthreadhandle)
+test_rthreadhandle = function() .Call(wrap__test_rthreadhandle)
 
-test_serde_df <- function(df) .Call(wrap__test_serde_df, df)
+test_serde_df = function(df) .Call(wrap__test_serde_df, df)
 
-internal_wrap_e <- function(robj, str_to_lit) .Call(wrap__internal_wrap_e, robj, str_to_lit)
+internal_wrap_e = function(robj, str_to_lit) .Call(wrap__internal_wrap_e, robj, str_to_lit)
 
-robj_to_col <- function(name, dotdotdot) .Call(wrap__robj_to_col, name, dotdotdot)
+robj_to_col = function(name, dotdotdot) .Call(wrap__robj_to_col, name, dotdotdot)
 
-cargo_rpolars_feature_info <- function() .Call(wrap__cargo_rpolars_feature_info)
+cargo_rpolars_feature_info = function() .Call(wrap__cargo_rpolars_feature_info)
 
-rust_polars_version <- function() .Call(wrap__rust_polars_version)
+rust_polars_version = function() .Call(wrap__rust_polars_version)
 
-enable_string_cache <- function() .Call(wrap__enable_string_cache)
+enable_string_cache = function() .Call(wrap__enable_string_cache)
 
-disable_string_cache <- function() .Call(wrap__disable_string_cache)
+disable_string_cache = function() .Call(wrap__disable_string_cache)
 
-using_string_cache <- function() .Call(wrap__using_string_cache)
+using_string_cache = function() .Call(wrap__using_string_cache)
 
-RPolarsDataFrame <- new.env(parent = emptyenv())
+RPolarsDataFrame = new.env(parent = emptyenv())
 
-RPolarsDataFrame$shape <- function() .Call(wrap__RPolarsDataFrame__shape, self)
+RPolarsDataFrame$shape = function() .Call(wrap__RPolarsDataFrame__shape, self)
 
-RPolarsDataFrame$n_chunks <- function(strategy) .Call(wrap__RPolarsDataFrame__n_chunks, self, strategy)
+RPolarsDataFrame$n_chunks = function(strategy) .Call(wrap__RPolarsDataFrame__n_chunks, self, strategy)
 
-RPolarsDataFrame$rechunk <- function() .Call(wrap__RPolarsDataFrame__rechunk, self)
+RPolarsDataFrame$rechunk = function() .Call(wrap__RPolarsDataFrame__rechunk, self)
 
-RPolarsDataFrame$clone_in_rust <- function() .Call(wrap__RPolarsDataFrame__clone_in_rust, self)
+RPolarsDataFrame$clone_in_rust = function() .Call(wrap__RPolarsDataFrame__clone_in_rust, self)
 
-RPolarsDataFrame$default <- function() .Call(wrap__RPolarsDataFrame__default)
+RPolarsDataFrame$default = function() .Call(wrap__RPolarsDataFrame__default)
 
-RPolarsDataFrame$lazy <- function() .Call(wrap__RPolarsDataFrame__lazy, self)
+RPolarsDataFrame$lazy = function() .Call(wrap__RPolarsDataFrame__lazy, self)
 
-RPolarsDataFrame$drop_all_in_place <- function() invisible(.Call(wrap__RPolarsDataFrame__drop_all_in_place, self))
+RPolarsDataFrame$drop_all_in_place = function() invisible(.Call(wrap__RPolarsDataFrame__drop_all_in_place, self))
 
-RPolarsDataFrame$new_with_capacity <- function(capacity) .Call(wrap__RPolarsDataFrame__new_with_capacity, capacity)
+RPolarsDataFrame$new_with_capacity = function(capacity) .Call(wrap__RPolarsDataFrame__new_with_capacity, capacity)
 
-RPolarsDataFrame$set_column_from_robj <- function(robj, name) .Call(wrap__RPolarsDataFrame__set_column_from_robj, self, robj, name)
+RPolarsDataFrame$set_column_from_robj = function(robj, name) .Call(wrap__RPolarsDataFrame__set_column_from_robj, self, robj, name)
 
-RPolarsDataFrame$set_column_from_series <- function(x) .Call(wrap__RPolarsDataFrame__set_column_from_series, self, x)
+RPolarsDataFrame$set_column_from_series = function(x) .Call(wrap__RPolarsDataFrame__set_column_from_series, self, x)
 
-RPolarsDataFrame$with_row_count <- function(name, offset) .Call(wrap__RPolarsDataFrame__with_row_count, self, name, offset)
+RPolarsDataFrame$with_row_count = function(name, offset) .Call(wrap__RPolarsDataFrame__with_row_count, self, name, offset)
 
-RPolarsDataFrame$print <- function() .Call(wrap__RPolarsDataFrame__print, self)
+RPolarsDataFrame$print = function() .Call(wrap__RPolarsDataFrame__print, self)
 
-RPolarsDataFrame$columns <- function() .Call(wrap__RPolarsDataFrame__columns, self)
+RPolarsDataFrame$columns = function() .Call(wrap__RPolarsDataFrame__columns, self)
 
-RPolarsDataFrame$set_column_names_mut <- function(names) .Call(wrap__RPolarsDataFrame__set_column_names_mut, self, names)
+RPolarsDataFrame$set_column_names_mut = function(names) .Call(wrap__RPolarsDataFrame__set_column_names_mut, self, names)
 
-RPolarsDataFrame$get_column <- function(name) .Call(wrap__RPolarsDataFrame__get_column, self, name)
+RPolarsDataFrame$get_column = function(name) .Call(wrap__RPolarsDataFrame__get_column, self, name)
 
-RPolarsDataFrame$get_columns <- function() .Call(wrap__RPolarsDataFrame__get_columns, self)
+RPolarsDataFrame$get_columns = function() .Call(wrap__RPolarsDataFrame__get_columns, self)
 
-RPolarsDataFrame$dtypes <- function() .Call(wrap__RPolarsDataFrame__dtypes, self)
+RPolarsDataFrame$dtypes = function() .Call(wrap__RPolarsDataFrame__dtypes, self)
 
-RPolarsDataFrame$dtype_strings <- function() .Call(wrap__RPolarsDataFrame__dtype_strings, self)
+RPolarsDataFrame$dtype_strings = function() .Call(wrap__RPolarsDataFrame__dtype_strings, self)
 
-RPolarsDataFrame$schema <- function() .Call(wrap__RPolarsDataFrame__schema, self)
+RPolarsDataFrame$schema = function() .Call(wrap__RPolarsDataFrame__schema, self)
 
-RPolarsDataFrame$to_list <- function() .Call(wrap__RPolarsDataFrame__to_list, self)
+RPolarsDataFrame$to_list = function() .Call(wrap__RPolarsDataFrame__to_list, self)
 
-RPolarsDataFrame$to_list_unwind <- function() .Call(wrap__RPolarsDataFrame__to_list_unwind, self)
+RPolarsDataFrame$to_list_unwind = function() .Call(wrap__RPolarsDataFrame__to_list_unwind, self)
 
-RPolarsDataFrame$to_list_tag_structs <- function() .Call(wrap__RPolarsDataFrame__to_list_tag_structs, self)
+RPolarsDataFrame$to_list_tag_structs = function() .Call(wrap__RPolarsDataFrame__to_list_tag_structs, self)
 
-RPolarsDataFrame$frame_equal <- function(other) .Call(wrap__RPolarsDataFrame__frame_equal, self, other)
+RPolarsDataFrame$frame_equal = function(other) .Call(wrap__RPolarsDataFrame__frame_equal, self, other)
 
-RPolarsDataFrame$select_at_idx <- function(idx) .Call(wrap__RPolarsDataFrame__select_at_idx, self, idx)
+RPolarsDataFrame$select_at_idx = function(idx) .Call(wrap__RPolarsDataFrame__select_at_idx, self, idx)
 
-RPolarsDataFrame$drop_in_place <- function(names) .Call(wrap__RPolarsDataFrame__drop_in_place, self, names)
+RPolarsDataFrame$drop_in_place = function(names) .Call(wrap__RPolarsDataFrame__drop_in_place, self, names)
 
-RPolarsDataFrame$select <- function(exprs) .Call(wrap__RPolarsDataFrame__select, self, exprs)
+RPolarsDataFrame$select = function(exprs) .Call(wrap__RPolarsDataFrame__select, self, exprs)
 
-RPolarsDataFrame$with_columns <- function(exprs) .Call(wrap__RPolarsDataFrame__with_columns, self, exprs)
+RPolarsDataFrame$with_columns = function(exprs) .Call(wrap__RPolarsDataFrame__with_columns, self, exprs)
 
-RPolarsDataFrame$by_agg <- function(group_exprs, agg_exprs, maintain_order) .Call(wrap__RPolarsDataFrame__by_agg, self, group_exprs, agg_exprs, maintain_order)
+RPolarsDataFrame$by_agg = function(group_exprs, agg_exprs, maintain_order) .Call(wrap__RPolarsDataFrame__by_agg, self, group_exprs, agg_exprs, maintain_order)
 
-RPolarsDataFrame$to_struct <- function(name) .Call(wrap__RPolarsDataFrame__to_struct, self, name)
+RPolarsDataFrame$to_struct = function(name) .Call(wrap__RPolarsDataFrame__to_struct, self, name)
 
-RPolarsDataFrame$unnest <- function(names) .Call(wrap__RPolarsDataFrame__unnest, self, names)
+RPolarsDataFrame$unnest = function(names) .Call(wrap__RPolarsDataFrame__unnest, self, names)
 
-RPolarsDataFrame$export_stream <- function(stream_ptr) invisible(.Call(wrap__RPolarsDataFrame__export_stream, self, stream_ptr))
+RPolarsDataFrame$export_stream = function(stream_ptr) invisible(.Call(wrap__RPolarsDataFrame__export_stream, self, stream_ptr))
 
-RPolarsDataFrame$from_arrow_record_batches <- function(rbr) .Call(wrap__RPolarsDataFrame__from_arrow_record_batches, rbr)
+RPolarsDataFrame$from_arrow_record_batches = function(rbr) .Call(wrap__RPolarsDataFrame__from_arrow_record_batches, rbr)
 
-RPolarsDataFrame$estimated_size <- function() .Call(wrap__RPolarsDataFrame__estimated_size, self)
+RPolarsDataFrame$estimated_size = function() .Call(wrap__RPolarsDataFrame__estimated_size, self)
 
-RPolarsDataFrame$null_count <- function() .Call(wrap__RPolarsDataFrame__null_count, self)
+RPolarsDataFrame$null_count = function() .Call(wrap__RPolarsDataFrame__null_count, self)
 
-RPolarsDataFrame$melt <- function(id_vars, value_vars, value_name, variable_name) .Call(wrap__RPolarsDataFrame__melt, self, id_vars, value_vars, value_name, variable_name)
+RPolarsDataFrame$melt = function(id_vars, value_vars, value_name, variable_name) .Call(wrap__RPolarsDataFrame__melt, self, id_vars, value_vars, value_name, variable_name)
 
-RPolarsDataFrame$pivot_expr <- function(values, index, columns, maintain_order, sort_columns, aggregate_expr, separator) .Call(wrap__RPolarsDataFrame__pivot_expr, self, values, index, columns, maintain_order, sort_columns, aggregate_expr, separator)
+RPolarsDataFrame$pivot_expr = function(values, index, columns, maintain_order, sort_columns, aggregate_expr, separator) .Call(wrap__RPolarsDataFrame__pivot_expr, self, values, index, columns, maintain_order, sort_columns, aggregate_expr, separator)
 
-RPolarsDataFrame$sample_n <- function(n, with_replacement, shuffle, seed) .Call(wrap__RPolarsDataFrame__sample_n, self, n, with_replacement, shuffle, seed)
+RPolarsDataFrame$sample_n = function(n, with_replacement, shuffle, seed) .Call(wrap__RPolarsDataFrame__sample_n, self, n, with_replacement, shuffle, seed)
 
-RPolarsDataFrame$sample_frac <- function(frac, with_replacement, shuffle, seed) .Call(wrap__RPolarsDataFrame__sample_frac, self, frac, with_replacement, shuffle, seed)
+RPolarsDataFrame$sample_frac = function(frac, with_replacement, shuffle, seed) .Call(wrap__RPolarsDataFrame__sample_frac, self, frac, with_replacement, shuffle, seed)
 
-RPolarsDataFrame$transpose <- function(keep_names_as, new_col_names) .Call(wrap__RPolarsDataFrame__transpose, self, keep_names_as, new_col_names)
+RPolarsDataFrame$transpose = function(keep_names_as, new_col_names) .Call(wrap__RPolarsDataFrame__transpose, self, keep_names_as, new_col_names)
 
-RPolarsDataFrame$write_csv <- function(path, include_bom, include_header, separator, line_terminator, quote, batch_size, datetime_format, date_format, time_format, float_precision, null_value, quote_style) .Call(wrap__RPolarsDataFrame__write_csv, self, path, include_bom, include_header, separator, line_terminator, quote, batch_size, datetime_format, date_format, time_format, float_precision, null_value, quote_style)
+RPolarsDataFrame$write_csv = function(path, include_bom, include_header, separator, line_terminator, quote, batch_size, datetime_format, date_format, time_format, float_precision, null_value, quote_style) .Call(wrap__RPolarsDataFrame__write_csv, self, path, include_bom, include_header, separator, line_terminator, quote, batch_size, datetime_format, date_format, time_format, float_precision, null_value, quote_style)
 
-RPolarsDataFrame$write_json <- function(file, pretty, row_oriented) .Call(wrap__RPolarsDataFrame__write_json, self, file, pretty, row_oriented)
+RPolarsDataFrame$write_json = function(file, pretty, row_oriented) .Call(wrap__RPolarsDataFrame__write_json, self, file, pretty, row_oriented)
 
-RPolarsDataFrame$write_ndjson <- function(file) .Call(wrap__RPolarsDataFrame__write_ndjson, self, file)
+RPolarsDataFrame$write_ndjson = function(file) .Call(wrap__RPolarsDataFrame__write_ndjson, self, file)
 
 #' @export
-`$.RPolarsDataFrame` <- function (self, name) { func <- RPolarsDataFrame[[name]]; environment(func) <- environment(); func }
+`$.RPolarsDataFrame` = function(self, name) {
+  func = RPolarsDataFrame[[name]]
+  environment(func) = environment()
+  func
+}
 
 #' @export
-`[[.RPolarsDataFrame` <- `$.RPolarsDataFrame`
+`[[.RPolarsDataFrame` = `$.RPolarsDataFrame`
 
-RPolarsVecDataFrame <- new.env(parent = emptyenv())
+RPolarsVecDataFrame = new.env(parent = emptyenv())
 
-RPolarsVecDataFrame$with_capacity <- function(n) .Call(wrap__RPolarsVecDataFrame__with_capacity, n)
+RPolarsVecDataFrame$with_capacity = function(n) .Call(wrap__RPolarsVecDataFrame__with_capacity, n)
 
-RPolarsVecDataFrame$push <- function(df) invisible(.Call(wrap__RPolarsVecDataFrame__push, self, df))
+RPolarsVecDataFrame$push = function(df) invisible(.Call(wrap__RPolarsVecDataFrame__push, self, df))
 
-RPolarsVecDataFrame$print <- function() invisible(.Call(wrap__RPolarsVecDataFrame__print, self))
-
-#' @export
-`$.RPolarsVecDataFrame` <- function (self, name) { func <- RPolarsVecDataFrame[[name]]; environment(func) <- environment(); func }
+RPolarsVecDataFrame$print = function() invisible(.Call(wrap__RPolarsVecDataFrame__print, self))
 
 #' @export
-`[[.RPolarsVecDataFrame` <- `$.RPolarsVecDataFrame`
-
-RPolarsRNullValues <- new.env(parent = emptyenv())
-
-RPolarsRNullValues$new_all_columns <- function(x) .Call(wrap__RPolarsRNullValues__new_all_columns, x)
-
-RPolarsRNullValues$new_columns <- function(x) .Call(wrap__RPolarsRNullValues__new_columns, x)
-
-RPolarsRNullValues$new_named <- function(robj) .Call(wrap__RPolarsRNullValues__new_named, robj)
+`$.RPolarsVecDataFrame` = function(self, name) {
+  func = RPolarsVecDataFrame[[name]]
+  environment(func) = environment()
+  func
+}
 
 #' @export
-`$.RPolarsRNullValues` <- function (self, name) { func <- RPolarsRNullValues[[name]]; environment(func) <- environment(); func }
+`[[.RPolarsVecDataFrame` = `$.RPolarsVecDataFrame`
+
+RPolarsRNullValues = new.env(parent = emptyenv())
+
+RPolarsRNullValues$new_all_columns = function(x) .Call(wrap__RPolarsRNullValues__new_all_columns, x)
+
+RPolarsRNullValues$new_columns = function(x) .Call(wrap__RPolarsRNullValues__new_columns, x)
+
+RPolarsRNullValues$new_named = function(robj) .Call(wrap__RPolarsRNullValues__new_named, robj)
 
 #' @export
-`[[.RPolarsRNullValues` <- `$.RPolarsRNullValues`
-
-RPolarsDataType <- new.env(parent = emptyenv())
-
-RPolarsDataType$new <- function(s) .Call(wrap__RPolarsDataType__new, s)
-
-RPolarsDataType$new_datetime <- function(tu, tz) .Call(wrap__RPolarsDataType__new_datetime, tu, tz)
-
-RPolarsDataType$new_duration <- function() .Call(wrap__RPolarsDataType__new_duration)
-
-RPolarsDataType$new_list <- function(inner) .Call(wrap__RPolarsDataType__new_list, inner)
-
-RPolarsDataType$new_object <- function() .Call(wrap__RPolarsDataType__new_object)
-
-RPolarsDataType$new_struct <- function(l) .Call(wrap__RPolarsDataType__new_struct, l)
-
-RPolarsDataType$get_all_simple_type_names <- function() .Call(wrap__RPolarsDataType__get_all_simple_type_names)
-
-RPolarsDataType$print <- function() invisible(.Call(wrap__RPolarsDataType__print, self))
-
-RPolarsDataType$eq <- function(other) .Call(wrap__RPolarsDataType__eq, self, other)
-
-RPolarsDataType$ne <- function(other) .Call(wrap__RPolarsDataType__ne, self, other)
-
-RPolarsDataType$same_outer_datatype <- function(other) .Call(wrap__RPolarsDataType__same_outer_datatype, self, other)
-
-RPolarsDataType$get_insides <- function() .Call(wrap__RPolarsDataType__get_insides, self)
-
-RPolarsDataType$is_temporal <- function() .Call(wrap__RPolarsDataType__is_temporal, self)
+`$.RPolarsRNullValues` = function(self, name) {
+  func = RPolarsRNullValues[[name]]
+  environment(func) = environment()
+  func
+}
 
 #' @export
-`$.RPolarsDataType` <- function (self, name) { func <- RPolarsDataType[[name]]; environment(func) <- environment(); func }
+`[[.RPolarsRNullValues` = `$.RPolarsRNullValues`
+
+RPolarsDataType = new.env(parent = emptyenv())
+
+RPolarsDataType$new = function(s) .Call(wrap__RPolarsDataType__new, s)
+
+RPolarsDataType$new_datetime = function(tu, tz) .Call(wrap__RPolarsDataType__new_datetime, tu, tz)
+
+RPolarsDataType$new_duration = function() .Call(wrap__RPolarsDataType__new_duration)
+
+RPolarsDataType$new_list = function(inner) .Call(wrap__RPolarsDataType__new_list, inner)
+
+RPolarsDataType$new_object = function() .Call(wrap__RPolarsDataType__new_object)
+
+RPolarsDataType$new_struct = function(l) .Call(wrap__RPolarsDataType__new_struct, l)
+
+RPolarsDataType$get_all_simple_type_names = function() .Call(wrap__RPolarsDataType__get_all_simple_type_names)
+
+RPolarsDataType$print = function() invisible(.Call(wrap__RPolarsDataType__print, self))
+
+RPolarsDataType$eq = function(other) .Call(wrap__RPolarsDataType__eq, self, other)
+
+RPolarsDataType$ne = function(other) .Call(wrap__RPolarsDataType__ne, self, other)
+
+RPolarsDataType$same_outer_datatype = function(other) .Call(wrap__RPolarsDataType__same_outer_datatype, self, other)
+
+RPolarsDataType$get_insides = function() .Call(wrap__RPolarsDataType__get_insides, self)
+
+RPolarsDataType$is_temporal = function() .Call(wrap__RPolarsDataType__is_temporal, self)
 
 #' @export
-`[[.RPolarsDataType` <- `$.RPolarsDataType`
-
-RPolarsDataTypeVector <- new.env(parent = emptyenv())
-
-RPolarsDataTypeVector$new <- function() .Call(wrap__RPolarsDataTypeVector__new)
-
-RPolarsDataTypeVector$push <- function(colname, datatype) invisible(.Call(wrap__RPolarsDataTypeVector__push, self, colname, datatype))
-
-RPolarsDataTypeVector$print <- function() invisible(.Call(wrap__RPolarsDataTypeVector__print, self))
-
-RPolarsDataTypeVector$from_rlist <- function(list) .Call(wrap__RPolarsDataTypeVector__from_rlist, list)
+`$.RPolarsDataType` = function(self, name) {
+  func = RPolarsDataType[[name]]
+  environment(func) = environment()
+  func
+}
 
 #' @export
-`$.RPolarsDataTypeVector` <- function (self, name) { func <- RPolarsDataTypeVector[[name]]; environment(func) <- environment(); func }
+`[[.RPolarsDataType` = `$.RPolarsDataType`
+
+RPolarsDataTypeVector = new.env(parent = emptyenv())
+
+RPolarsDataTypeVector$new = function() .Call(wrap__RPolarsDataTypeVector__new)
+
+RPolarsDataTypeVector$push = function(colname, datatype) invisible(.Call(wrap__RPolarsDataTypeVector__push, self, colname, datatype))
+
+RPolarsDataTypeVector$print = function() invisible(.Call(wrap__RPolarsDataTypeVector__print, self))
+
+RPolarsDataTypeVector$from_rlist = function(list) .Call(wrap__RPolarsDataTypeVector__from_rlist, list)
 
 #' @export
-`[[.RPolarsDataTypeVector` <- `$.RPolarsDataTypeVector`
-
-RPolarsRField <- new.env(parent = emptyenv())
-
-RPolarsRField$new <- function(name, datatype) .Call(wrap__RPolarsRField__new, name, datatype)
-
-RPolarsRField$print <- function() invisible(.Call(wrap__RPolarsRField__print, self))
-
-RPolarsRField$clone <- function() .Call(wrap__RPolarsRField__clone, self)
-
-RPolarsRField$get_name <- function() .Call(wrap__RPolarsRField__get_name, self)
-
-RPolarsRField$get_datatype <- function() .Call(wrap__RPolarsRField__get_datatype, self)
-
-RPolarsRField$set_name_mut <- function(name) invisible(.Call(wrap__RPolarsRField__set_name_mut, self, name))
-
-RPolarsRField$set_datatype_mut <- function(datatype) invisible(.Call(wrap__RPolarsRField__set_datatype_mut, self, datatype))
+`$.RPolarsDataTypeVector` = function(self, name) {
+  func = RPolarsDataTypeVector[[name]]
+  environment(func) = environment()
+  func
+}
 
 #' @export
-`$.RPolarsRField` <- function (self, name) { func <- RPolarsRField[[name]]; environment(func) <- environment(); func }
+`[[.RPolarsDataTypeVector` = `$.RPolarsDataTypeVector`
+
+RPolarsRField = new.env(parent = emptyenv())
+
+RPolarsRField$new = function(name, datatype) .Call(wrap__RPolarsRField__new, name, datatype)
+
+RPolarsRField$print = function() invisible(.Call(wrap__RPolarsRField__print, self))
+
+RPolarsRField$clone = function() .Call(wrap__RPolarsRField__clone, self)
+
+RPolarsRField$get_name = function() .Call(wrap__RPolarsRField__get_name, self)
+
+RPolarsRField$get_datatype = function() .Call(wrap__RPolarsRField__get_datatype, self)
+
+RPolarsRField$set_name_mut = function(name) invisible(.Call(wrap__RPolarsRField__set_name_mut, self, name))
+
+RPolarsRField$set_datatype_mut = function(datatype) invisible(.Call(wrap__RPolarsRField__set_datatype_mut, self, datatype))
 
 #' @export
-`[[.RPolarsRField` <- `$.RPolarsRField`
-
-RPolarsErr <- new.env(parent = emptyenv())
-
-RPolarsErr$new <- function() .Call(wrap__RPolarsErr__new)
-
-RPolarsErr$contexts <- function() .Call(wrap__RPolarsErr__contexts, self)
-
-RPolarsErr$pretty_msg <- function() .Call(wrap__RPolarsErr__pretty_msg, self)
-
-RPolarsErr$bad_arg <- function(s) .Call(wrap__RPolarsErr__bad_arg, self, s)
-
-RPolarsErr$bad_robj <- function(r) .Call(wrap__RPolarsErr__bad_robj, self, r)
-
-RPolarsErr$bad_val <- function(s) .Call(wrap__RPolarsErr__bad_val, self, s)
-
-RPolarsErr$hint <- function(s) .Call(wrap__RPolarsErr__hint, self, s)
-
-RPolarsErr$mistyped <- function(s) .Call(wrap__RPolarsErr__mistyped, self, s)
-
-RPolarsErr$misvalued <- function(s) .Call(wrap__RPolarsErr__misvalued, self, s)
-
-RPolarsErr$notachoice <- function(s) .Call(wrap__RPolarsErr__notachoice, self, s)
-
-RPolarsErr$plain <- function(s) .Call(wrap__RPolarsErr__plain, self, s)
-
-RPolarsErr$rcall <- function(c) .Call(wrap__RPolarsErr__rcall, self, c)
-
-RPolarsErr$get_rcall <- function() .Call(wrap__RPolarsErr__get_rcall, self)
-
-RPolarsErr$rinfo <- function(i) .Call(wrap__RPolarsErr__rinfo, self, i)
-
-RPolarsErr$get_rinfo <- function() .Call(wrap__RPolarsErr__get_rinfo, self)
-
-RPolarsErr$when <- function(s) .Call(wrap__RPolarsErr__when, self, s)
+`$.RPolarsRField` = function(self, name) {
+  func = RPolarsRField[[name]]
+  environment(func) = environment()
+  func
+}
 
 #' @export
-`$.RPolarsErr` <- function (self, name) { func <- RPolarsErr[[name]]; environment(func) <- environment(); func }
+`[[.RPolarsRField` = `$.RPolarsRField`
+
+RPolarsErr = new.env(parent = emptyenv())
+
+RPolarsErr$new = function() .Call(wrap__RPolarsErr__new)
+
+RPolarsErr$contexts = function() .Call(wrap__RPolarsErr__contexts, self)
+
+RPolarsErr$pretty_msg = function() .Call(wrap__RPolarsErr__pretty_msg, self)
+
+RPolarsErr$bad_arg = function(s) .Call(wrap__RPolarsErr__bad_arg, self, s)
+
+RPolarsErr$bad_robj = function(r) .Call(wrap__RPolarsErr__bad_robj, self, r)
+
+RPolarsErr$bad_val = function(s) .Call(wrap__RPolarsErr__bad_val, self, s)
+
+RPolarsErr$hint = function(s) .Call(wrap__RPolarsErr__hint, self, s)
+
+RPolarsErr$mistyped = function(s) .Call(wrap__RPolarsErr__mistyped, self, s)
+
+RPolarsErr$misvalued = function(s) .Call(wrap__RPolarsErr__misvalued, self, s)
+
+RPolarsErr$notachoice = function(s) .Call(wrap__RPolarsErr__notachoice, self, s)
+
+RPolarsErr$plain = function(s) .Call(wrap__RPolarsErr__plain, self, s)
+
+RPolarsErr$rcall = function(c) .Call(wrap__RPolarsErr__rcall, self, c)
+
+RPolarsErr$get_rcall = function() .Call(wrap__RPolarsErr__get_rcall, self)
+
+RPolarsErr$rinfo = function(i) .Call(wrap__RPolarsErr__rinfo, self, i)
+
+RPolarsErr$get_rinfo = function() .Call(wrap__RPolarsErr__get_rinfo, self)
+
+RPolarsErr$when = function(s) .Call(wrap__RPolarsErr__when, self, s)
 
 #' @export
-`[[.RPolarsErr` <- `$.RPolarsErr`
-
-RPolarsRThreadHandle <- new.env(parent = emptyenv())
-
-RPolarsRThreadHandle$join <- function() .Call(wrap__RPolarsRThreadHandle__join, self)
-
-RPolarsRThreadHandle$is_finished <- function() .Call(wrap__RPolarsRThreadHandle__is_finished, self)
-
-RPolarsRThreadHandle$thread_description <- function() .Call(wrap__RPolarsRThreadHandle__thread_description, self)
+`$.RPolarsErr` = function(self, name) {
+  func = RPolarsErr[[name]]
+  environment(func) = environment()
+  func
+}
 
 #' @export
-`$.RPolarsRThreadHandle` <- function (self, name) { func <- RPolarsRThreadHandle[[name]]; environment(func) <- environment(); func }
+`[[.RPolarsErr` = `$.RPolarsErr`
+
+RPolarsRThreadHandle = new.env(parent = emptyenv())
+
+RPolarsRThreadHandle$join = function() .Call(wrap__RPolarsRThreadHandle__join, self)
+
+RPolarsRThreadHandle$is_finished = function() .Call(wrap__RPolarsRThreadHandle__is_finished, self)
+
+RPolarsRThreadHandle$thread_description = function() .Call(wrap__RPolarsRThreadHandle__thread_description, self)
 
 #' @export
-`[[.RPolarsRThreadHandle` <- `$.RPolarsRThreadHandle`
-
-RPolarsWhen <- new.env(parent = emptyenv())
-
-RPolarsWhen$new <- function(condition) .Call(wrap__RPolarsWhen__new, condition)
-
-RPolarsWhen$then <- function(statement) .Call(wrap__RPolarsWhen__then, self, statement)
+`$.RPolarsRThreadHandle` = function(self, name) {
+  func = RPolarsRThreadHandle[[name]]
+  environment(func) = environment()
+  func
+}
 
 #' @export
-`$.RPolarsWhen` <- function (self, name) { func <- RPolarsWhen[[name]]; environment(func) <- environment(); func }
+`[[.RPolarsRThreadHandle` = `$.RPolarsRThreadHandle`
+
+RPolarsWhen = new.env(parent = emptyenv())
+
+RPolarsWhen$new = function(condition) .Call(wrap__RPolarsWhen__new, condition)
+
+RPolarsWhen$then = function(statement) .Call(wrap__RPolarsWhen__then, self, statement)
 
 #' @export
-`[[.RPolarsWhen` <- `$.RPolarsWhen`
-
-RPolarsThen <- new.env(parent = emptyenv())
-
-RPolarsThen$when <- function(condition) .Call(wrap__RPolarsThen__when, self, condition)
-
-RPolarsThen$otherwise <- function(statement) .Call(wrap__RPolarsThen__otherwise, self, statement)
+`$.RPolarsWhen` = function(self, name) {
+  func = RPolarsWhen[[name]]
+  environment(func) = environment()
+  func
+}
 
 #' @export
-`$.RPolarsThen` <- function (self, name) { func <- RPolarsThen[[name]]; environment(func) <- environment(); func }
+`[[.RPolarsWhen` = `$.RPolarsWhen`
+
+RPolarsThen = new.env(parent = emptyenv())
+
+RPolarsThen$when = function(condition) .Call(wrap__RPolarsThen__when, self, condition)
+
+RPolarsThen$otherwise = function(statement) .Call(wrap__RPolarsThen__otherwise, self, statement)
 
 #' @export
-`[[.RPolarsThen` <- `$.RPolarsThen`
-
-RPolarsChainedWhen <- new.env(parent = emptyenv())
-
-RPolarsChainedWhen$then <- function(statement) .Call(wrap__RPolarsChainedWhen__then, self, statement)
-
-#' @export
-`$.RPolarsChainedWhen` <- function (self, name) { func <- RPolarsChainedWhen[[name]]; environment(func) <- environment(); func }
+`$.RPolarsThen` = function(self, name) {
+  func = RPolarsThen[[name]]
+  environment(func) = environment()
+  func
+}
 
 #' @export
-`[[.RPolarsChainedWhen` <- `$.RPolarsChainedWhen`
+`[[.RPolarsThen` = `$.RPolarsThen`
 
-RPolarsChainedThen <- new.env(parent = emptyenv())
+RPolarsChainedWhen = new.env(parent = emptyenv())
 
-RPolarsChainedThen$when <- function(condition) .Call(wrap__RPolarsChainedThen__when, self, condition)
-
-RPolarsChainedThen$otherwise <- function(statement) .Call(wrap__RPolarsChainedThen__otherwise, self, statement)
+RPolarsChainedWhen$then = function(statement) .Call(wrap__RPolarsChainedWhen__then, self, statement)
 
 #' @export
-`$.RPolarsChainedThen` <- function (self, name) { func <- RPolarsChainedThen[[name]]; environment(func) <- environment(); func }
+`$.RPolarsChainedWhen` = function(self, name) {
+  func = RPolarsChainedWhen[[name]]
+  environment(func) = environment()
+  func
+}
 
 #' @export
-`[[.RPolarsChainedThen` <- `$.RPolarsChainedThen`
+`[[.RPolarsChainedWhen` = `$.RPolarsChainedWhen`
 
-RPolarsExpr <- new.env(parent = emptyenv())
+RPolarsChainedThen = new.env(parent = emptyenv())
 
-RPolarsExpr$col <- function(name) .Call(wrap__RPolarsExpr__col, name)
+RPolarsChainedThen$when = function(condition) .Call(wrap__RPolarsChainedThen__when, self, condition)
 
-RPolarsExpr$dtype_cols <- function(dtypes) .Call(wrap__RPolarsExpr__dtype_cols, dtypes)
-
-RPolarsExpr$cols <- function(names) .Call(wrap__RPolarsExpr__cols, names)
-
-RPolarsExpr$lit <- function(robj) .Call(wrap__RPolarsExpr__lit, robj)
-
-RPolarsExpr$gt <- function(other) .Call(wrap__RPolarsExpr__gt, self, other)
-
-RPolarsExpr$gt_eq <- function(other) .Call(wrap__RPolarsExpr__gt_eq, self, other)
-
-RPolarsExpr$lt <- function(other) .Call(wrap__RPolarsExpr__lt, self, other)
-
-RPolarsExpr$lt_eq <- function(other) .Call(wrap__RPolarsExpr__lt_eq, self, other)
-
-RPolarsExpr$neq <- function(other) .Call(wrap__RPolarsExpr__neq, self, other)
-
-RPolarsExpr$neq_missing <- function(other) .Call(wrap__RPolarsExpr__neq_missing, self, other)
-
-RPolarsExpr$eq <- function(other) .Call(wrap__RPolarsExpr__eq, self, other)
-
-RPolarsExpr$eq_missing <- function(other) .Call(wrap__RPolarsExpr__eq_missing, self, other)
-
-RPolarsExpr$and <- function(other) .Call(wrap__RPolarsExpr__and, self, other)
-
-RPolarsExpr$or <- function(other) .Call(wrap__RPolarsExpr__or, self, other)
-
-RPolarsExpr$xor <- function(other) .Call(wrap__RPolarsExpr__xor, self, other)
-
-RPolarsExpr$to_physical <- function() .Call(wrap__RPolarsExpr__to_physical, self)
-
-RPolarsExpr$cast <- function(data_type, strict) .Call(wrap__RPolarsExpr__cast, self, data_type, strict)
-
-RPolarsExpr$sort <- function(descending, nulls_last) .Call(wrap__RPolarsExpr__sort, self, descending, nulls_last)
-
-RPolarsExpr$arg_sort <- function(descending, nulls_last) .Call(wrap__RPolarsExpr__arg_sort, self, descending, nulls_last)
-
-RPolarsExpr$top_k <- function(k) .Call(wrap__RPolarsExpr__top_k, self, k)
-
-RPolarsExpr$bottom_k <- function(k) .Call(wrap__RPolarsExpr__bottom_k, self, k)
-
-RPolarsExpr$arg_max <- function() .Call(wrap__RPolarsExpr__arg_max, self)
-
-RPolarsExpr$arg_min <- function() .Call(wrap__RPolarsExpr__arg_min, self)
-
-RPolarsExpr$search_sorted <- function(element) .Call(wrap__RPolarsExpr__search_sorted, self, element)
-
-RPolarsExpr$gather <- function(idx) .Call(wrap__RPolarsExpr__gather, self, idx)
-
-RPolarsExpr$sort_by <- function(by, descending) .Call(wrap__RPolarsExpr__sort_by, self, by, descending)
-
-RPolarsExpr$backward_fill <- function(limit) .Call(wrap__RPolarsExpr__backward_fill, self, limit)
-
-RPolarsExpr$forward_fill <- function(limit) .Call(wrap__RPolarsExpr__forward_fill, self, limit)
-
-RPolarsExpr$shift <- function(periods) .Call(wrap__RPolarsExpr__shift, self, periods)
-
-RPolarsExpr$shift_and_fill <- function(periods, fill_value) .Call(wrap__RPolarsExpr__shift_and_fill, self, periods, fill_value)
-
-RPolarsExpr$fill_null <- function(expr) .Call(wrap__RPolarsExpr__fill_null, self, expr)
-
-RPolarsExpr$fill_null_with_strategy <- function(strategy, limit) .Call(wrap__RPolarsExpr__fill_null_with_strategy, self, strategy, limit)
-
-RPolarsExpr$fill_nan <- function(expr) .Call(wrap__RPolarsExpr__fill_nan, self, expr)
-
-RPolarsExpr$reverse <- function() .Call(wrap__RPolarsExpr__reverse, self)
-
-RPolarsExpr$std <- function(ddof) .Call(wrap__RPolarsExpr__std, self, ddof)
-
-RPolarsExpr$var <- function(ddof) .Call(wrap__RPolarsExpr__var, self, ddof)
-
-RPolarsExpr$max <- function() .Call(wrap__RPolarsExpr__max, self)
-
-RPolarsExpr$min <- function() .Call(wrap__RPolarsExpr__min, self)
-
-RPolarsExpr$nan_min <- function() .Call(wrap__RPolarsExpr__nan_min, self)
-
-RPolarsExpr$nan_max <- function() .Call(wrap__RPolarsExpr__nan_max, self)
-
-RPolarsExpr$mean <- function() .Call(wrap__RPolarsExpr__mean, self)
-
-RPolarsExpr$median <- function() .Call(wrap__RPolarsExpr__median, self)
-
-RPolarsExpr$sum <- function() .Call(wrap__RPolarsExpr__sum, self)
-
-RPolarsExpr$product <- function() .Call(wrap__RPolarsExpr__product, self)
-
-RPolarsExpr$n_unique <- function() .Call(wrap__RPolarsExpr__n_unique, self)
-
-RPolarsExpr$null_count <- function() .Call(wrap__RPolarsExpr__null_count, self)
-
-RPolarsExpr$arg_unique <- function() .Call(wrap__RPolarsExpr__arg_unique, self)
-
-RPolarsExpr$quantile <- function(quantile, interpolation) .Call(wrap__RPolarsExpr__quantile, self, quantile, interpolation)
-
-RPolarsExpr$filter <- function(predicate) .Call(wrap__RPolarsExpr__filter, self, predicate)
-
-RPolarsExpr$explode <- function() .Call(wrap__RPolarsExpr__explode, self)
-
-RPolarsExpr$flatten <- function() .Call(wrap__RPolarsExpr__flatten, self)
-
-RPolarsExpr$gather_every <- function(n) .Call(wrap__RPolarsExpr__gather_every, self, n)
-
-RPolarsExpr$hash <- function(seed, seed_1, seed_2, seed_3) .Call(wrap__RPolarsExpr__hash, self, seed, seed_1, seed_2, seed_3)
-
-RPolarsExpr$reinterpret <- function(signed) .Call(wrap__RPolarsExpr__reinterpret, self, signed)
-
-RPolarsExpr$interpolate <- function(method) .Call(wrap__RPolarsExpr__interpolate, self, method)
-
-RPolarsExpr$rolling_min <- function(window_size, weights, min_periods, center, by_null, closed_null) .Call(wrap__RPolarsExpr__rolling_min, self, window_size, weights, min_periods, center, by_null, closed_null)
-
-RPolarsExpr$rolling_max <- function(window_size, weights, min_periods, center, by_null, closed_null) .Call(wrap__RPolarsExpr__rolling_max, self, window_size, weights, min_periods, center, by_null, closed_null)
-
-RPolarsExpr$rolling_mean <- function(window_size, weights, min_periods, center, by_null, closed_null) .Call(wrap__RPolarsExpr__rolling_mean, self, window_size, weights, min_periods, center, by_null, closed_null)
-
-RPolarsExpr$rolling_sum <- function(window_size, weights, min_periods, center, by_null, closed_null) .Call(wrap__RPolarsExpr__rolling_sum, self, window_size, weights, min_periods, center, by_null, closed_null)
-
-RPolarsExpr$rolling_std <- function(window_size, weights, min_periods, center, by_null, closed_null) .Call(wrap__RPolarsExpr__rolling_std, self, window_size, weights, min_periods, center, by_null, closed_null)
-
-RPolarsExpr$rolling_var <- function(window_size, weights, min_periods, center, by_null, closed_null) .Call(wrap__RPolarsExpr__rolling_var, self, window_size, weights, min_periods, center, by_null, closed_null)
-
-RPolarsExpr$rolling_median <- function(window_size, weights, min_periods, center, by_null, closed_null) .Call(wrap__RPolarsExpr__rolling_median, self, window_size, weights, min_periods, center, by_null, closed_null)
-
-RPolarsExpr$rolling_quantile <- function(quantile, interpolation, window_size, weights, min_periods, center, by, closed) .Call(wrap__RPolarsExpr__rolling_quantile, self, quantile, interpolation, window_size, weights, min_periods, center, by, closed)
-
-RPolarsExpr$rolling_skew <- function(window_size_f, bias) .Call(wrap__RPolarsExpr__rolling_skew, self, window_size_f, bias)
-
-RPolarsExpr$abs <- function() .Call(wrap__RPolarsExpr__abs, self)
-
-RPolarsExpr$rank <- function(method, descending) .Call(wrap__RPolarsExpr__rank, self, method, descending)
-
-RPolarsExpr$diff <- function(n_float, null_behavior) .Call(wrap__RPolarsExpr__diff, self, n_float, null_behavior)
-
-RPolarsExpr$pct_change <- function(n_float) .Call(wrap__RPolarsExpr__pct_change, self, n_float)
-
-RPolarsExpr$skew <- function(bias) .Call(wrap__RPolarsExpr__skew, self, bias)
-
-RPolarsExpr$kurtosis <- function(fisher, bias) .Call(wrap__RPolarsExpr__kurtosis, self, fisher, bias)
-
-RPolarsExpr$clip <- function(min, max) .Call(wrap__RPolarsExpr__clip, self, min, max)
-
-RPolarsExpr$clip_min <- function(min) .Call(wrap__RPolarsExpr__clip_min, self, min)
-
-RPolarsExpr$clip_max <- function(max) .Call(wrap__RPolarsExpr__clip_max, self, max)
-
-RPolarsExpr$lower_bound <- function() .Call(wrap__RPolarsExpr__lower_bound, self)
-
-RPolarsExpr$upper_bound <- function() .Call(wrap__RPolarsExpr__upper_bound, self)
-
-RPolarsExpr$sign <- function() .Call(wrap__RPolarsExpr__sign, self)
-
-RPolarsExpr$sin <- function() .Call(wrap__RPolarsExpr__sin, self)
-
-RPolarsExpr$cos <- function() .Call(wrap__RPolarsExpr__cos, self)
-
-RPolarsExpr$tan <- function() .Call(wrap__RPolarsExpr__tan, self)
-
-RPolarsExpr$arcsin <- function() .Call(wrap__RPolarsExpr__arcsin, self)
-
-RPolarsExpr$arccos <- function() .Call(wrap__RPolarsExpr__arccos, self)
-
-RPolarsExpr$arctan <- function() .Call(wrap__RPolarsExpr__arctan, self)
-
-RPolarsExpr$sinh <- function() .Call(wrap__RPolarsExpr__sinh, self)
-
-RPolarsExpr$cosh <- function() .Call(wrap__RPolarsExpr__cosh, self)
-
-RPolarsExpr$tanh <- function() .Call(wrap__RPolarsExpr__tanh, self)
-
-RPolarsExpr$arcsinh <- function() .Call(wrap__RPolarsExpr__arcsinh, self)
-
-RPolarsExpr$arccosh <- function() .Call(wrap__RPolarsExpr__arccosh, self)
-
-RPolarsExpr$arctanh <- function() .Call(wrap__RPolarsExpr__arctanh, self)
-
-RPolarsExpr$reshape <- function(dims) .Call(wrap__RPolarsExpr__reshape, self, dims)
-
-RPolarsExpr$shuffle <- function(seed) .Call(wrap__RPolarsExpr__shuffle, self, seed)
-
-RPolarsExpr$sample_n <- function(n, with_replacement, shuffle, seed) .Call(wrap__RPolarsExpr__sample_n, self, n, with_replacement, shuffle, seed)
-
-RPolarsExpr$sample_frac <- function(frac, with_replacement, shuffle, seed) .Call(wrap__RPolarsExpr__sample_frac, self, frac, with_replacement, shuffle, seed)
-
-RPolarsExpr$ewm_mean <- function(alpha, adjust, min_periods, ignore_nulls) .Call(wrap__RPolarsExpr__ewm_mean, self, alpha, adjust, min_periods, ignore_nulls)
-
-RPolarsExpr$ewm_std <- function(alpha, adjust, bias, min_periods, ignore_nulls) .Call(wrap__RPolarsExpr__ewm_std, self, alpha, adjust, bias, min_periods, ignore_nulls)
-
-RPolarsExpr$ewm_var <- function(alpha, adjust, bias, min_periods, ignore_nulls) .Call(wrap__RPolarsExpr__ewm_var, self, alpha, adjust, bias, min_periods, ignore_nulls)
-
-RPolarsExpr$extend_constant <- function(value, n) .Call(wrap__RPolarsExpr__extend_constant, self, value, n)
-
-RPolarsExpr$rep <- function(n, rechunk) .Call(wrap__RPolarsExpr__rep, self, n, rechunk)
-
-RPolarsExpr$value_counts <- function(sort, parallel) .Call(wrap__RPolarsExpr__value_counts, self, sort, parallel)
-
-RPolarsExpr$unique_counts <- function() .Call(wrap__RPolarsExpr__unique_counts, self)
-
-RPolarsExpr$entropy <- function(base, normalize) .Call(wrap__RPolarsExpr__entropy, self, base, normalize)
-
-RPolarsExpr$cumulative_eval <- function(expr, min_periods, parallel) .Call(wrap__RPolarsExpr__cumulative_eval, self, expr, min_periods, parallel)
-
-RPolarsExpr$implode <- function() .Call(wrap__RPolarsExpr__implode, self)
-
-RPolarsExpr$shrink_dtype <- function() .Call(wrap__RPolarsExpr__shrink_dtype, self)
-
-RPolarsExpr$peak_min <- function() .Call(wrap__RPolarsExpr__peak_min, self)
-
-RPolarsExpr$peak_max <- function() .Call(wrap__RPolarsExpr__peak_max, self)
-
-RPolarsExpr$list_lengths <- function() .Call(wrap__RPolarsExpr__list_lengths, self)
-
-RPolarsExpr$list_contains <- function(other) .Call(wrap__RPolarsExpr__list_contains, self, other)
-
-RPolarsExpr$list_max <- function() .Call(wrap__RPolarsExpr__list_max, self)
-
-RPolarsExpr$list_min <- function() .Call(wrap__RPolarsExpr__list_min, self)
-
-RPolarsExpr$list_sum <- function() .Call(wrap__RPolarsExpr__list_sum, self)
-
-RPolarsExpr$list_mean <- function() .Call(wrap__RPolarsExpr__list_mean, self)
-
-RPolarsExpr$list_sort <- function(descending) .Call(wrap__RPolarsExpr__list_sort, self, descending)
-
-RPolarsExpr$list_reverse <- function() .Call(wrap__RPolarsExpr__list_reverse, self)
-
-RPolarsExpr$list_unique <- function() .Call(wrap__RPolarsExpr__list_unique, self)
-
-RPolarsExpr$list_gather <- function(index, null_on_oob) .Call(wrap__RPolarsExpr__list_gather, self, index, null_on_oob)
-
-RPolarsExpr$list_get <- function(index) .Call(wrap__RPolarsExpr__list_get, self, index)
-
-RPolarsExpr$list_join <- function(separator) .Call(wrap__RPolarsExpr__list_join, self, separator)
-
-RPolarsExpr$list_arg_min <- function() .Call(wrap__RPolarsExpr__list_arg_min, self)
-
-RPolarsExpr$list_arg_max <- function() .Call(wrap__RPolarsExpr__list_arg_max, self)
-
-RPolarsExpr$list_diff <- function(n, null_behavior) .Call(wrap__RPolarsExpr__list_diff, self, n, null_behavior)
-
-RPolarsExpr$list_shift <- function(periods) .Call(wrap__RPolarsExpr__list_shift, self, periods)
-
-RPolarsExpr$list_slice <- function(offset, length) .Call(wrap__RPolarsExpr__list_slice, self, offset, length)
-
-RPolarsExpr$list_eval <- function(expr, parallel) .Call(wrap__RPolarsExpr__list_eval, self, expr, parallel)
-
-RPolarsExpr$list_to_struct <- function(n_field_strategy, name_gen, upper_bound) .Call(wrap__RPolarsExpr__list_to_struct, self, n_field_strategy, name_gen, upper_bound)
-
-RPolarsExpr$str_to_date <- function(format, strict, exact, cache) .Call(wrap__RPolarsExpr__str_to_date, self, format, strict, exact, cache)
-
-RPolarsExpr$str_to_datetime <- function(format, time_unit, time_zone, strict, exact, cache, ambiguous) .Call(wrap__RPolarsExpr__str_to_datetime, self, format, time_unit, time_zone, strict, exact, cache, ambiguous)
-
-RPolarsExpr$str_to_time <- function(format, strict, cache) .Call(wrap__RPolarsExpr__str_to_time, self, format, strict, cache)
-
-RPolarsExpr$dt_truncate <- function(every, offset) .Call(wrap__RPolarsExpr__dt_truncate, self, every, offset)
-
-RPolarsExpr$dt_round <- function(every, offset) .Call(wrap__RPolarsExpr__dt_round, self, every, offset)
-
-RPolarsExpr$dt_time <- function() .Call(wrap__RPolarsExpr__dt_time, self)
-
-RPolarsExpr$dt_combine <- function(time, tu) .Call(wrap__RPolarsExpr__dt_combine, self, time, tu)
-
-RPolarsExpr$dt_strftime <- function(fmt) .Call(wrap__RPolarsExpr__dt_strftime, self, fmt)
-
-RPolarsExpr$dt_year <- function() .Call(wrap__RPolarsExpr__dt_year, self)
-
-RPolarsExpr$dt_iso_year <- function() .Call(wrap__RPolarsExpr__dt_iso_year, self)
-
-RPolarsExpr$dt_quarter <- function() .Call(wrap__RPolarsExpr__dt_quarter, self)
-
-RPolarsExpr$dt_month <- function() .Call(wrap__RPolarsExpr__dt_month, self)
-
-RPolarsExpr$dt_week <- function() .Call(wrap__RPolarsExpr__dt_week, self)
-
-RPolarsExpr$dt_weekday <- function() .Call(wrap__RPolarsExpr__dt_weekday, self)
-
-RPolarsExpr$dt_day <- function() .Call(wrap__RPolarsExpr__dt_day, self)
-
-RPolarsExpr$dt_ordinal_day <- function() .Call(wrap__RPolarsExpr__dt_ordinal_day, self)
-
-RPolarsExpr$dt_hour <- function() .Call(wrap__RPolarsExpr__dt_hour, self)
-
-RPolarsExpr$dt_minute <- function() .Call(wrap__RPolarsExpr__dt_minute, self)
-
-RPolarsExpr$dt_second <- function() .Call(wrap__RPolarsExpr__dt_second, self)
-
-RPolarsExpr$dt_millisecond <- function() .Call(wrap__RPolarsExpr__dt_millisecond, self)
-
-RPolarsExpr$dt_microsecond <- function() .Call(wrap__RPolarsExpr__dt_microsecond, self)
-
-RPolarsExpr$dt_nanosecond <- function() .Call(wrap__RPolarsExpr__dt_nanosecond, self)
-
-RPolarsExpr$timestamp <- function(tu) .Call(wrap__RPolarsExpr__timestamp, self, tu)
-
-RPolarsExpr$dt_epoch_seconds <- function() .Call(wrap__RPolarsExpr__dt_epoch_seconds, self)
-
-RPolarsExpr$dt_with_time_unit <- function(tu) .Call(wrap__RPolarsExpr__dt_with_time_unit, self, tu)
-
-RPolarsExpr$dt_cast_time_unit <- function(tu) .Call(wrap__RPolarsExpr__dt_cast_time_unit, self, tu)
-
-RPolarsExpr$dt_convert_time_zone <- function(tz) .Call(wrap__RPolarsExpr__dt_convert_time_zone, self, tz)
-
-RPolarsExpr$dt_replace_time_zone <- function(tz, ambiguous) .Call(wrap__RPolarsExpr__dt_replace_time_zone, self, tz, ambiguous)
-
-RPolarsExpr$dt_total_days <- function() .Call(wrap__RPolarsExpr__dt_total_days, self)
-
-RPolarsExpr$dt_total_hours <- function() .Call(wrap__RPolarsExpr__dt_total_hours, self)
-
-RPolarsExpr$dt_total_minutes <- function() .Call(wrap__RPolarsExpr__dt_total_minutes, self)
-
-RPolarsExpr$dt_total_seconds <- function() .Call(wrap__RPolarsExpr__dt_total_seconds, self)
-
-RPolarsExpr$dt_total_milliseconds <- function() .Call(wrap__RPolarsExpr__dt_total_milliseconds, self)
-
-RPolarsExpr$dt_total_microseconds <- function() .Call(wrap__RPolarsExpr__dt_total_microseconds, self)
-
-RPolarsExpr$dt_total_nanoseconds <- function() .Call(wrap__RPolarsExpr__dt_total_nanoseconds, self)
-
-RPolarsExpr$dt_offset_by <- function(by) .Call(wrap__RPolarsExpr__dt_offset_by, self, by)
-
-RPolarsExpr$repeat_by <- function(by) .Call(wrap__RPolarsExpr__repeat_by, self, by)
-
-RPolarsExpr$log10 <- function() .Call(wrap__RPolarsExpr__log10, self)
-
-RPolarsExpr$log <- function(base) .Call(wrap__RPolarsExpr__log, self, base)
-
-RPolarsExpr$exp <- function() .Call(wrap__RPolarsExpr__exp, self)
-
-RPolarsExpr$exclude <- function(columns) .Call(wrap__RPolarsExpr__exclude, self, columns)
-
-RPolarsExpr$exclude_dtype <- function(columns) .Call(wrap__RPolarsExpr__exclude_dtype, self, columns)
-
-RPolarsExpr$alias <- function(s) .Call(wrap__RPolarsExpr__alias, self, s)
-
-RPolarsExpr$drop_nulls <- function() .Call(wrap__RPolarsExpr__drop_nulls, self)
-
-RPolarsExpr$drop_nans <- function() .Call(wrap__RPolarsExpr__drop_nans, self)
-
-RPolarsExpr$cum_sum <- function(reverse) .Call(wrap__RPolarsExpr__cum_sum, self, reverse)
-
-RPolarsExpr$cum_prod <- function(reverse) .Call(wrap__RPolarsExpr__cum_prod, self, reverse)
-
-RPolarsExpr$cum_min <- function(reverse) .Call(wrap__RPolarsExpr__cum_min, self, reverse)
-
-RPolarsExpr$cum_max <- function(reverse) .Call(wrap__RPolarsExpr__cum_max, self, reverse)
-
-RPolarsExpr$cum_count <- function(reverse) .Call(wrap__RPolarsExpr__cum_count, self, reverse)
-
-RPolarsExpr$floor <- function() .Call(wrap__RPolarsExpr__floor, self)
-
-RPolarsExpr$ceil <- function() .Call(wrap__RPolarsExpr__ceil, self)
-
-RPolarsExpr$round <- function(decimals) .Call(wrap__RPolarsExpr__round, self, decimals)
-
-RPolarsExpr$dot <- function(other) .Call(wrap__RPolarsExpr__dot, self, other)
-
-RPolarsExpr$mode <- function() .Call(wrap__RPolarsExpr__mode, self)
-
-RPolarsExpr$first <- function() .Call(wrap__RPolarsExpr__first, self)
-
-RPolarsExpr$last <- function() .Call(wrap__RPolarsExpr__last, self)
-
-RPolarsExpr$head <- function(n) .Call(wrap__RPolarsExpr__head, self, n)
-
-RPolarsExpr$tail <- function(n) .Call(wrap__RPolarsExpr__tail, self, n)
-
-RPolarsExpr$unique <- function() .Call(wrap__RPolarsExpr__unique, self)
-
-RPolarsExpr$unique_stable <- function() .Call(wrap__RPolarsExpr__unique_stable, self)
-
-RPolarsExpr$agg_groups <- function() .Call(wrap__RPolarsExpr__agg_groups, self)
-
-RPolarsExpr$all <- function(drop_nulls) .Call(wrap__RPolarsExpr__all, self, drop_nulls)
-
-RPolarsExpr$any <- function(drop_nulls) .Call(wrap__RPolarsExpr__any, self, drop_nulls)
-
-RPolarsExpr$is_duplicated <- function() .Call(wrap__RPolarsExpr__is_duplicated, self)
-
-RPolarsExpr$is_finite <- function() .Call(wrap__RPolarsExpr__is_finite, self)
-
-RPolarsExpr$is_first_distinct <- function() .Call(wrap__RPolarsExpr__is_first_distinct, self)
-
-RPolarsExpr$is_in <- function(other) .Call(wrap__RPolarsExpr__is_in, self, other)
-
-RPolarsExpr$is_infinite <- function() .Call(wrap__RPolarsExpr__is_infinite, self)
-
-RPolarsExpr$is_last_distinct <- function() .Call(wrap__RPolarsExpr__is_last_distinct, self)
-
-RPolarsExpr$is_nan <- function() .Call(wrap__RPolarsExpr__is_nan, self)
-
-RPolarsExpr$is_not_null <- function() .Call(wrap__RPolarsExpr__is_not_null, self)
-
-RPolarsExpr$is_not_nan <- function() .Call(wrap__RPolarsExpr__is_not_nan, self)
-
-RPolarsExpr$is_null <- function() .Call(wrap__RPolarsExpr__is_null, self)
-
-RPolarsExpr$is_unique <- function() .Call(wrap__RPolarsExpr__is_unique, self)
-
-RPolarsExpr$not <- function() .Call(wrap__RPolarsExpr__not, self)
-
-RPolarsExpr$count <- function() .Call(wrap__RPolarsExpr__count, self)
-
-RPolarsExpr$len <- function() .Call(wrap__RPolarsExpr__len, self)
-
-RPolarsExpr$slice <- function(offset, length) .Call(wrap__RPolarsExpr__slice, self, offset, length)
-
-RPolarsExpr$append <- function(other, upcast) .Call(wrap__RPolarsExpr__append, self, other, upcast)
-
-RPolarsExpr$rechunk <- function() .Call(wrap__RPolarsExpr__rechunk, self)
-
-RPolarsExpr$add <- function(other) .Call(wrap__RPolarsExpr__add, self, other)
-
-RPolarsExpr$floor_div <- function(other) .Call(wrap__RPolarsExpr__floor_div, self, other)
-
-RPolarsExpr$rem <- function(other) .Call(wrap__RPolarsExpr__rem, self, other)
-
-RPolarsExpr$mul <- function(other) .Call(wrap__RPolarsExpr__mul, self, other)
-
-RPolarsExpr$sub <- function(other) .Call(wrap__RPolarsExpr__sub, self, other)
-
-RPolarsExpr$div <- function(other) .Call(wrap__RPolarsExpr__div, self, other)
-
-RPolarsExpr$pow <- function(exponent) .Call(wrap__RPolarsExpr__pow, self, exponent)
-
-RPolarsExpr$over <- function(proto_exprs) .Call(wrap__RPolarsExpr__over, self, proto_exprs)
-
-RPolarsExpr$print <- function() invisible(.Call(wrap__RPolarsExpr__print, self))
-
-RPolarsExpr$map_batches <- function(lambda, output_type, agg_list) .Call(wrap__RPolarsExpr__map_batches, self, lambda, output_type, agg_list)
-
-RPolarsExpr$map_batches_in_background <- function(lambda, output_type, agg_list) .Call(wrap__RPolarsExpr__map_batches_in_background, self, lambda, output_type, agg_list)
-
-RPolarsExpr$map_elements_in_background <- function(lambda, output_type) .Call(wrap__RPolarsExpr__map_elements_in_background, self, lambda, output_type)
-
-RPolarsExpr$approx_n_unique <- function() .Call(wrap__RPolarsExpr__approx_n_unique, self)
-
-RPolarsExpr$name_keep <- function() .Call(wrap__RPolarsExpr__name_keep, self)
-
-RPolarsExpr$name_suffix <- function(suffix) .Call(wrap__RPolarsExpr__name_suffix, self, suffix)
-
-RPolarsExpr$name_prefix <- function(prefix) .Call(wrap__RPolarsExpr__name_prefix, self, prefix)
-
-RPolarsExpr$name_to_lowercase <- function() .Call(wrap__RPolarsExpr__name_to_lowercase, self)
-
-RPolarsExpr$name_to_uppercase <- function() .Call(wrap__RPolarsExpr__name_to_uppercase, self)
-
-RPolarsExpr$name_map <- function(lambda) .Call(wrap__RPolarsExpr__name_map, self, lambda)
-
-RPolarsExpr$str_len_bytes <- function() .Call(wrap__RPolarsExpr__str_len_bytes, self)
-
-RPolarsExpr$str_len_chars <- function() .Call(wrap__RPolarsExpr__str_len_chars, self)
-
-RPolarsExpr$str_concat <- function(delimiter, ignore_nulls) .Call(wrap__RPolarsExpr__str_concat, self, delimiter, ignore_nulls)
-
-RPolarsExpr$str_to_uppercase <- function() .Call(wrap__RPolarsExpr__str_to_uppercase, self)
-
-RPolarsExpr$str_to_lowercase <- function() .Call(wrap__RPolarsExpr__str_to_lowercase, self)
-
-RPolarsExpr$str_to_titlecase <- function() .Call(wrap__RPolarsExpr__str_to_titlecase, self)
-
-RPolarsExpr$str_strip_chars <- function(matches) .Call(wrap__RPolarsExpr__str_strip_chars, self, matches)
-
-RPolarsExpr$str_strip_chars_end <- function(matches) .Call(wrap__RPolarsExpr__str_strip_chars_end, self, matches)
-
-RPolarsExpr$str_strip_chars_start <- function(matches) .Call(wrap__RPolarsExpr__str_strip_chars_start, self, matches)
-
-RPolarsExpr$str_zfill <- function(alignment) .Call(wrap__RPolarsExpr__str_zfill, self, alignment)
-
-RPolarsExpr$str_pad_end <- function(width, fillchar) .Call(wrap__RPolarsExpr__str_pad_end, self, width, fillchar)
-
-RPolarsExpr$str_pad_start <- function(width, fillchar) .Call(wrap__RPolarsExpr__str_pad_start, self, width, fillchar)
-
-RPolarsExpr$str_contains <- function(pat, literal, strict) .Call(wrap__RPolarsExpr__str_contains, self, pat, literal, strict)
-
-RPolarsExpr$str_ends_with <- function(sub) .Call(wrap__RPolarsExpr__str_ends_with, self, sub)
-
-RPolarsExpr$str_starts_with <- function(sub) .Call(wrap__RPolarsExpr__str_starts_with, self, sub)
-
-RPolarsExpr$str_json_path_match <- function(pat) .Call(wrap__RPolarsExpr__str_json_path_match, self, pat)
-
-RPolarsExpr$str_json_extract <- function(dtype, infer_schema_len) .Call(wrap__RPolarsExpr__str_json_extract, self, dtype, infer_schema_len)
-
-RPolarsExpr$str_hex_encode <- function() .Call(wrap__RPolarsExpr__str_hex_encode, self)
-
-RPolarsExpr$str_hex_decode <- function(strict) .Call(wrap__RPolarsExpr__str_hex_decode, self, strict)
-
-RPolarsExpr$str_base64_encode <- function() .Call(wrap__RPolarsExpr__str_base64_encode, self)
-
-RPolarsExpr$str_base64_decode <- function(strict) .Call(wrap__RPolarsExpr__str_base64_decode, self, strict)
-
-RPolarsExpr$str_extract <- function(pattern, group_index) .Call(wrap__RPolarsExpr__str_extract, self, pattern, group_index)
-
-RPolarsExpr$str_extract_all <- function(pattern) .Call(wrap__RPolarsExpr__str_extract_all, self, pattern)
-
-RPolarsExpr$str_count_matches <- function(pattern, literal) .Call(wrap__RPolarsExpr__str_count_matches, self, pattern, literal)
-
-RPolarsExpr$str_split <- function(by, inclusive) .Call(wrap__RPolarsExpr__str_split, self, by, inclusive)
-
-RPolarsExpr$str_split_exact <- function(by, n, inclusive) .Call(wrap__RPolarsExpr__str_split_exact, self, by, n, inclusive)
-
-RPolarsExpr$str_splitn <- function(by, n) .Call(wrap__RPolarsExpr__str_splitn, self, by, n)
-
-RPolarsExpr$str_replace <- function(pattern, value, literal) .Call(wrap__RPolarsExpr__str_replace, self, pattern, value, literal)
-
-RPolarsExpr$str_replace_all <- function(pattern, value, literal) .Call(wrap__RPolarsExpr__str_replace_all, self, pattern, value, literal)
-
-RPolarsExpr$str_slice <- function(offset, length) .Call(wrap__RPolarsExpr__str_slice, self, offset, length)
-
-RPolarsExpr$str_explode <- function() .Call(wrap__RPolarsExpr__str_explode, self)
-
-RPolarsExpr$str_parse_int <- function(radix, strict) .Call(wrap__RPolarsExpr__str_parse_int, self, radix, strict)
-
-RPolarsExpr$bin_contains <- function(lit) .Call(wrap__RPolarsExpr__bin_contains, self, lit)
-
-RPolarsExpr$bin_starts_with <- function(sub) .Call(wrap__RPolarsExpr__bin_starts_with, self, sub)
-
-RPolarsExpr$bin_ends_with <- function(sub) .Call(wrap__RPolarsExpr__bin_ends_with, self, sub)
-
-RPolarsExpr$bin_encode_hex <- function() .Call(wrap__RPolarsExpr__bin_encode_hex, self)
-
-RPolarsExpr$bin_encode_base64 <- function() .Call(wrap__RPolarsExpr__bin_encode_base64, self)
-
-RPolarsExpr$bin_decode_hex <- function(strict) .Call(wrap__RPolarsExpr__bin_decode_hex, self, strict)
-
-RPolarsExpr$bin_decode_base64 <- function(strict) .Call(wrap__RPolarsExpr__bin_decode_base64, self, strict)
-
-RPolarsExpr$struct_field_by_name <- function(name) .Call(wrap__RPolarsExpr__struct_field_by_name, self, name)
-
-RPolarsExpr$struct_rename_fields <- function(names) .Call(wrap__RPolarsExpr__struct_rename_fields, self, names)
-
-RPolarsExpr$meta_pop <- function() .Call(wrap__RPolarsExpr__meta_pop, self)
-
-RPolarsExpr$meta_eq <- function(other) .Call(wrap__RPolarsExpr__meta_eq, self, other)
-
-RPolarsExpr$meta_roots <- function() .Call(wrap__RPolarsExpr__meta_roots, self)
-
-RPolarsExpr$meta_output_name <- function() .Call(wrap__RPolarsExpr__meta_output_name, self)
-
-RPolarsExpr$meta_undo_aliases <- function() .Call(wrap__RPolarsExpr__meta_undo_aliases, self)
-
-RPolarsExpr$meta_has_multiple_outputs <- function() .Call(wrap__RPolarsExpr__meta_has_multiple_outputs, self)
-
-RPolarsExpr$meta_is_regex_projection <- function() .Call(wrap__RPolarsExpr__meta_is_regex_projection, self)
-
-RPolarsExpr$meta_tree_format <- function() .Call(wrap__RPolarsExpr__meta_tree_format, self)
-
-RPolarsExpr$cat_set_ordering <- function(ordering) .Call(wrap__RPolarsExpr__cat_set_ordering, self, ordering)
-
-RPolarsExpr$cat_get_categories <- function() .Call(wrap__RPolarsExpr__cat_get_categories, self)
-
-RPolarsExpr$new_count <- function() .Call(wrap__RPolarsExpr__new_count)
-
-RPolarsExpr$new_first <- function() .Call(wrap__RPolarsExpr__new_first)
-
-RPolarsExpr$new_last <- function() .Call(wrap__RPolarsExpr__new_last)
-
-RPolarsExpr$cov <- function(a, b, ddof) .Call(wrap__RPolarsExpr__cov, a, b, ddof)
-
-RPolarsExpr$rolling_cov <- function(a, b, window_size, min_periods, ddof) .Call(wrap__RPolarsExpr__rolling_cov, a, b, window_size, min_periods, ddof)
-
-RPolarsExpr$corr <- function(a, b, method, ddof, propagate_nans) .Call(wrap__RPolarsExpr__corr, a, b, method, ddof, propagate_nans)
-
-RPolarsExpr$rolling_corr <- function(a, b, window_size, min_periods, ddof) .Call(wrap__RPolarsExpr__rolling_corr, a, b, window_size, min_periods, ddof)
-
-RPolarsExpr$rolling <- function(index_column, period, offset, closed, check_sorted) .Call(wrap__RPolarsExpr__rolling, self, index_column, period, offset, closed, check_sorted)
+RPolarsChainedThen$otherwise = function(statement) .Call(wrap__RPolarsChainedThen__otherwise, self, statement)
 
 #' @export
-`$.RPolarsExpr` <- function (self, name) { func <- RPolarsExpr[[name]]; environment(func) <- environment(); func }
+`$.RPolarsChainedThen` = function(self, name) {
+  func = RPolarsChainedThen[[name]]
+  environment(func) = environment()
+  func
+}
 
 #' @export
-`[[.RPolarsExpr` <- `$.RPolarsExpr`
+`[[.RPolarsChainedThen` = `$.RPolarsChainedThen`
 
-RPolarsProtoExprArray <- new.env(parent = emptyenv())
+RPolarsExpr = new.env(parent = emptyenv())
 
-RPolarsProtoExprArray$new <- function() .Call(wrap__RPolarsProtoExprArray__new)
+RPolarsExpr$col = function(name) .Call(wrap__RPolarsExpr__col, name)
 
-RPolarsProtoExprArray$push_back_str <- function(s) invisible(.Call(wrap__RPolarsProtoExprArray__push_back_str, self, s))
+RPolarsExpr$dtype_cols = function(dtypes) .Call(wrap__RPolarsExpr__dtype_cols, dtypes)
 
-RPolarsProtoExprArray$push_back_rexpr <- function(r) invisible(.Call(wrap__RPolarsProtoExprArray__push_back_rexpr, self, r))
+RPolarsExpr$cols = function(names) .Call(wrap__RPolarsExpr__cols, names)
 
-RPolarsProtoExprArray$print <- function() invisible(.Call(wrap__RPolarsProtoExprArray__print, self))
+RPolarsExpr$lit = function(robj) .Call(wrap__RPolarsExpr__lit, robj)
+
+RPolarsExpr$gt = function(other) .Call(wrap__RPolarsExpr__gt, self, other)
+
+RPolarsExpr$gt_eq = function(other) .Call(wrap__RPolarsExpr__gt_eq, self, other)
+
+RPolarsExpr$lt = function(other) .Call(wrap__RPolarsExpr__lt, self, other)
+
+RPolarsExpr$lt_eq = function(other) .Call(wrap__RPolarsExpr__lt_eq, self, other)
+
+RPolarsExpr$neq = function(other) .Call(wrap__RPolarsExpr__neq, self, other)
+
+RPolarsExpr$neq_missing = function(other) .Call(wrap__RPolarsExpr__neq_missing, self, other)
+
+RPolarsExpr$eq = function(other) .Call(wrap__RPolarsExpr__eq, self, other)
+
+RPolarsExpr$eq_missing = function(other) .Call(wrap__RPolarsExpr__eq_missing, self, other)
+
+RPolarsExpr$and = function(other) .Call(wrap__RPolarsExpr__and, self, other)
+
+RPolarsExpr$or = function(other) .Call(wrap__RPolarsExpr__or, self, other)
+
+RPolarsExpr$xor = function(other) .Call(wrap__RPolarsExpr__xor, self, other)
+
+RPolarsExpr$to_physical = function() .Call(wrap__RPolarsExpr__to_physical, self)
+
+RPolarsExpr$cast = function(data_type, strict) .Call(wrap__RPolarsExpr__cast, self, data_type, strict)
+
+RPolarsExpr$sort = function(descending, nulls_last) .Call(wrap__RPolarsExpr__sort, self, descending, nulls_last)
+
+RPolarsExpr$arg_sort = function(descending, nulls_last) .Call(wrap__RPolarsExpr__arg_sort, self, descending, nulls_last)
+
+RPolarsExpr$top_k = function(k) .Call(wrap__RPolarsExpr__top_k, self, k)
+
+RPolarsExpr$bottom_k = function(k) .Call(wrap__RPolarsExpr__bottom_k, self, k)
+
+RPolarsExpr$arg_max = function() .Call(wrap__RPolarsExpr__arg_max, self)
+
+RPolarsExpr$arg_min = function() .Call(wrap__RPolarsExpr__arg_min, self)
+
+RPolarsExpr$search_sorted = function(element) .Call(wrap__RPolarsExpr__search_sorted, self, element)
+
+RPolarsExpr$gather = function(idx) .Call(wrap__RPolarsExpr__gather, self, idx)
+
+RPolarsExpr$sort_by = function(by, descending) .Call(wrap__RPolarsExpr__sort_by, self, by, descending)
+
+RPolarsExpr$backward_fill = function(limit) .Call(wrap__RPolarsExpr__backward_fill, self, limit)
+
+RPolarsExpr$forward_fill = function(limit) .Call(wrap__RPolarsExpr__forward_fill, self, limit)
+
+RPolarsExpr$shift = function(periods) .Call(wrap__RPolarsExpr__shift, self, periods)
+
+RPolarsExpr$shift_and_fill = function(periods, fill_value) .Call(wrap__RPolarsExpr__shift_and_fill, self, periods, fill_value)
+
+RPolarsExpr$fill_null = function(expr) .Call(wrap__RPolarsExpr__fill_null, self, expr)
+
+RPolarsExpr$fill_null_with_strategy = function(strategy, limit) .Call(wrap__RPolarsExpr__fill_null_with_strategy, self, strategy, limit)
+
+RPolarsExpr$fill_nan = function(expr) .Call(wrap__RPolarsExpr__fill_nan, self, expr)
+
+RPolarsExpr$reverse = function() .Call(wrap__RPolarsExpr__reverse, self)
+
+RPolarsExpr$std = function(ddof) .Call(wrap__RPolarsExpr__std, self, ddof)
+
+RPolarsExpr$var = function(ddof) .Call(wrap__RPolarsExpr__var, self, ddof)
+
+RPolarsExpr$max = function() .Call(wrap__RPolarsExpr__max, self)
+
+RPolarsExpr$min = function() .Call(wrap__RPolarsExpr__min, self)
+
+RPolarsExpr$nan_min = function() .Call(wrap__RPolarsExpr__nan_min, self)
+
+RPolarsExpr$nan_max = function() .Call(wrap__RPolarsExpr__nan_max, self)
+
+RPolarsExpr$mean = function() .Call(wrap__RPolarsExpr__mean, self)
+
+RPolarsExpr$median = function() .Call(wrap__RPolarsExpr__median, self)
+
+RPolarsExpr$sum = function() .Call(wrap__RPolarsExpr__sum, self)
+
+RPolarsExpr$product = function() .Call(wrap__RPolarsExpr__product, self)
+
+RPolarsExpr$n_unique = function() .Call(wrap__RPolarsExpr__n_unique, self)
+
+RPolarsExpr$null_count = function() .Call(wrap__RPolarsExpr__null_count, self)
+
+RPolarsExpr$arg_unique = function() .Call(wrap__RPolarsExpr__arg_unique, self)
+
+RPolarsExpr$quantile = function(quantile, interpolation) .Call(wrap__RPolarsExpr__quantile, self, quantile, interpolation)
+
+RPolarsExpr$filter = function(predicate) .Call(wrap__RPolarsExpr__filter, self, predicate)
+
+RPolarsExpr$explode = function() .Call(wrap__RPolarsExpr__explode, self)
+
+RPolarsExpr$flatten = function() .Call(wrap__RPolarsExpr__flatten, self)
+
+RPolarsExpr$gather_every = function(n) .Call(wrap__RPolarsExpr__gather_every, self, n)
+
+RPolarsExpr$hash = function(seed, seed_1, seed_2, seed_3) .Call(wrap__RPolarsExpr__hash, self, seed, seed_1, seed_2, seed_3)
+
+RPolarsExpr$reinterpret = function(signed) .Call(wrap__RPolarsExpr__reinterpret, self, signed)
+
+RPolarsExpr$interpolate = function(method) .Call(wrap__RPolarsExpr__interpolate, self, method)
+
+RPolarsExpr$rolling_min = function(window_size, weights, min_periods, center, by_null, closed_null) .Call(wrap__RPolarsExpr__rolling_min, self, window_size, weights, min_periods, center, by_null, closed_null)
+
+RPolarsExpr$rolling_max = function(window_size, weights, min_periods, center, by_null, closed_null) .Call(wrap__RPolarsExpr__rolling_max, self, window_size, weights, min_periods, center, by_null, closed_null)
+
+RPolarsExpr$rolling_mean = function(window_size, weights, min_periods, center, by_null, closed_null) .Call(wrap__RPolarsExpr__rolling_mean, self, window_size, weights, min_periods, center, by_null, closed_null)
+
+RPolarsExpr$rolling_sum = function(window_size, weights, min_periods, center, by_null, closed_null) .Call(wrap__RPolarsExpr__rolling_sum, self, window_size, weights, min_periods, center, by_null, closed_null)
+
+RPolarsExpr$rolling_std = function(window_size, weights, min_periods, center, by_null, closed_null) .Call(wrap__RPolarsExpr__rolling_std, self, window_size, weights, min_periods, center, by_null, closed_null)
+
+RPolarsExpr$rolling_var = function(window_size, weights, min_periods, center, by_null, closed_null) .Call(wrap__RPolarsExpr__rolling_var, self, window_size, weights, min_periods, center, by_null, closed_null)
+
+RPolarsExpr$rolling_median = function(window_size, weights, min_periods, center, by_null, closed_null) .Call(wrap__RPolarsExpr__rolling_median, self, window_size, weights, min_periods, center, by_null, closed_null)
+
+RPolarsExpr$rolling_quantile = function(quantile, interpolation, window_size, weights, min_periods, center, by, closed) .Call(wrap__RPolarsExpr__rolling_quantile, self, quantile, interpolation, window_size, weights, min_periods, center, by, closed)
+
+RPolarsExpr$rolling_skew = function(window_size_f, bias) .Call(wrap__RPolarsExpr__rolling_skew, self, window_size_f, bias)
+
+RPolarsExpr$abs = function() .Call(wrap__RPolarsExpr__abs, self)
+
+RPolarsExpr$rank = function(method, descending) .Call(wrap__RPolarsExpr__rank, self, method, descending)
+
+RPolarsExpr$diff = function(n_float, null_behavior) .Call(wrap__RPolarsExpr__diff, self, n_float, null_behavior)
+
+RPolarsExpr$pct_change = function(n_float) .Call(wrap__RPolarsExpr__pct_change, self, n_float)
+
+RPolarsExpr$skew = function(bias) .Call(wrap__RPolarsExpr__skew, self, bias)
+
+RPolarsExpr$kurtosis = function(fisher, bias) .Call(wrap__RPolarsExpr__kurtosis, self, fisher, bias)
+
+RPolarsExpr$clip = function(min, max) .Call(wrap__RPolarsExpr__clip, self, min, max)
+
+RPolarsExpr$clip_min = function(min) .Call(wrap__RPolarsExpr__clip_min, self, min)
+
+RPolarsExpr$clip_max = function(max) .Call(wrap__RPolarsExpr__clip_max, self, max)
+
+RPolarsExpr$lower_bound = function() .Call(wrap__RPolarsExpr__lower_bound, self)
+
+RPolarsExpr$upper_bound = function() .Call(wrap__RPolarsExpr__upper_bound, self)
+
+RPolarsExpr$sign = function() .Call(wrap__RPolarsExpr__sign, self)
+
+RPolarsExpr$sin = function() .Call(wrap__RPolarsExpr__sin, self)
+
+RPolarsExpr$cos = function() .Call(wrap__RPolarsExpr__cos, self)
+
+RPolarsExpr$tan = function() .Call(wrap__RPolarsExpr__tan, self)
+
+RPolarsExpr$arcsin = function() .Call(wrap__RPolarsExpr__arcsin, self)
+
+RPolarsExpr$arccos = function() .Call(wrap__RPolarsExpr__arccos, self)
+
+RPolarsExpr$arctan = function() .Call(wrap__RPolarsExpr__arctan, self)
+
+RPolarsExpr$sinh = function() .Call(wrap__RPolarsExpr__sinh, self)
+
+RPolarsExpr$cosh = function() .Call(wrap__RPolarsExpr__cosh, self)
+
+RPolarsExpr$tanh = function() .Call(wrap__RPolarsExpr__tanh, self)
+
+RPolarsExpr$arcsinh = function() .Call(wrap__RPolarsExpr__arcsinh, self)
+
+RPolarsExpr$arccosh = function() .Call(wrap__RPolarsExpr__arccosh, self)
+
+RPolarsExpr$arctanh = function() .Call(wrap__RPolarsExpr__arctanh, self)
+
+RPolarsExpr$reshape = function(dims) .Call(wrap__RPolarsExpr__reshape, self, dims)
+
+RPolarsExpr$shuffle = function(seed) .Call(wrap__RPolarsExpr__shuffle, self, seed)
+
+RPolarsExpr$sample_n = function(n, with_replacement, shuffle, seed) .Call(wrap__RPolarsExpr__sample_n, self, n, with_replacement, shuffle, seed)
+
+RPolarsExpr$sample_frac = function(frac, with_replacement, shuffle, seed) .Call(wrap__RPolarsExpr__sample_frac, self, frac, with_replacement, shuffle, seed)
+
+RPolarsExpr$ewm_mean = function(alpha, adjust, min_periods, ignore_nulls) .Call(wrap__RPolarsExpr__ewm_mean, self, alpha, adjust, min_periods, ignore_nulls)
+
+RPolarsExpr$ewm_std = function(alpha, adjust, bias, min_periods, ignore_nulls) .Call(wrap__RPolarsExpr__ewm_std, self, alpha, adjust, bias, min_periods, ignore_nulls)
+
+RPolarsExpr$ewm_var = function(alpha, adjust, bias, min_periods, ignore_nulls) .Call(wrap__RPolarsExpr__ewm_var, self, alpha, adjust, bias, min_periods, ignore_nulls)
+
+RPolarsExpr$extend_constant = function(value, n) .Call(wrap__RPolarsExpr__extend_constant, self, value, n)
+
+RPolarsExpr$rep = function(n, rechunk) .Call(wrap__RPolarsExpr__rep, self, n, rechunk)
+
+RPolarsExpr$value_counts = function(sort, parallel) .Call(wrap__RPolarsExpr__value_counts, self, sort, parallel)
+
+RPolarsExpr$unique_counts = function() .Call(wrap__RPolarsExpr__unique_counts, self)
+
+RPolarsExpr$entropy = function(base, normalize) .Call(wrap__RPolarsExpr__entropy, self, base, normalize)
+
+RPolarsExpr$cumulative_eval = function(expr, min_periods, parallel) .Call(wrap__RPolarsExpr__cumulative_eval, self, expr, min_periods, parallel)
+
+RPolarsExpr$implode = function() .Call(wrap__RPolarsExpr__implode, self)
+
+RPolarsExpr$shrink_dtype = function() .Call(wrap__RPolarsExpr__shrink_dtype, self)
+
+RPolarsExpr$peak_min = function() .Call(wrap__RPolarsExpr__peak_min, self)
+
+RPolarsExpr$peak_max = function() .Call(wrap__RPolarsExpr__peak_max, self)
+
+RPolarsExpr$list_lengths = function() .Call(wrap__RPolarsExpr__list_lengths, self)
+
+RPolarsExpr$list_contains = function(other) .Call(wrap__RPolarsExpr__list_contains, self, other)
+
+RPolarsExpr$list_max = function() .Call(wrap__RPolarsExpr__list_max, self)
+
+RPolarsExpr$list_min = function() .Call(wrap__RPolarsExpr__list_min, self)
+
+RPolarsExpr$list_sum = function() .Call(wrap__RPolarsExpr__list_sum, self)
+
+RPolarsExpr$list_mean = function() .Call(wrap__RPolarsExpr__list_mean, self)
+
+RPolarsExpr$list_sort = function(descending) .Call(wrap__RPolarsExpr__list_sort, self, descending)
+
+RPolarsExpr$list_reverse = function() .Call(wrap__RPolarsExpr__list_reverse, self)
+
+RPolarsExpr$list_unique = function() .Call(wrap__RPolarsExpr__list_unique, self)
+
+RPolarsExpr$list_gather = function(index, null_on_oob) .Call(wrap__RPolarsExpr__list_gather, self, index, null_on_oob)
+
+RPolarsExpr$list_get = function(index) .Call(wrap__RPolarsExpr__list_get, self, index)
+
+RPolarsExpr$list_join = function(separator) .Call(wrap__RPolarsExpr__list_join, self, separator)
+
+RPolarsExpr$list_arg_min = function() .Call(wrap__RPolarsExpr__list_arg_min, self)
+
+RPolarsExpr$list_arg_max = function() .Call(wrap__RPolarsExpr__list_arg_max, self)
+
+RPolarsExpr$list_diff = function(n, null_behavior) .Call(wrap__RPolarsExpr__list_diff, self, n, null_behavior)
+
+RPolarsExpr$list_shift = function(periods) .Call(wrap__RPolarsExpr__list_shift, self, periods)
+
+RPolarsExpr$list_slice = function(offset, length) .Call(wrap__RPolarsExpr__list_slice, self, offset, length)
+
+RPolarsExpr$list_eval = function(expr, parallel) .Call(wrap__RPolarsExpr__list_eval, self, expr, parallel)
+
+RPolarsExpr$list_to_struct = function(n_field_strategy, name_gen, upper_bound) .Call(wrap__RPolarsExpr__list_to_struct, self, n_field_strategy, name_gen, upper_bound)
+
+RPolarsExpr$str_to_date = function(format, strict, exact, cache) .Call(wrap__RPolarsExpr__str_to_date, self, format, strict, exact, cache)
+
+RPolarsExpr$str_to_datetime = function(format, time_unit, time_zone, strict, exact, cache, ambiguous) .Call(wrap__RPolarsExpr__str_to_datetime, self, format, time_unit, time_zone, strict, exact, cache, ambiguous)
+
+RPolarsExpr$str_to_time = function(format, strict, cache) .Call(wrap__RPolarsExpr__str_to_time, self, format, strict, cache)
+
+RPolarsExpr$dt_truncate = function(every, offset) .Call(wrap__RPolarsExpr__dt_truncate, self, every, offset)
+
+RPolarsExpr$dt_round = function(every, offset) .Call(wrap__RPolarsExpr__dt_round, self, every, offset)
+
+RPolarsExpr$dt_time = function() .Call(wrap__RPolarsExpr__dt_time, self)
+
+RPolarsExpr$dt_combine = function(time, tu) .Call(wrap__RPolarsExpr__dt_combine, self, time, tu)
+
+RPolarsExpr$dt_strftime = function(fmt) .Call(wrap__RPolarsExpr__dt_strftime, self, fmt)
+
+RPolarsExpr$dt_year = function() .Call(wrap__RPolarsExpr__dt_year, self)
+
+RPolarsExpr$dt_iso_year = function() .Call(wrap__RPolarsExpr__dt_iso_year, self)
+
+RPolarsExpr$dt_quarter = function() .Call(wrap__RPolarsExpr__dt_quarter, self)
+
+RPolarsExpr$dt_month = function() .Call(wrap__RPolarsExpr__dt_month, self)
+
+RPolarsExpr$dt_week = function() .Call(wrap__RPolarsExpr__dt_week, self)
+
+RPolarsExpr$dt_weekday = function() .Call(wrap__RPolarsExpr__dt_weekday, self)
+
+RPolarsExpr$dt_day = function() .Call(wrap__RPolarsExpr__dt_day, self)
+
+RPolarsExpr$dt_ordinal_day = function() .Call(wrap__RPolarsExpr__dt_ordinal_day, self)
+
+RPolarsExpr$dt_hour = function() .Call(wrap__RPolarsExpr__dt_hour, self)
+
+RPolarsExpr$dt_minute = function() .Call(wrap__RPolarsExpr__dt_minute, self)
+
+RPolarsExpr$dt_second = function() .Call(wrap__RPolarsExpr__dt_second, self)
+
+RPolarsExpr$dt_millisecond = function() .Call(wrap__RPolarsExpr__dt_millisecond, self)
+
+RPolarsExpr$dt_microsecond = function() .Call(wrap__RPolarsExpr__dt_microsecond, self)
+
+RPolarsExpr$dt_nanosecond = function() .Call(wrap__RPolarsExpr__dt_nanosecond, self)
+
+RPolarsExpr$timestamp = function(tu) .Call(wrap__RPolarsExpr__timestamp, self, tu)
+
+RPolarsExpr$dt_epoch_seconds = function() .Call(wrap__RPolarsExpr__dt_epoch_seconds, self)
+
+RPolarsExpr$dt_with_time_unit = function(tu) .Call(wrap__RPolarsExpr__dt_with_time_unit, self, tu)
+
+RPolarsExpr$dt_cast_time_unit = function(tu) .Call(wrap__RPolarsExpr__dt_cast_time_unit, self, tu)
+
+RPolarsExpr$dt_convert_time_zone = function(tz) .Call(wrap__RPolarsExpr__dt_convert_time_zone, self, tz)
+
+RPolarsExpr$dt_replace_time_zone = function(tz, ambiguous) .Call(wrap__RPolarsExpr__dt_replace_time_zone, self, tz, ambiguous)
+
+RPolarsExpr$dt_total_days = function() .Call(wrap__RPolarsExpr__dt_total_days, self)
+
+RPolarsExpr$dt_total_hours = function() .Call(wrap__RPolarsExpr__dt_total_hours, self)
+
+RPolarsExpr$dt_total_minutes = function() .Call(wrap__RPolarsExpr__dt_total_minutes, self)
+
+RPolarsExpr$dt_total_seconds = function() .Call(wrap__RPolarsExpr__dt_total_seconds, self)
+
+RPolarsExpr$dt_total_milliseconds = function() .Call(wrap__RPolarsExpr__dt_total_milliseconds, self)
+
+RPolarsExpr$dt_total_microseconds = function() .Call(wrap__RPolarsExpr__dt_total_microseconds, self)
+
+RPolarsExpr$dt_total_nanoseconds = function() .Call(wrap__RPolarsExpr__dt_total_nanoseconds, self)
+
+RPolarsExpr$dt_offset_by = function(by) .Call(wrap__RPolarsExpr__dt_offset_by, self, by)
+
+RPolarsExpr$repeat_by = function(by) .Call(wrap__RPolarsExpr__repeat_by, self, by)
+
+RPolarsExpr$log10 = function() .Call(wrap__RPolarsExpr__log10, self)
+
+RPolarsExpr$log = function(base) .Call(wrap__RPolarsExpr__log, self, base)
+
+RPolarsExpr$exp = function() .Call(wrap__RPolarsExpr__exp, self)
+
+RPolarsExpr$exclude = function(columns) .Call(wrap__RPolarsExpr__exclude, self, columns)
+
+RPolarsExpr$exclude_dtype = function(columns) .Call(wrap__RPolarsExpr__exclude_dtype, self, columns)
+
+RPolarsExpr$alias = function(s) .Call(wrap__RPolarsExpr__alias, self, s)
+
+RPolarsExpr$drop_nulls = function() .Call(wrap__RPolarsExpr__drop_nulls, self)
+
+RPolarsExpr$drop_nans = function() .Call(wrap__RPolarsExpr__drop_nans, self)
+
+RPolarsExpr$cum_sum = function(reverse) .Call(wrap__RPolarsExpr__cum_sum, self, reverse)
+
+RPolarsExpr$cum_prod = function(reverse) .Call(wrap__RPolarsExpr__cum_prod, self, reverse)
+
+RPolarsExpr$cum_min = function(reverse) .Call(wrap__RPolarsExpr__cum_min, self, reverse)
+
+RPolarsExpr$cum_max = function(reverse) .Call(wrap__RPolarsExpr__cum_max, self, reverse)
+
+RPolarsExpr$cum_count = function(reverse) .Call(wrap__RPolarsExpr__cum_count, self, reverse)
+
+RPolarsExpr$floor = function() .Call(wrap__RPolarsExpr__floor, self)
+
+RPolarsExpr$ceil = function() .Call(wrap__RPolarsExpr__ceil, self)
+
+RPolarsExpr$round = function(decimals) .Call(wrap__RPolarsExpr__round, self, decimals)
+
+RPolarsExpr$dot = function(other) .Call(wrap__RPolarsExpr__dot, self, other)
+
+RPolarsExpr$mode = function() .Call(wrap__RPolarsExpr__mode, self)
+
+RPolarsExpr$first = function() .Call(wrap__RPolarsExpr__first, self)
+
+RPolarsExpr$last = function() .Call(wrap__RPolarsExpr__last, self)
+
+RPolarsExpr$head = function(n) .Call(wrap__RPolarsExpr__head, self, n)
+
+RPolarsExpr$tail = function(n) .Call(wrap__RPolarsExpr__tail, self, n)
+
+RPolarsExpr$unique = function() .Call(wrap__RPolarsExpr__unique, self)
+
+RPolarsExpr$unique_stable = function() .Call(wrap__RPolarsExpr__unique_stable, self)
+
+RPolarsExpr$agg_groups = function() .Call(wrap__RPolarsExpr__agg_groups, self)
+
+RPolarsExpr$all = function(drop_nulls) .Call(wrap__RPolarsExpr__all, self, drop_nulls)
+
+RPolarsExpr$any = function(drop_nulls) .Call(wrap__RPolarsExpr__any, self, drop_nulls)
+
+RPolarsExpr$is_duplicated = function() .Call(wrap__RPolarsExpr__is_duplicated, self)
+
+RPolarsExpr$is_finite = function() .Call(wrap__RPolarsExpr__is_finite, self)
+
+RPolarsExpr$is_first_distinct = function() .Call(wrap__RPolarsExpr__is_first_distinct, self)
+
+RPolarsExpr$is_in = function(other) .Call(wrap__RPolarsExpr__is_in, self, other)
+
+RPolarsExpr$is_infinite = function() .Call(wrap__RPolarsExpr__is_infinite, self)
+
+RPolarsExpr$is_last_distinct = function() .Call(wrap__RPolarsExpr__is_last_distinct, self)
+
+RPolarsExpr$is_nan = function() .Call(wrap__RPolarsExpr__is_nan, self)
+
+RPolarsExpr$is_not_null = function() .Call(wrap__RPolarsExpr__is_not_null, self)
+
+RPolarsExpr$is_not_nan = function() .Call(wrap__RPolarsExpr__is_not_nan, self)
+
+RPolarsExpr$is_null = function() .Call(wrap__RPolarsExpr__is_null, self)
+
+RPolarsExpr$is_unique = function() .Call(wrap__RPolarsExpr__is_unique, self)
+
+RPolarsExpr$not = function() .Call(wrap__RPolarsExpr__not, self)
+
+RPolarsExpr$count = function() .Call(wrap__RPolarsExpr__count, self)
+
+RPolarsExpr$len = function() .Call(wrap__RPolarsExpr__len, self)
+
+RPolarsExpr$slice = function(offset, length) .Call(wrap__RPolarsExpr__slice, self, offset, length)
+
+RPolarsExpr$append = function(other, upcast) .Call(wrap__RPolarsExpr__append, self, other, upcast)
+
+RPolarsExpr$rechunk = function() .Call(wrap__RPolarsExpr__rechunk, self)
+
+RPolarsExpr$add = function(other) .Call(wrap__RPolarsExpr__add, self, other)
+
+RPolarsExpr$floor_div = function(other) .Call(wrap__RPolarsExpr__floor_div, self, other)
+
+RPolarsExpr$rem = function(other) .Call(wrap__RPolarsExpr__rem, self, other)
+
+RPolarsExpr$mul = function(other) .Call(wrap__RPolarsExpr__mul, self, other)
+
+RPolarsExpr$sub = function(other) .Call(wrap__RPolarsExpr__sub, self, other)
+
+RPolarsExpr$div = function(other) .Call(wrap__RPolarsExpr__div, self, other)
+
+RPolarsExpr$pow = function(exponent) .Call(wrap__RPolarsExpr__pow, self, exponent)
+
+RPolarsExpr$over = function(proto_exprs) .Call(wrap__RPolarsExpr__over, self, proto_exprs)
+
+RPolarsExpr$print = function() invisible(.Call(wrap__RPolarsExpr__print, self))
+
+RPolarsExpr$map_batches = function(lambda, output_type, agg_list) .Call(wrap__RPolarsExpr__map_batches, self, lambda, output_type, agg_list)
+
+RPolarsExpr$map_batches_in_background = function(lambda, output_type, agg_list) .Call(wrap__RPolarsExpr__map_batches_in_background, self, lambda, output_type, agg_list)
+
+RPolarsExpr$map_elements_in_background = function(lambda, output_type) .Call(wrap__RPolarsExpr__map_elements_in_background, self, lambda, output_type)
+
+RPolarsExpr$approx_n_unique = function() .Call(wrap__RPolarsExpr__approx_n_unique, self)
+
+RPolarsExpr$name_keep = function() .Call(wrap__RPolarsExpr__name_keep, self)
+
+RPolarsExpr$name_suffix = function(suffix) .Call(wrap__RPolarsExpr__name_suffix, self, suffix)
+
+RPolarsExpr$name_prefix = function(prefix) .Call(wrap__RPolarsExpr__name_prefix, self, prefix)
+
+RPolarsExpr$name_to_lowercase = function() .Call(wrap__RPolarsExpr__name_to_lowercase, self)
+
+RPolarsExpr$name_to_uppercase = function() .Call(wrap__RPolarsExpr__name_to_uppercase, self)
+
+RPolarsExpr$name_map = function(lambda) .Call(wrap__RPolarsExpr__name_map, self, lambda)
+
+RPolarsExpr$str_len_bytes = function() .Call(wrap__RPolarsExpr__str_len_bytes, self)
+
+RPolarsExpr$str_len_chars = function() .Call(wrap__RPolarsExpr__str_len_chars, self)
+
+RPolarsExpr$str_concat = function(delimiter, ignore_nulls) .Call(wrap__RPolarsExpr__str_concat, self, delimiter, ignore_nulls)
+
+RPolarsExpr$str_to_uppercase = function() .Call(wrap__RPolarsExpr__str_to_uppercase, self)
+
+RPolarsExpr$str_to_lowercase = function() .Call(wrap__RPolarsExpr__str_to_lowercase, self)
+
+RPolarsExpr$str_to_titlecase = function() .Call(wrap__RPolarsExpr__str_to_titlecase, self)
+
+RPolarsExpr$str_strip_chars = function(matches) .Call(wrap__RPolarsExpr__str_strip_chars, self, matches)
+
+RPolarsExpr$str_strip_chars_end = function(matches) .Call(wrap__RPolarsExpr__str_strip_chars_end, self, matches)
+
+RPolarsExpr$str_strip_chars_start = function(matches) .Call(wrap__RPolarsExpr__str_strip_chars_start, self, matches)
+
+RPolarsExpr$str_zfill = function(alignment) .Call(wrap__RPolarsExpr__str_zfill, self, alignment)
+
+RPolarsExpr$str_pad_end = function(width, fillchar) .Call(wrap__RPolarsExpr__str_pad_end, self, width, fillchar)
+
+RPolarsExpr$str_pad_start = function(width, fillchar) .Call(wrap__RPolarsExpr__str_pad_start, self, width, fillchar)
+
+RPolarsExpr$str_contains = function(pat, literal, strict) .Call(wrap__RPolarsExpr__str_contains, self, pat, literal, strict)
+
+RPolarsExpr$str_ends_with = function(sub) .Call(wrap__RPolarsExpr__str_ends_with, self, sub)
+
+RPolarsExpr$str_starts_with = function(sub) .Call(wrap__RPolarsExpr__str_starts_with, self, sub)
+
+RPolarsExpr$str_json_path_match = function(pat) .Call(wrap__RPolarsExpr__str_json_path_match, self, pat)
+
+RPolarsExpr$str_json_extract = function(dtype, infer_schema_len) .Call(wrap__RPolarsExpr__str_json_extract, self, dtype, infer_schema_len)
+
+RPolarsExpr$str_hex_encode = function() .Call(wrap__RPolarsExpr__str_hex_encode, self)
+
+RPolarsExpr$str_hex_decode = function(strict) .Call(wrap__RPolarsExpr__str_hex_decode, self, strict)
+
+RPolarsExpr$str_base64_encode = function() .Call(wrap__RPolarsExpr__str_base64_encode, self)
+
+RPolarsExpr$str_base64_decode = function(strict) .Call(wrap__RPolarsExpr__str_base64_decode, self, strict)
+
+RPolarsExpr$str_extract = function(pattern, group_index) .Call(wrap__RPolarsExpr__str_extract, self, pattern, group_index)
+
+RPolarsExpr$str_extract_all = function(pattern) .Call(wrap__RPolarsExpr__str_extract_all, self, pattern)
+
+RPolarsExpr$str_count_matches = function(pattern, literal) .Call(wrap__RPolarsExpr__str_count_matches, self, pattern, literal)
+
+RPolarsExpr$str_split = function(by, inclusive) .Call(wrap__RPolarsExpr__str_split, self, by, inclusive)
+
+RPolarsExpr$str_split_exact = function(by, n, inclusive) .Call(wrap__RPolarsExpr__str_split_exact, self, by, n, inclusive)
+
+RPolarsExpr$str_splitn = function(by, n) .Call(wrap__RPolarsExpr__str_splitn, self, by, n)
+
+RPolarsExpr$str_replace = function(pattern, value, literal) .Call(wrap__RPolarsExpr__str_replace, self, pattern, value, literal)
+
+RPolarsExpr$str_replace_all = function(pattern, value, literal) .Call(wrap__RPolarsExpr__str_replace_all, self, pattern, value, literal)
+
+RPolarsExpr$str_slice = function(offset, length) .Call(wrap__RPolarsExpr__str_slice, self, offset, length)
+
+RPolarsExpr$str_explode = function() .Call(wrap__RPolarsExpr__str_explode, self)
+
+RPolarsExpr$str_parse_int = function(radix, strict) .Call(wrap__RPolarsExpr__str_parse_int, self, radix, strict)
+
+RPolarsExpr$bin_contains = function(lit) .Call(wrap__RPolarsExpr__bin_contains, self, lit)
+
+RPolarsExpr$bin_starts_with = function(sub) .Call(wrap__RPolarsExpr__bin_starts_with, self, sub)
+
+RPolarsExpr$bin_ends_with = function(sub) .Call(wrap__RPolarsExpr__bin_ends_with, self, sub)
+
+RPolarsExpr$bin_encode_hex = function() .Call(wrap__RPolarsExpr__bin_encode_hex, self)
+
+RPolarsExpr$bin_encode_base64 = function() .Call(wrap__RPolarsExpr__bin_encode_base64, self)
+
+RPolarsExpr$bin_decode_hex = function(strict) .Call(wrap__RPolarsExpr__bin_decode_hex, self, strict)
+
+RPolarsExpr$bin_decode_base64 = function(strict) .Call(wrap__RPolarsExpr__bin_decode_base64, self, strict)
+
+RPolarsExpr$struct_field_by_name = function(name) .Call(wrap__RPolarsExpr__struct_field_by_name, self, name)
+
+RPolarsExpr$struct_rename_fields = function(names) .Call(wrap__RPolarsExpr__struct_rename_fields, self, names)
+
+RPolarsExpr$meta_pop = function() .Call(wrap__RPolarsExpr__meta_pop, self)
+
+RPolarsExpr$meta_eq = function(other) .Call(wrap__RPolarsExpr__meta_eq, self, other)
+
+RPolarsExpr$meta_roots = function() .Call(wrap__RPolarsExpr__meta_roots, self)
+
+RPolarsExpr$meta_output_name = function() .Call(wrap__RPolarsExpr__meta_output_name, self)
+
+RPolarsExpr$meta_undo_aliases = function() .Call(wrap__RPolarsExpr__meta_undo_aliases, self)
+
+RPolarsExpr$meta_has_multiple_outputs = function() .Call(wrap__RPolarsExpr__meta_has_multiple_outputs, self)
+
+RPolarsExpr$meta_is_regex_projection = function() .Call(wrap__RPolarsExpr__meta_is_regex_projection, self)
+
+RPolarsExpr$meta_tree_format = function() .Call(wrap__RPolarsExpr__meta_tree_format, self)
+
+RPolarsExpr$cat_set_ordering = function(ordering) .Call(wrap__RPolarsExpr__cat_set_ordering, self, ordering)
+
+RPolarsExpr$cat_get_categories = function() .Call(wrap__RPolarsExpr__cat_get_categories, self)
+
+RPolarsExpr$new_count = function() .Call(wrap__RPolarsExpr__new_count)
+
+RPolarsExpr$new_first = function() .Call(wrap__RPolarsExpr__new_first)
+
+RPolarsExpr$new_last = function() .Call(wrap__RPolarsExpr__new_last)
+
+RPolarsExpr$cov = function(a, b, ddof) .Call(wrap__RPolarsExpr__cov, a, b, ddof)
+
+RPolarsExpr$rolling_cov = function(a, b, window_size, min_periods, ddof) .Call(wrap__RPolarsExpr__rolling_cov, a, b, window_size, min_periods, ddof)
+
+RPolarsExpr$corr = function(a, b, method, ddof, propagate_nans) .Call(wrap__RPolarsExpr__corr, a, b, method, ddof, propagate_nans)
+
+RPolarsExpr$rolling_corr = function(a, b, window_size, min_periods, ddof) .Call(wrap__RPolarsExpr__rolling_corr, a, b, window_size, min_periods, ddof)
+
+RPolarsExpr$rolling = function(index_column, period, offset, closed, check_sorted) .Call(wrap__RPolarsExpr__rolling, self, index_column, period, offset, closed, check_sorted)
 
 #' @export
-`$.RPolarsProtoExprArray` <- function (self, name) { func <- RPolarsProtoExprArray[[name]]; environment(func) <- environment(); func }
+`$.RPolarsExpr` = function(self, name) {
+  func = RPolarsExpr[[name]]
+  environment(func) = environment()
+  func
+}
 
 #' @export
-`[[.RPolarsProtoExprArray` <- `$.RPolarsProtoExprArray`
+`[[.RPolarsExpr` = `$.RPolarsExpr`
 
-RPolarsLazyFrame <- new.env(parent = emptyenv())
+RPolarsProtoExprArray = new.env(parent = emptyenv())
 
-RPolarsLazyFrame$print <- function() .Call(wrap__RPolarsLazyFrame__print, self)
+RPolarsProtoExprArray$new = function() .Call(wrap__RPolarsProtoExprArray__new)
 
-RPolarsLazyFrame$describe_plan <- function() invisible(.Call(wrap__RPolarsLazyFrame__describe_plan, self))
+RPolarsProtoExprArray$push_back_str = function(s) invisible(.Call(wrap__RPolarsProtoExprArray__push_back_str, self, s))
 
-RPolarsLazyFrame$debug_plan <- function() .Call(wrap__RPolarsLazyFrame__debug_plan, self)
+RPolarsProtoExprArray$push_back_rexpr = function(r) invisible(.Call(wrap__RPolarsProtoExprArray__push_back_rexpr, self, r))
 
-RPolarsLazyFrame$describe_optimized_plan <- function() .Call(wrap__RPolarsLazyFrame__describe_optimized_plan, self)
-
-RPolarsLazyFrame$collect <- function() .Call(wrap__RPolarsLazyFrame__collect, self)
-
-RPolarsLazyFrame$collect_in_background <- function() .Call(wrap__RPolarsLazyFrame__collect_in_background, self)
-
-RPolarsLazyFrame$sink_parquet <- function(path, compression_method, compression_level, statistics, row_group_size, data_pagesize_limit, maintain_order) .Call(wrap__RPolarsLazyFrame__sink_parquet, self, path, compression_method, compression_level, statistics, row_group_size, data_pagesize_limit, maintain_order)
-
-RPolarsLazyFrame$sink_ipc <- function(path, compression_method, maintain_order) .Call(wrap__RPolarsLazyFrame__sink_ipc, self, path, compression_method, maintain_order)
-
-RPolarsLazyFrame$sink_csv <- function(path, include_bom, include_header, separator, line_terminator, quote, batch_size, datetime_format, date_format, time_format, float_precision, null_value, quote_style, maintain_order) .Call(wrap__RPolarsLazyFrame__sink_csv, self, path, include_bom, include_header, separator, line_terminator, quote, batch_size, datetime_format, date_format, time_format, float_precision, null_value, quote_style, maintain_order)
-
-RPolarsLazyFrame$first <- function() .Call(wrap__RPolarsLazyFrame__first, self)
-
-RPolarsLazyFrame$last <- function() .Call(wrap__RPolarsLazyFrame__last, self)
-
-RPolarsLazyFrame$max <- function() .Call(wrap__RPolarsLazyFrame__max, self)
-
-RPolarsLazyFrame$min <- function() .Call(wrap__RPolarsLazyFrame__min, self)
-
-RPolarsLazyFrame$mean <- function() .Call(wrap__RPolarsLazyFrame__mean, self)
-
-RPolarsLazyFrame$median <- function() .Call(wrap__RPolarsLazyFrame__median, self)
-
-RPolarsLazyFrame$sum <- function() .Call(wrap__RPolarsLazyFrame__sum, self)
-
-RPolarsLazyFrame$std <- function(ddof) .Call(wrap__RPolarsLazyFrame__std, self, ddof)
-
-RPolarsLazyFrame$var <- function(ddof) .Call(wrap__RPolarsLazyFrame__var, self, ddof)
-
-RPolarsLazyFrame$quantile <- function(quantile, interpolation) .Call(wrap__RPolarsLazyFrame__quantile, self, quantile, interpolation)
-
-RPolarsLazyFrame$shift <- function(periods) .Call(wrap__RPolarsLazyFrame__shift, self, periods)
-
-RPolarsLazyFrame$shift_and_fill <- function(fill_value, periods) .Call(wrap__RPolarsLazyFrame__shift_and_fill, self, fill_value, periods)
-
-RPolarsLazyFrame$reverse <- function() .Call(wrap__RPolarsLazyFrame__reverse, self)
-
-RPolarsLazyFrame$drop <- function(columns) .Call(wrap__RPolarsLazyFrame__drop, self, columns)
-
-RPolarsLazyFrame$fill_nan <- function(fill_value) .Call(wrap__RPolarsLazyFrame__fill_nan, self, fill_value)
-
-RPolarsLazyFrame$fill_null <- function(fill_value) .Call(wrap__RPolarsLazyFrame__fill_null, self, fill_value)
-
-RPolarsLazyFrame$slice <- function(offset, length) .Call(wrap__RPolarsLazyFrame__slice, self, offset, length)
-
-RPolarsLazyFrame$with_columns <- function(exprs) .Call(wrap__RPolarsLazyFrame__with_columns, self, exprs)
-
-RPolarsLazyFrame$unnest <- function(names) .Call(wrap__RPolarsLazyFrame__unnest, self, names)
-
-RPolarsLazyFrame$select <- function(exprs) .Call(wrap__RPolarsLazyFrame__select, self, exprs)
-
-RPolarsLazyFrame$select_str_as_lit <- function(exprs) .Call(wrap__RPolarsLazyFrame__select_str_as_lit, self, exprs)
-
-RPolarsLazyFrame$limit <- function(n) .Call(wrap__RPolarsLazyFrame__limit, self, n)
-
-RPolarsLazyFrame$tail <- function(n) .Call(wrap__RPolarsLazyFrame__tail, self, n)
-
-RPolarsLazyFrame$filter <- function(expr) .Call(wrap__RPolarsLazyFrame__filter, self, expr)
-
-RPolarsLazyFrame$drop_nulls <- function(subset) .Call(wrap__RPolarsLazyFrame__drop_nulls, self, subset)
-
-RPolarsLazyFrame$unique <- function(subset, keep, maintain_order) .Call(wrap__RPolarsLazyFrame__unique, self, subset, keep, maintain_order)
-
-RPolarsLazyFrame$group_by <- function(exprs, maintain_order) .Call(wrap__RPolarsLazyFrame__group_by, self, exprs, maintain_order)
-
-RPolarsLazyFrame$with_row_count <- function(name, offset) .Call(wrap__RPolarsLazyFrame__with_row_count, self, name, offset)
-
-RPolarsLazyFrame$join_asof <- function(other, left_on, right_on, left_by, right_by, allow_parallel, force_parallel, suffix, strategy, tolerance, tolerance_str) .Call(wrap__RPolarsLazyFrame__join_asof, self, other, left_on, right_on, left_by, right_by, allow_parallel, force_parallel, suffix, strategy, tolerance, tolerance_str)
-
-RPolarsLazyFrame$join <- function(other, left_on, right_on, how, suffix, allow_parallel, force_parallel) .Call(wrap__RPolarsLazyFrame__join, self, other, left_on, right_on, how, suffix, allow_parallel, force_parallel)
-
-RPolarsLazyFrame$sort_by_exprs <- function(by, dotdotdot, descending, nulls_last, maintain_order) .Call(wrap__RPolarsLazyFrame__sort_by_exprs, self, by, dotdotdot, descending, nulls_last, maintain_order)
-
-RPolarsLazyFrame$melt <- function(id_vars, value_vars, value_name, variable_name, streamable) .Call(wrap__RPolarsLazyFrame__melt, self, id_vars, value_vars, value_name, variable_name, streamable)
-
-RPolarsLazyFrame$rename <- function(existing, new) .Call(wrap__RPolarsLazyFrame__rename, self, existing, new)
-
-RPolarsLazyFrame$schema <- function() .Call(wrap__RPolarsLazyFrame__schema, self)
-
-RPolarsLazyFrame$fetch <- function(n_rows) .Call(wrap__RPolarsLazyFrame__fetch, self, n_rows)
-
-RPolarsLazyFrame$set_optimization_toggle <- function(type_coercion, predicate_pushdown, projection_pushdown, simplify_expression, slice_pushdown, comm_subplan_elim, comm_subexpr_elim, streaming, eager) .Call(wrap__RPolarsLazyFrame__set_optimization_toggle, self, type_coercion, predicate_pushdown, projection_pushdown, simplify_expression, slice_pushdown, comm_subplan_elim, comm_subexpr_elim, streaming, eager)
-
-RPolarsLazyFrame$get_optimization_toggle <- function() .Call(wrap__RPolarsLazyFrame__get_optimization_toggle, self)
-
-RPolarsLazyFrame$profile <- function() .Call(wrap__RPolarsLazyFrame__profile, self)
-
-RPolarsLazyFrame$explode <- function(dotdotdot) .Call(wrap__RPolarsLazyFrame__explode, self, dotdotdot)
-
-RPolarsLazyFrame$clone_in_rust <- function() .Call(wrap__RPolarsLazyFrame__clone_in_rust, self)
-
-RPolarsLazyFrame$with_context <- function(contexts) .Call(wrap__RPolarsLazyFrame__with_context, self, contexts)
+RPolarsProtoExprArray$print = function() invisible(.Call(wrap__RPolarsProtoExprArray__print, self))
 
 #' @export
-`$.RPolarsLazyFrame` <- function (self, name) { func <- RPolarsLazyFrame[[name]]; environment(func) <- environment(); func }
+`$.RPolarsProtoExprArray` = function(self, name) {
+  func = RPolarsProtoExprArray[[name]]
+  environment(func) = environment()
+  func
+}
 
 #' @export
-`[[.RPolarsLazyFrame` <- `$.RPolarsLazyFrame`
+`[[.RPolarsProtoExprArray` = `$.RPolarsProtoExprArray`
 
-RPolarsLazyGroupBy <- new.env(parent = emptyenv())
+RPolarsLazyFrame = new.env(parent = emptyenv())
 
-RPolarsLazyGroupBy$print <- function() invisible(.Call(wrap__RPolarsLazyGroupBy__print, self))
+RPolarsLazyFrame$print = function() .Call(wrap__RPolarsLazyFrame__print, self)
 
-RPolarsLazyGroupBy$clone_in_rust <- function() .Call(wrap__RPolarsLazyGroupBy__clone_in_rust, self)
+RPolarsLazyFrame$describe_plan = function() invisible(.Call(wrap__RPolarsLazyFrame__describe_plan, self))
 
-RPolarsLazyGroupBy$ungroup <- function() .Call(wrap__RPolarsLazyGroupBy__ungroup, self)
+RPolarsLazyFrame$debug_plan = function() .Call(wrap__RPolarsLazyFrame__debug_plan, self)
 
-RPolarsLazyGroupBy$agg <- function(exprs) .Call(wrap__RPolarsLazyGroupBy__agg, self, exprs)
+RPolarsLazyFrame$describe_optimized_plan = function() .Call(wrap__RPolarsLazyFrame__describe_optimized_plan, self)
 
-RPolarsLazyGroupBy$head <- function(n) .Call(wrap__RPolarsLazyGroupBy__head, self, n)
+RPolarsLazyFrame$collect = function() .Call(wrap__RPolarsLazyFrame__collect, self)
 
-RPolarsLazyGroupBy$tail <- function(n) .Call(wrap__RPolarsLazyGroupBy__tail, self, n)
+RPolarsLazyFrame$collect_in_background = function() .Call(wrap__RPolarsLazyFrame__collect_in_background, self)
 
-#' @export
-`$.RPolarsLazyGroupBy` <- function (self, name) { func <- RPolarsLazyGroupBy[[name]]; environment(func) <- environment(); func }
+RPolarsLazyFrame$sink_parquet = function(path, compression_method, compression_level, statistics, row_group_size, data_pagesize_limit, maintain_order) .Call(wrap__RPolarsLazyFrame__sink_parquet, self, path, compression_method, compression_level, statistics, row_group_size, data_pagesize_limit, maintain_order)
 
-#' @export
-`[[.RPolarsLazyGroupBy` <- `$.RPolarsLazyGroupBy`
+RPolarsLazyFrame$sink_ipc = function(path, compression_method, maintain_order) .Call(wrap__RPolarsLazyFrame__sink_ipc, self, path, compression_method, maintain_order)
 
-RPolarsSeries <- new.env(parent = emptyenv())
+RPolarsLazyFrame$sink_csv = function(path, include_bom, include_header, separator, line_terminator, quote, batch_size, datetime_format, date_format, time_format, float_precision, null_value, quote_style, maintain_order) .Call(wrap__RPolarsLazyFrame__sink_csv, self, path, include_bom, include_header, separator, line_terminator, quote, batch_size, datetime_format, date_format, time_format, float_precision, null_value, quote_style, maintain_order)
 
-RPolarsSeries$new <- function(x, name) .Call(wrap__RPolarsSeries__new, x, name)
+RPolarsLazyFrame$first = function() .Call(wrap__RPolarsLazyFrame__first, self)
 
-RPolarsSeries$clone <- function() .Call(wrap__RPolarsSeries__clone, self)
+RPolarsLazyFrame$last = function() .Call(wrap__RPolarsLazyFrame__last, self)
 
-RPolarsSeries$sleep <- function(millis) .Call(wrap__RPolarsSeries__sleep, self, millis)
+RPolarsLazyFrame$max = function() .Call(wrap__RPolarsLazyFrame__max, self)
 
-RPolarsSeries$panic <- function() .Call(wrap__RPolarsSeries__panic, self)
+RPolarsLazyFrame$min = function() .Call(wrap__RPolarsLazyFrame__min, self)
 
-RPolarsSeries$to_r <- function() .Call(wrap__RPolarsSeries__to_r, self)
+RPolarsLazyFrame$mean = function() .Call(wrap__RPolarsLazyFrame__mean, self)
 
-RPolarsSeries$rename_mut <- function(name) invisible(.Call(wrap__RPolarsSeries__rename_mut, self, name))
+RPolarsLazyFrame$median = function() .Call(wrap__RPolarsLazyFrame__median, self)
 
-RPolarsSeries$dtype <- function() .Call(wrap__RPolarsSeries__dtype, self)
+RPolarsLazyFrame$sum = function() .Call(wrap__RPolarsLazyFrame__sum, self)
 
-RPolarsSeries$n_unique <- function() .Call(wrap__RPolarsSeries__n_unique, self)
+RPolarsLazyFrame$std = function(ddof) .Call(wrap__RPolarsLazyFrame__std, self, ddof)
 
-RPolarsSeries$name <- function() .Call(wrap__RPolarsSeries__name, self)
+RPolarsLazyFrame$var = function(ddof) .Call(wrap__RPolarsLazyFrame__var, self, ddof)
 
-RPolarsSeries$sort_mut <- function(descending) .Call(wrap__RPolarsSeries__sort_mut, self, descending)
+RPolarsLazyFrame$quantile = function(quantile, interpolation) .Call(wrap__RPolarsLazyFrame__quantile, self, quantile, interpolation)
 
-RPolarsSeries$value_counts <- function(sort, parallel) .Call(wrap__RPolarsSeries__value_counts, self, sort, parallel)
+RPolarsLazyFrame$shift = function(periods) .Call(wrap__RPolarsLazyFrame__shift, self, periods)
 
-RPolarsSeries$arg_min <- function() .Call(wrap__RPolarsSeries__arg_min, self)
+RPolarsLazyFrame$shift_and_fill = function(fill_value, periods) .Call(wrap__RPolarsLazyFrame__shift_and_fill, self, fill_value, periods)
 
-RPolarsSeries$arg_max <- function() .Call(wrap__RPolarsSeries__arg_max, self)
+RPolarsLazyFrame$reverse = function() .Call(wrap__RPolarsLazyFrame__reverse, self)
 
-RPolarsSeries$is_sorted_flag <- function() .Call(wrap__RPolarsSeries__is_sorted_flag, self)
+RPolarsLazyFrame$drop = function(columns) .Call(wrap__RPolarsLazyFrame__drop, self, columns)
 
-RPolarsSeries$is_sorted_reverse_flag <- function() .Call(wrap__RPolarsSeries__is_sorted_reverse_flag, self)
+RPolarsLazyFrame$fill_nan = function(fill_value) .Call(wrap__RPolarsLazyFrame__fill_nan, self, fill_value)
 
-RPolarsSeries$is_sorted <- function(descending) .Call(wrap__RPolarsSeries__is_sorted, self, descending)
+RPolarsLazyFrame$fill_null = function(fill_value) .Call(wrap__RPolarsLazyFrame__fill_null, self, fill_value)
 
-RPolarsSeries$series_equal <- function(other, null_equal, strict) .Call(wrap__RPolarsSeries__series_equal, self, other, null_equal, strict)
+RPolarsLazyFrame$slice = function(offset, length) .Call(wrap__RPolarsLazyFrame__slice, self, offset, length)
 
-RPolarsSeries$get_fmt <- function(index, str_length) .Call(wrap__RPolarsSeries__get_fmt, self, index, str_length)
+RPolarsLazyFrame$with_columns = function(exprs) .Call(wrap__RPolarsLazyFrame__with_columns, self, exprs)
 
-RPolarsSeries$to_fmt_char <- function(str_length) .Call(wrap__RPolarsSeries__to_fmt_char, self, str_length)
+RPolarsLazyFrame$unnest = function(names) .Call(wrap__RPolarsLazyFrame__unnest, self, names)
 
-RPolarsSeries$compare <- function(other, op) .Call(wrap__RPolarsSeries__compare, self, other, op)
+RPolarsLazyFrame$select = function(exprs) .Call(wrap__RPolarsLazyFrame__select, self, exprs)
 
-RPolarsSeries$rep <- function(n, rechunk) .Call(wrap__RPolarsSeries__rep, self, n, rechunk)
+RPolarsLazyFrame$select_str_as_lit = function(exprs) .Call(wrap__RPolarsLazyFrame__select_str_as_lit, self, exprs)
 
-RPolarsSeries$shape <- function() .Call(wrap__RPolarsSeries__shape, self)
+RPolarsLazyFrame$limit = function(n) .Call(wrap__RPolarsLazyFrame__limit, self, n)
 
-RPolarsSeries$len <- function() .Call(wrap__RPolarsSeries__len, self)
+RPolarsLazyFrame$tail = function(n) .Call(wrap__RPolarsLazyFrame__tail, self, n)
 
-RPolarsSeries$chunk_lengths <- function() .Call(wrap__RPolarsSeries__chunk_lengths, self)
+RPolarsLazyFrame$filter = function(expr) .Call(wrap__RPolarsLazyFrame__filter, self, expr)
 
-RPolarsSeries$abs <- function() .Call(wrap__RPolarsSeries__abs, self)
+RPolarsLazyFrame$drop_nulls = function(subset) .Call(wrap__RPolarsLazyFrame__drop_nulls, self, subset)
 
-RPolarsSeries$alias <- function(name) .Call(wrap__RPolarsSeries__alias, self, name)
+RPolarsLazyFrame$unique = function(subset, keep, maintain_order) .Call(wrap__RPolarsLazyFrame__unique, self, subset, keep, maintain_order)
 
-RPolarsSeries$all <- function() .Call(wrap__RPolarsSeries__all, self)
+RPolarsLazyFrame$group_by = function(exprs, maintain_order) .Call(wrap__RPolarsLazyFrame__group_by, self, exprs, maintain_order)
 
-RPolarsSeries$any <- function() .Call(wrap__RPolarsSeries__any, self)
+RPolarsLazyFrame$with_row_count = function(name, offset) .Call(wrap__RPolarsLazyFrame__with_row_count, self, name, offset)
 
-RPolarsSeries$add <- function(other) .Call(wrap__RPolarsSeries__add, self, other)
+RPolarsLazyFrame$join_asof = function(other, left_on, right_on, left_by, right_by, allow_parallel, force_parallel, suffix, strategy, tolerance, tolerance_str) .Call(wrap__RPolarsLazyFrame__join_asof, self, other, left_on, right_on, left_by, right_by, allow_parallel, force_parallel, suffix, strategy, tolerance, tolerance_str)
 
-RPolarsSeries$sub <- function(other) .Call(wrap__RPolarsSeries__sub, self, other)
+RPolarsLazyFrame$join = function(other, left_on, right_on, how, suffix, allow_parallel, force_parallel) .Call(wrap__RPolarsLazyFrame__join, self, other, left_on, right_on, how, suffix, allow_parallel, force_parallel)
 
-RPolarsSeries$mul <- function(other) .Call(wrap__RPolarsSeries__mul, self, other)
+RPolarsLazyFrame$sort_by_exprs = function(by, dotdotdot, descending, nulls_last, maintain_order) .Call(wrap__RPolarsLazyFrame__sort_by_exprs, self, by, dotdotdot, descending, nulls_last, maintain_order)
 
-RPolarsSeries$div <- function(other) .Call(wrap__RPolarsSeries__div, self, other)
+RPolarsLazyFrame$melt = function(id_vars, value_vars, value_name, variable_name, streamable) .Call(wrap__RPolarsLazyFrame__melt, self, id_vars, value_vars, value_name, variable_name, streamable)
 
-RPolarsSeries$rem <- function(other) .Call(wrap__RPolarsSeries__rem, self, other)
+RPolarsLazyFrame$rename = function(existing, new) .Call(wrap__RPolarsLazyFrame__rename, self, existing, new)
 
-RPolarsSeries$append_mut <- function(other) .Call(wrap__RPolarsSeries__append_mut, self, other)
+RPolarsLazyFrame$schema = function() .Call(wrap__RPolarsLazyFrame__schema, self)
 
-RPolarsSeries$map_elements <- function(robj, rdatatype, strict, allow_fail_eval) .Call(wrap__RPolarsSeries__map_elements, self, robj, rdatatype, strict, allow_fail_eval)
+RPolarsLazyFrame$fetch = function(n_rows) .Call(wrap__RPolarsLazyFrame__fetch, self, n_rows)
 
-RPolarsSeries$mean <- function() .Call(wrap__RPolarsSeries__mean, self)
+RPolarsLazyFrame$set_optimization_toggle = function(type_coercion, predicate_pushdown, projection_pushdown, simplify_expression, slice_pushdown, comm_subplan_elim, comm_subexpr_elim, streaming, eager) .Call(wrap__RPolarsLazyFrame__set_optimization_toggle, self, type_coercion, predicate_pushdown, projection_pushdown, simplify_expression, slice_pushdown, comm_subplan_elim, comm_subexpr_elim, streaming, eager)
 
-RPolarsSeries$median <- function() .Call(wrap__RPolarsSeries__median, self)
+RPolarsLazyFrame$get_optimization_toggle = function() .Call(wrap__RPolarsLazyFrame__get_optimization_toggle, self)
 
-RPolarsSeries$min <- function() .Call(wrap__RPolarsSeries__min, self)
+RPolarsLazyFrame$profile = function() .Call(wrap__RPolarsLazyFrame__profile, self)
 
-RPolarsSeries$max <- function() .Call(wrap__RPolarsSeries__max, self)
+RPolarsLazyFrame$explode = function(dotdotdot) .Call(wrap__RPolarsLazyFrame__explode, self, dotdotdot)
 
-RPolarsSeries$sum <- function() .Call(wrap__RPolarsSeries__sum, self)
+RPolarsLazyFrame$clone_in_rust = function() .Call(wrap__RPolarsLazyFrame__clone_in_rust, self)
 
-RPolarsSeries$std <- function(ddof) .Call(wrap__RPolarsSeries__std, self, ddof)
-
-RPolarsSeries$var <- function(ddof) .Call(wrap__RPolarsSeries__var, self, ddof)
-
-RPolarsSeries$ceil <- function() .Call(wrap__RPolarsSeries__ceil, self)
-
-RPolarsSeries$floor <- function() .Call(wrap__RPolarsSeries__floor, self)
-
-RPolarsSeries$print <- function() invisible(.Call(wrap__RPolarsSeries__print, self))
-
-RPolarsSeries$cum_sum <- function(reverse) .Call(wrap__RPolarsSeries__cum_sum, self, reverse)
-
-RPolarsSeries$to_frame <- function() .Call(wrap__RPolarsSeries__to_frame, self)
-
-RPolarsSeries$set_sorted_mut <- function(descending) invisible(.Call(wrap__RPolarsSeries__set_sorted_mut, self, descending))
-
-RPolarsSeries$from_arrow <- function(name, array) .Call(wrap__RPolarsSeries__from_arrow, name, array)
+RPolarsLazyFrame$with_context = function(contexts) .Call(wrap__RPolarsLazyFrame__with_context, self, contexts)
 
 #' @export
-`$.RPolarsSeries` <- function (self, name) { func <- RPolarsSeries[[name]]; environment(func) <- environment(); func }
+`$.RPolarsLazyFrame` = function(self, name) {
+  func = RPolarsLazyFrame[[name]]
+  environment(func) = environment()
+  func
+}
 
 #' @export
-`[[.RPolarsSeries` <- `$.RPolarsSeries`
+`[[.RPolarsLazyFrame` = `$.RPolarsLazyFrame`
 
-RPolarsSQLContext <- new.env(parent = emptyenv())
+RPolarsLazyGroupBy = new.env(parent = emptyenv())
 
-RPolarsSQLContext$new <- function() .Call(wrap__RPolarsSQLContext__new)
+RPolarsLazyGroupBy$print = function() invisible(.Call(wrap__RPolarsLazyGroupBy__print, self))
 
-RPolarsSQLContext$execute <- function(query) .Call(wrap__RPolarsSQLContext__execute, self, query)
+RPolarsLazyGroupBy$clone_in_rust = function() .Call(wrap__RPolarsLazyGroupBy__clone_in_rust, self)
 
-RPolarsSQLContext$get_tables <- function() .Call(wrap__RPolarsSQLContext__get_tables, self)
+RPolarsLazyGroupBy$ungroup = function() .Call(wrap__RPolarsLazyGroupBy__ungroup, self)
 
-RPolarsSQLContext$register <- function(name, lf) .Call(wrap__RPolarsSQLContext__register, self, name, lf)
+RPolarsLazyGroupBy$agg = function(exprs) .Call(wrap__RPolarsLazyGroupBy__agg, self, exprs)
 
-RPolarsSQLContext$unregister <- function(name) .Call(wrap__RPolarsSQLContext__unregister, self, name)
+RPolarsLazyGroupBy$head = function(n) .Call(wrap__RPolarsLazyGroupBy__head, self, n)
 
-#' @export
-`$.RPolarsSQLContext` <- function (self, name) { func <- RPolarsSQLContext[[name]]; environment(func) <- environment(); func }
-
-#' @export
-`[[.RPolarsSQLContext` <- `$.RPolarsSQLContext`
-
-RPolarsStringCacheHolder <- new.env(parent = emptyenv())
-
-RPolarsStringCacheHolder$hold <- function() .Call(wrap__RPolarsStringCacheHolder__hold)
-
-RPolarsStringCacheHolder$release <- function() .Call(wrap__RPolarsStringCacheHolder__release, self)
+RPolarsLazyGroupBy$tail = function(n) .Call(wrap__RPolarsLazyGroupBy__tail, self, n)
 
 #' @export
-`$.RPolarsStringCacheHolder` <- function (self, name) { func <- RPolarsStringCacheHolder[[name]]; environment(func) <- environment(); func }
+`$.RPolarsLazyGroupBy` = function(self, name) {
+  func = RPolarsLazyGroupBy[[name]]
+  environment(func) = environment()
+  func
+}
 
 #' @export
-`[[.RPolarsStringCacheHolder` <- `$.RPolarsStringCacheHolder`
+`[[.RPolarsLazyGroupBy` = `$.RPolarsLazyGroupBy`
+
+RPolarsSeries = new.env(parent = emptyenv())
+
+RPolarsSeries$new = function(x, name) .Call(wrap__RPolarsSeries__new, x, name)
+
+RPolarsSeries$clone = function() .Call(wrap__RPolarsSeries__clone, self)
+
+RPolarsSeries$sleep = function(millis) .Call(wrap__RPolarsSeries__sleep, self, millis)
+
+RPolarsSeries$panic = function() .Call(wrap__RPolarsSeries__panic, self)
+
+RPolarsSeries$to_r = function() .Call(wrap__RPolarsSeries__to_r, self)
+
+RPolarsSeries$rename_mut = function(name) invisible(.Call(wrap__RPolarsSeries__rename_mut, self, name))
+
+RPolarsSeries$dtype = function() .Call(wrap__RPolarsSeries__dtype, self)
+
+RPolarsSeries$n_unique = function() .Call(wrap__RPolarsSeries__n_unique, self)
+
+RPolarsSeries$name = function() .Call(wrap__RPolarsSeries__name, self)
+
+RPolarsSeries$sort_mut = function(descending) .Call(wrap__RPolarsSeries__sort_mut, self, descending)
+
+RPolarsSeries$value_counts = function(sort, parallel) .Call(wrap__RPolarsSeries__value_counts, self, sort, parallel)
+
+RPolarsSeries$arg_min = function() .Call(wrap__RPolarsSeries__arg_min, self)
+
+RPolarsSeries$arg_max = function() .Call(wrap__RPolarsSeries__arg_max, self)
+
+RPolarsSeries$is_sorted_flag = function() .Call(wrap__RPolarsSeries__is_sorted_flag, self)
+
+RPolarsSeries$is_sorted_reverse_flag = function() .Call(wrap__RPolarsSeries__is_sorted_reverse_flag, self)
+
+RPolarsSeries$is_sorted = function(descending) .Call(wrap__RPolarsSeries__is_sorted, self, descending)
+
+RPolarsSeries$series_equal = function(other, null_equal, strict) .Call(wrap__RPolarsSeries__series_equal, self, other, null_equal, strict)
+
+RPolarsSeries$get_fmt = function(index, str_length) .Call(wrap__RPolarsSeries__get_fmt, self, index, str_length)
+
+RPolarsSeries$to_fmt_char = function(str_length) .Call(wrap__RPolarsSeries__to_fmt_char, self, str_length)
+
+RPolarsSeries$compare = function(other, op) .Call(wrap__RPolarsSeries__compare, self, other, op)
+
+RPolarsSeries$rep = function(n, rechunk) .Call(wrap__RPolarsSeries__rep, self, n, rechunk)
+
+RPolarsSeries$shape = function() .Call(wrap__RPolarsSeries__shape, self)
+
+RPolarsSeries$len = function() .Call(wrap__RPolarsSeries__len, self)
+
+RPolarsSeries$chunk_lengths = function() .Call(wrap__RPolarsSeries__chunk_lengths, self)
+
+RPolarsSeries$abs = function() .Call(wrap__RPolarsSeries__abs, self)
+
+RPolarsSeries$alias = function(name) .Call(wrap__RPolarsSeries__alias, self, name)
+
+RPolarsSeries$all = function() .Call(wrap__RPolarsSeries__all, self)
+
+RPolarsSeries$any = function() .Call(wrap__RPolarsSeries__any, self)
+
+RPolarsSeries$add = function(other) .Call(wrap__RPolarsSeries__add, self, other)
+
+RPolarsSeries$sub = function(other) .Call(wrap__RPolarsSeries__sub, self, other)
+
+RPolarsSeries$mul = function(other) .Call(wrap__RPolarsSeries__mul, self, other)
+
+RPolarsSeries$div = function(other) .Call(wrap__RPolarsSeries__div, self, other)
+
+RPolarsSeries$rem = function(other) .Call(wrap__RPolarsSeries__rem, self, other)
+
+RPolarsSeries$append_mut = function(other) .Call(wrap__RPolarsSeries__append_mut, self, other)
+
+RPolarsSeries$map_elements = function(robj, rdatatype, strict, allow_fail_eval) .Call(wrap__RPolarsSeries__map_elements, self, robj, rdatatype, strict, allow_fail_eval)
+
+RPolarsSeries$mean = function() .Call(wrap__RPolarsSeries__mean, self)
+
+RPolarsSeries$median = function() .Call(wrap__RPolarsSeries__median, self)
+
+RPolarsSeries$min = function() .Call(wrap__RPolarsSeries__min, self)
+
+RPolarsSeries$max = function() .Call(wrap__RPolarsSeries__max, self)
+
+RPolarsSeries$sum = function() .Call(wrap__RPolarsSeries__sum, self)
+
+RPolarsSeries$std = function(ddof) .Call(wrap__RPolarsSeries__std, self, ddof)
+
+RPolarsSeries$var = function(ddof) .Call(wrap__RPolarsSeries__var, self, ddof)
+
+RPolarsSeries$ceil = function() .Call(wrap__RPolarsSeries__ceil, self)
+
+RPolarsSeries$floor = function() .Call(wrap__RPolarsSeries__floor, self)
+
+RPolarsSeries$print = function() invisible(.Call(wrap__RPolarsSeries__print, self))
+
+RPolarsSeries$cum_sum = function(reverse) .Call(wrap__RPolarsSeries__cum_sum, self, reverse)
+
+RPolarsSeries$to_frame = function() .Call(wrap__RPolarsSeries__to_frame, self)
+
+RPolarsSeries$set_sorted_mut = function(descending) invisible(.Call(wrap__RPolarsSeries__set_sorted_mut, self, descending))
+
+RPolarsSeries$from_arrow = function(name, array) .Call(wrap__RPolarsSeries__from_arrow, name, array)
+
+#' @export
+`$.RPolarsSeries` = function(self, name) {
+  func = RPolarsSeries[[name]]
+  environment(func) = environment()
+  func
+}
+
+#' @export
+`[[.RPolarsSeries` = `$.RPolarsSeries`
+
+RPolarsSQLContext = new.env(parent = emptyenv())
+
+RPolarsSQLContext$new = function() .Call(wrap__RPolarsSQLContext__new)
+
+RPolarsSQLContext$execute = function(query) .Call(wrap__RPolarsSQLContext__execute, self, query)
+
+RPolarsSQLContext$get_tables = function() .Call(wrap__RPolarsSQLContext__get_tables, self)
+
+RPolarsSQLContext$register = function(name, lf) .Call(wrap__RPolarsSQLContext__register, self, name, lf)
+
+RPolarsSQLContext$unregister = function(name) .Call(wrap__RPolarsSQLContext__unregister, self, name)
+
+#' @export
+`$.RPolarsSQLContext` = function(self, name) {
+  func = RPolarsSQLContext[[name]]
+  environment(func) = environment()
+  func
+}
+
+#' @export
+`[[.RPolarsSQLContext` = `$.RPolarsSQLContext`
+
+RPolarsStringCacheHolder = new.env(parent = emptyenv())
+
+RPolarsStringCacheHolder$hold = function() .Call(wrap__RPolarsStringCacheHolder__hold)
+
+RPolarsStringCacheHolder$release = function() .Call(wrap__RPolarsStringCacheHolder__release, self)
+
+#' @export
+`$.RPolarsStringCacheHolder` = function(self, name) {
+  func = RPolarsStringCacheHolder[[name]]
+  environment(func) = environment()
+  func
+}
+
+#' @export
+`[[.RPolarsStringCacheHolder` = `$.RPolarsStringCacheHolder`
 
 
 # nolint end

--- a/R/extendr-wrappers.R
+++ b/R/extendr-wrappers.R
@@ -11,1333 +11,1257 @@
 #' @useDynLib polars, .registration = TRUE
 NULL
 
-all_horizontal = function(dotdotdot) .Call(wrap__all_horizontal, dotdotdot)
+all_horizontal <- function(dotdotdot) .Call(wrap__all_horizontal, dotdotdot)
 
-any_horizontal = function(dotdotdot) .Call(wrap__any_horizontal, dotdotdot)
+any_horizontal <- function(dotdotdot) .Call(wrap__any_horizontal, dotdotdot)
 
-min_horizontal = function(dotdotdot) .Call(wrap__min_horizontal, dotdotdot)
+min_horizontal <- function(dotdotdot) .Call(wrap__min_horizontal, dotdotdot)
 
-max_horizontal = function(dotdotdot) .Call(wrap__max_horizontal, dotdotdot)
+max_horizontal <- function(dotdotdot) .Call(wrap__max_horizontal, dotdotdot)
 
-sum_horizontal = function(dotdotdot) .Call(wrap__sum_horizontal, dotdotdot)
+sum_horizontal <- function(dotdotdot) .Call(wrap__sum_horizontal, dotdotdot)
 
-coalesce_exprs = function(exprs) .Call(wrap__coalesce_exprs, exprs)
+coalesce_exprs <- function(exprs) .Call(wrap__coalesce_exprs, exprs)
 
-concat_list = function(exprs) .Call(wrap__concat_list, exprs)
+concat_list <- function(exprs) .Call(wrap__concat_list, exprs)
 
-concat_str = function(dotdotdot, separator) .Call(wrap__concat_str, dotdotdot, separator)
+concat_str <- function(dotdotdot, separator) .Call(wrap__concat_str, dotdotdot, separator)
 
-fold = function(acc, lambda, exprs) .Call(wrap__fold, acc, lambda, exprs)
+fold <- function(acc, lambda, exprs) .Call(wrap__fold, acc, lambda, exprs)
 
-reduce = function(lambda, exprs) .Call(wrap__reduce, lambda, exprs)
+reduce <- function(lambda, exprs) .Call(wrap__reduce, lambda, exprs)
 
-r_date_range_lazy = function(start, end, every, closed, time_unit, time_zone, explode) .Call(wrap__r_date_range_lazy, start, end, every, closed, time_unit, time_zone, explode)
+r_date_range_lazy <- function(start, end, every, closed, time_unit, time_zone, explode) .Call(wrap__r_date_range_lazy, start, end, every, closed, time_unit, time_zone, explode)
 
-as_struct = function(exprs) .Call(wrap__as_struct, exprs)
+as_struct <- function(exprs) .Call(wrap__as_struct, exprs)
 
-struct_ = function(exprs, eager, schema) .Call(wrap__struct_, exprs, eager, schema)
+struct_ <- function(exprs, eager, schema) .Call(wrap__struct_, exprs, eager, schema)
 
-rb_list_to_df = function(r_batches, names) .Call(wrap__rb_list_to_df, r_batches, names)
+rb_list_to_df <- function(r_batches, names) .Call(wrap__rb_list_to_df, r_batches, names)
 
-dtype_str_repr = function(dtype) .Call(wrap__dtype_str_repr, dtype)
+dtype_str_repr <- function(dtype) .Call(wrap__dtype_str_repr, dtype)
 
-new_arrow_stream = function() .Call(wrap__new_arrow_stream)
+new_arrow_stream <- function() .Call(wrap__new_arrow_stream)
 
-arrow_stream_to_df = function(robj_str) .Call(wrap__arrow_stream_to_df, robj_str)
+arrow_stream_to_df <- function(robj_str) .Call(wrap__arrow_stream_to_df, robj_str)
 
-arrow_stream_to_series = function(robj_str) .Call(wrap__arrow_stream_to_series, robj_str)
+arrow_stream_to_series <- function(robj_str) .Call(wrap__arrow_stream_to_series, robj_str)
 
-export_df_to_arrow_stream = function(robj_df, robj_str) .Call(wrap__export_df_to_arrow_stream, robj_df, robj_str)
+export_df_to_arrow_stream <- function(robj_df, robj_str) .Call(wrap__export_df_to_arrow_stream, robj_df, robj_str)
 
-mem_address = function(robj) .Call(wrap__mem_address, robj)
+mem_address <- function(robj) .Call(wrap__mem_address, robj)
 
-clone_robj = function(robj) .Call(wrap__clone_robj, robj)
+clone_robj <- function(robj) .Call(wrap__clone_robj, robj)
 
-test_robj_to_usize = function(robj) .Call(wrap__test_robj_to_usize, robj)
+test_robj_to_usize <- function(robj) .Call(wrap__test_robj_to_usize, robj)
 
-test_robj_to_f64 = function(robj) .Call(wrap__test_robj_to_f64, robj)
+test_robj_to_f64 <- function(robj) .Call(wrap__test_robj_to_f64, robj)
 
-test_robj_to_i64 = function(robj) .Call(wrap__test_robj_to_i64, robj)
+test_robj_to_i64 <- function(robj) .Call(wrap__test_robj_to_i64, robj)
 
-test_robj_to_u32 = function(robj) .Call(wrap__test_robj_to_u32, robj)
+test_robj_to_u32 <- function(robj) .Call(wrap__test_robj_to_u32, robj)
 
-test_robj_to_i32 = function(robj) .Call(wrap__test_robj_to_i32, robj)
+test_robj_to_i32 <- function(robj) .Call(wrap__test_robj_to_i32, robj)
 
-test_print_string = function(s) invisible(.Call(wrap__test_print_string, s))
+test_print_string <- function(s) invisible(.Call(wrap__test_print_string, s))
 
-test_robj_to_expr = function(robj) .Call(wrap__test_robj_to_expr, robj)
+test_robj_to_expr <- function(robj) .Call(wrap__test_robj_to_expr, robj)
 
-test_wrong_call_pl_lit = function(robj) .Call(wrap__test_wrong_call_pl_lit, robj)
+test_wrong_call_pl_lit <- function(robj) .Call(wrap__test_wrong_call_pl_lit, robj)
 
-test_robj_to_rchoice = function(robj) .Call(wrap__test_robj_to_rchoice, robj)
+test_robj_to_rchoice <- function(robj) .Call(wrap__test_robj_to_rchoice, robj)
 
-concat_lf = function(l, rechunk, parallel, to_supertypes) .Call(wrap__concat_lf, l, rechunk, parallel, to_supertypes)
+concat_lf <- function(l, rechunk, parallel, to_supertypes) .Call(wrap__concat_lf, l, rechunk, parallel, to_supertypes)
 
-concat_lf_diagonal = function(l, rechunk, parallel, to_supertypes) .Call(wrap__concat_lf_diagonal, l, rechunk, parallel, to_supertypes)
+concat_lf_diagonal <- function(l, rechunk, parallel, to_supertypes) .Call(wrap__concat_lf_diagonal, l, rechunk, parallel, to_supertypes)
 
-concat_df_horizontal = function(l) .Call(wrap__concat_df_horizontal, l)
+concat_df_horizontal <- function(l) .Call(wrap__concat_df_horizontal, l)
 
-concat_series = function(l, rechunk, to_supertypes) .Call(wrap__concat_series, l, rechunk, to_supertypes)
+concat_series <- function(l, rechunk, to_supertypes) .Call(wrap__concat_series, l, rechunk, to_supertypes)
 
-new_from_csv = function(path, has_header, separator, comment_char, quote_char, skip_rows, dtypes, null_values, ignore_errors, cache, infer_schema_length, n_rows, encoding, low_memory, rechunk, skip_rows_after_header, row_count_name, row_count_offset, try_parse_dates, eol_char, raise_if_empty, truncate_ragged_lines) .Call(wrap__new_from_csv, path, has_header, separator, comment_char, quote_char, skip_rows, dtypes, null_values, ignore_errors, cache, infer_schema_length, n_rows, encoding, low_memory, rechunk, skip_rows_after_header, row_count_name, row_count_offset, try_parse_dates, eol_char, raise_if_empty, truncate_ragged_lines)
+new_from_csv <- function(path, has_header, separator, comment_char, quote_char, skip_rows, dtypes, null_values, ignore_errors, cache, infer_schema_length, n_rows, encoding, low_memory, rechunk, skip_rows_after_header, row_count_name, row_count_offset, try_parse_dates, eol_char, raise_if_empty, truncate_ragged_lines) .Call(wrap__new_from_csv, path, has_header, separator, comment_char, quote_char, skip_rows, dtypes, null_values, ignore_errors, cache, infer_schema_length, n_rows, encoding, low_memory, rechunk, skip_rows_after_header, row_count_name, row_count_offset, try_parse_dates, eol_char, raise_if_empty, truncate_ragged_lines)
 
-import_arrow_ipc = function(path, n_rows, cache, rechunk, row_name, row_count, memmap) .Call(wrap__import_arrow_ipc, path, n_rows, cache, rechunk, row_name, row_count, memmap)
+import_arrow_ipc <- function(path, n_rows, cache, rechunk, row_name, row_count, memmap) .Call(wrap__import_arrow_ipc, path, n_rows, cache, rechunk, row_name, row_count, memmap)
 
-new_from_ndjson = function(path, infer_schema_length, batch_size, n_rows, low_memory, rechunk, row_count_name, row_count_offset) .Call(wrap__new_from_ndjson, path, infer_schema_length, batch_size, n_rows, low_memory, rechunk, row_count_name, row_count_offset)
+new_from_ndjson <- function(path, infer_schema_length, batch_size, n_rows, low_memory, rechunk, row_count_name, row_count_offset) .Call(wrap__new_from_ndjson, path, infer_schema_length, batch_size, n_rows, low_memory, rechunk, row_count_name, row_count_offset)
 
-new_from_parquet = function(path, n_rows, cache, parallel, rechunk, row_name, row_count, use_statistics, low_memory, hive_partitioning) .Call(wrap__new_from_parquet, path, n_rows, cache, parallel, rechunk, row_name, row_count, use_statistics, low_memory, hive_partitioning)
+new_from_parquet <- function(path, n_rows, cache, parallel, rechunk, row_name, row_count, use_statistics, low_memory, hive_partitioning) .Call(wrap__new_from_parquet, path, n_rows, cache, parallel, rechunk, row_name, row_count, use_statistics, low_memory, hive_partitioning)
 
-test_rpolarserr = function() .Call(wrap__test_rpolarserr)
+test_rpolarserr <- function() .Call(wrap__test_rpolarserr)
 
-setup_renv = function() .Call(wrap__setup_renv)
+setup_renv <- function() .Call(wrap__setup_renv)
 
-set_global_rpool_cap = function(c) .Call(wrap__set_global_rpool_cap, c)
+set_global_rpool_cap <- function(c) .Call(wrap__set_global_rpool_cap, c)
 
-get_global_rpool_cap = function() .Call(wrap__get_global_rpool_cap)
+get_global_rpool_cap <- function() .Call(wrap__get_global_rpool_cap)
 
-handle_background_request = function(server_name) .Call(wrap__handle_background_request, server_name)
+handle_background_request <- function(server_name) .Call(wrap__handle_background_request, server_name)
 
-test_rbackgroundhandler = function(lambda, arg) .Call(wrap__test_rbackgroundhandler, lambda, arg)
+test_rbackgroundhandler <- function(lambda, arg) .Call(wrap__test_rbackgroundhandler, lambda, arg)
 
-test_rthreadhandle = function() .Call(wrap__test_rthreadhandle)
+test_rthreadhandle <- function() .Call(wrap__test_rthreadhandle)
 
-test_serde_df = function(df) .Call(wrap__test_serde_df, df)
+test_serde_df <- function(df) .Call(wrap__test_serde_df, df)
 
-internal_wrap_e = function(robj, str_to_lit) .Call(wrap__internal_wrap_e, robj, str_to_lit)
+internal_wrap_e <- function(robj, str_to_lit) .Call(wrap__internal_wrap_e, robj, str_to_lit)
 
-robj_to_col = function(name, dotdotdot) .Call(wrap__robj_to_col, name, dotdotdot)
+robj_to_col <- function(name, dotdotdot) .Call(wrap__robj_to_col, name, dotdotdot)
 
-cargo_rpolars_feature_info = function() .Call(wrap__cargo_rpolars_feature_info)
+cargo_rpolars_feature_info <- function() .Call(wrap__cargo_rpolars_feature_info)
 
-rust_polars_version = function() .Call(wrap__rust_polars_version)
+rust_polars_version <- function() .Call(wrap__rust_polars_version)
 
-enable_string_cache = function() .Call(wrap__enable_string_cache)
+enable_string_cache <- function() .Call(wrap__enable_string_cache)
 
-disable_string_cache = function() .Call(wrap__disable_string_cache)
+disable_string_cache <- function() .Call(wrap__disable_string_cache)
 
-using_string_cache = function() .Call(wrap__using_string_cache)
+using_string_cache <- function() .Call(wrap__using_string_cache)
 
-RPolarsDataFrame = new.env(parent = emptyenv())
+RPolarsDataFrame <- new.env(parent = emptyenv())
 
-RPolarsDataFrame$shape = function() .Call(wrap__RPolarsDataFrame__shape, self)
+RPolarsDataFrame$shape <- function() .Call(wrap__RPolarsDataFrame__shape, self)
 
-RPolarsDataFrame$n_chunks = function(strategy) .Call(wrap__RPolarsDataFrame__n_chunks, self, strategy)
+RPolarsDataFrame$n_chunks <- function(strategy) .Call(wrap__RPolarsDataFrame__n_chunks, self, strategy)
 
-RPolarsDataFrame$rechunk = function() .Call(wrap__RPolarsDataFrame__rechunk, self)
+RPolarsDataFrame$rechunk <- function() .Call(wrap__RPolarsDataFrame__rechunk, self)
 
-RPolarsDataFrame$clone_in_rust = function() .Call(wrap__RPolarsDataFrame__clone_in_rust, self)
+RPolarsDataFrame$clone_in_rust <- function() .Call(wrap__RPolarsDataFrame__clone_in_rust, self)
 
-RPolarsDataFrame$default = function() .Call(wrap__RPolarsDataFrame__default)
+RPolarsDataFrame$default <- function() .Call(wrap__RPolarsDataFrame__default)
 
-RPolarsDataFrame$lazy = function() .Call(wrap__RPolarsDataFrame__lazy, self)
+RPolarsDataFrame$lazy <- function() .Call(wrap__RPolarsDataFrame__lazy, self)
 
-RPolarsDataFrame$drop_all_in_place = function() invisible(.Call(wrap__RPolarsDataFrame__drop_all_in_place, self))
+RPolarsDataFrame$drop_all_in_place <- function() invisible(.Call(wrap__RPolarsDataFrame__drop_all_in_place, self))
 
-RPolarsDataFrame$new_with_capacity = function(capacity) .Call(wrap__RPolarsDataFrame__new_with_capacity, capacity)
+RPolarsDataFrame$new_with_capacity <- function(capacity) .Call(wrap__RPolarsDataFrame__new_with_capacity, capacity)
 
-RPolarsDataFrame$set_column_from_robj = function(robj, name) .Call(wrap__RPolarsDataFrame__set_column_from_robj, self, robj, name)
+RPolarsDataFrame$set_column_from_robj <- function(robj, name) .Call(wrap__RPolarsDataFrame__set_column_from_robj, self, robj, name)
 
-RPolarsDataFrame$set_column_from_series = function(x) .Call(wrap__RPolarsDataFrame__set_column_from_series, self, x)
+RPolarsDataFrame$set_column_from_series <- function(x) .Call(wrap__RPolarsDataFrame__set_column_from_series, self, x)
 
-RPolarsDataFrame$with_row_count = function(name, offset) .Call(wrap__RPolarsDataFrame__with_row_count, self, name, offset)
+RPolarsDataFrame$with_row_count <- function(name, offset) .Call(wrap__RPolarsDataFrame__with_row_count, self, name, offset)
 
-RPolarsDataFrame$print = function() .Call(wrap__RPolarsDataFrame__print, self)
+RPolarsDataFrame$print <- function() .Call(wrap__RPolarsDataFrame__print, self)
 
-RPolarsDataFrame$columns = function() .Call(wrap__RPolarsDataFrame__columns, self)
+RPolarsDataFrame$columns <- function() .Call(wrap__RPolarsDataFrame__columns, self)
 
-RPolarsDataFrame$set_column_names_mut = function(names) .Call(wrap__RPolarsDataFrame__set_column_names_mut, self, names)
+RPolarsDataFrame$set_column_names_mut <- function(names) .Call(wrap__RPolarsDataFrame__set_column_names_mut, self, names)
 
-RPolarsDataFrame$get_column = function(name) .Call(wrap__RPolarsDataFrame__get_column, self, name)
+RPolarsDataFrame$get_column <- function(name) .Call(wrap__RPolarsDataFrame__get_column, self, name)
 
-RPolarsDataFrame$get_columns = function() .Call(wrap__RPolarsDataFrame__get_columns, self)
+RPolarsDataFrame$get_columns <- function() .Call(wrap__RPolarsDataFrame__get_columns, self)
 
-RPolarsDataFrame$dtypes = function() .Call(wrap__RPolarsDataFrame__dtypes, self)
+RPolarsDataFrame$dtypes <- function() .Call(wrap__RPolarsDataFrame__dtypes, self)
 
-RPolarsDataFrame$dtype_strings = function() .Call(wrap__RPolarsDataFrame__dtype_strings, self)
+RPolarsDataFrame$dtype_strings <- function() .Call(wrap__RPolarsDataFrame__dtype_strings, self)
 
-RPolarsDataFrame$schema = function() .Call(wrap__RPolarsDataFrame__schema, self)
+RPolarsDataFrame$schema <- function() .Call(wrap__RPolarsDataFrame__schema, self)
 
-RPolarsDataFrame$to_list = function() .Call(wrap__RPolarsDataFrame__to_list, self)
+RPolarsDataFrame$to_list <- function() .Call(wrap__RPolarsDataFrame__to_list, self)
 
-RPolarsDataFrame$to_list_unwind = function() .Call(wrap__RPolarsDataFrame__to_list_unwind, self)
+RPolarsDataFrame$to_list_unwind <- function() .Call(wrap__RPolarsDataFrame__to_list_unwind, self)
 
-RPolarsDataFrame$to_list_tag_structs = function() .Call(wrap__RPolarsDataFrame__to_list_tag_structs, self)
+RPolarsDataFrame$to_list_tag_structs <- function() .Call(wrap__RPolarsDataFrame__to_list_tag_structs, self)
 
-RPolarsDataFrame$frame_equal = function(other) .Call(wrap__RPolarsDataFrame__frame_equal, self, other)
+RPolarsDataFrame$frame_equal <- function(other) .Call(wrap__RPolarsDataFrame__frame_equal, self, other)
 
-RPolarsDataFrame$select_at_idx = function(idx) .Call(wrap__RPolarsDataFrame__select_at_idx, self, idx)
+RPolarsDataFrame$select_at_idx <- function(idx) .Call(wrap__RPolarsDataFrame__select_at_idx, self, idx)
 
-RPolarsDataFrame$drop_in_place = function(names) .Call(wrap__RPolarsDataFrame__drop_in_place, self, names)
+RPolarsDataFrame$drop_in_place <- function(names) .Call(wrap__RPolarsDataFrame__drop_in_place, self, names)
 
-RPolarsDataFrame$select = function(exprs) .Call(wrap__RPolarsDataFrame__select, self, exprs)
+RPolarsDataFrame$select <- function(exprs) .Call(wrap__RPolarsDataFrame__select, self, exprs)
 
-RPolarsDataFrame$with_columns = function(exprs) .Call(wrap__RPolarsDataFrame__with_columns, self, exprs)
+RPolarsDataFrame$with_columns <- function(exprs) .Call(wrap__RPolarsDataFrame__with_columns, self, exprs)
 
-RPolarsDataFrame$by_agg = function(group_exprs, agg_exprs, maintain_order) .Call(wrap__RPolarsDataFrame__by_agg, self, group_exprs, agg_exprs, maintain_order)
+RPolarsDataFrame$by_agg <- function(group_exprs, agg_exprs, maintain_order) .Call(wrap__RPolarsDataFrame__by_agg, self, group_exprs, agg_exprs, maintain_order)
 
-RPolarsDataFrame$to_struct = function(name) .Call(wrap__RPolarsDataFrame__to_struct, self, name)
+RPolarsDataFrame$to_struct <- function(name) .Call(wrap__RPolarsDataFrame__to_struct, self, name)
 
-RPolarsDataFrame$unnest = function(names) .Call(wrap__RPolarsDataFrame__unnest, self, names)
+RPolarsDataFrame$unnest <- function(names) .Call(wrap__RPolarsDataFrame__unnest, self, names)
 
-RPolarsDataFrame$export_stream = function(stream_ptr) invisible(.Call(wrap__RPolarsDataFrame__export_stream, self, stream_ptr))
+RPolarsDataFrame$export_stream <- function(stream_ptr) invisible(.Call(wrap__RPolarsDataFrame__export_stream, self, stream_ptr))
 
-RPolarsDataFrame$from_arrow_record_batches = function(rbr) .Call(wrap__RPolarsDataFrame__from_arrow_record_batches, rbr)
+RPolarsDataFrame$from_arrow_record_batches <- function(rbr) .Call(wrap__RPolarsDataFrame__from_arrow_record_batches, rbr)
 
-RPolarsDataFrame$estimated_size = function() .Call(wrap__RPolarsDataFrame__estimated_size, self)
+RPolarsDataFrame$estimated_size <- function() .Call(wrap__RPolarsDataFrame__estimated_size, self)
 
-RPolarsDataFrame$null_count = function() .Call(wrap__RPolarsDataFrame__null_count, self)
+RPolarsDataFrame$null_count <- function() .Call(wrap__RPolarsDataFrame__null_count, self)
 
-RPolarsDataFrame$melt = function(id_vars, value_vars, value_name, variable_name) .Call(wrap__RPolarsDataFrame__melt, self, id_vars, value_vars, value_name, variable_name)
+RPolarsDataFrame$melt <- function(id_vars, value_vars, value_name, variable_name) .Call(wrap__RPolarsDataFrame__melt, self, id_vars, value_vars, value_name, variable_name)
 
-RPolarsDataFrame$pivot_expr = function(values, index, columns, maintain_order, sort_columns, aggregate_expr, separator) .Call(wrap__RPolarsDataFrame__pivot_expr, self, values, index, columns, maintain_order, sort_columns, aggregate_expr, separator)
+RPolarsDataFrame$pivot_expr <- function(values, index, columns, maintain_order, sort_columns, aggregate_expr, separator) .Call(wrap__RPolarsDataFrame__pivot_expr, self, values, index, columns, maintain_order, sort_columns, aggregate_expr, separator)
 
-RPolarsDataFrame$sample_n = function(n, with_replacement, shuffle, seed) .Call(wrap__RPolarsDataFrame__sample_n, self, n, with_replacement, shuffle, seed)
+RPolarsDataFrame$sample_n <- function(n, with_replacement, shuffle, seed) .Call(wrap__RPolarsDataFrame__sample_n, self, n, with_replacement, shuffle, seed)
 
-RPolarsDataFrame$sample_frac = function(frac, with_replacement, shuffle, seed) .Call(wrap__RPolarsDataFrame__sample_frac, self, frac, with_replacement, shuffle, seed)
+RPolarsDataFrame$sample_frac <- function(frac, with_replacement, shuffle, seed) .Call(wrap__RPolarsDataFrame__sample_frac, self, frac, with_replacement, shuffle, seed)
 
-RPolarsDataFrame$transpose = function(keep_names_as, new_col_names) .Call(wrap__RPolarsDataFrame__transpose, self, keep_names_as, new_col_names)
+RPolarsDataFrame$transpose <- function(keep_names_as, new_col_names) .Call(wrap__RPolarsDataFrame__transpose, self, keep_names_as, new_col_names)
 
-RPolarsDataFrame$write_csv = function(path, include_bom, include_header, separator, line_terminator, quote, batch_size, datetime_format, date_format, time_format, float_precision, null_value, quote_style) .Call(wrap__RPolarsDataFrame__write_csv, self, path, include_bom, include_header, separator, line_terminator, quote, batch_size, datetime_format, date_format, time_format, float_precision, null_value, quote_style)
+RPolarsDataFrame$write_csv <- function(path, include_bom, include_header, separator, line_terminator, quote, batch_size, datetime_format, date_format, time_format, float_precision, null_value, quote_style) .Call(wrap__RPolarsDataFrame__write_csv, self, path, include_bom, include_header, separator, line_terminator, quote, batch_size, datetime_format, date_format, time_format, float_precision, null_value, quote_style)
 
-RPolarsDataFrame$write_json = function(file, pretty, row_oriented) .Call(wrap__RPolarsDataFrame__write_json, self, file, pretty, row_oriented)
+RPolarsDataFrame$write_json <- function(file, pretty, row_oriented) .Call(wrap__RPolarsDataFrame__write_json, self, file, pretty, row_oriented)
 
-RPolarsDataFrame$write_ndjson = function(file) .Call(wrap__RPolarsDataFrame__write_ndjson, self, file)
+RPolarsDataFrame$write_ndjson <- function(file) .Call(wrap__RPolarsDataFrame__write_ndjson, self, file)
 
 #' @export
-`$.RPolarsDataFrame` = function(self, name) {
-  func = RPolarsDataFrame[[name]]
-  environment(func) = environment()
-  func
-}
+`$.RPolarsDataFrame` <- function (self, name) { func <- RPolarsDataFrame[[name]]; environment(func) <- environment(); func }
 
 #' @export
-`[[.RPolarsDataFrame` = `$.RPolarsDataFrame`
+`[[.RPolarsDataFrame` <- `$.RPolarsDataFrame`
 
-RPolarsVecDataFrame = new.env(parent = emptyenv())
+RPolarsVecDataFrame <- new.env(parent = emptyenv())
 
-RPolarsVecDataFrame$with_capacity = function(n) .Call(wrap__RPolarsVecDataFrame__with_capacity, n)
+RPolarsVecDataFrame$with_capacity <- function(n) .Call(wrap__RPolarsVecDataFrame__with_capacity, n)
 
-RPolarsVecDataFrame$push = function(df) invisible(.Call(wrap__RPolarsVecDataFrame__push, self, df))
+RPolarsVecDataFrame$push <- function(df) invisible(.Call(wrap__RPolarsVecDataFrame__push, self, df))
 
-RPolarsVecDataFrame$print = function() invisible(.Call(wrap__RPolarsVecDataFrame__print, self))
-
-#' @export
-`$.RPolarsVecDataFrame` = function(self, name) {
-  func = RPolarsVecDataFrame[[name]]
-  environment(func) = environment()
-  func
-}
+RPolarsVecDataFrame$print <- function() invisible(.Call(wrap__RPolarsVecDataFrame__print, self))
 
 #' @export
-`[[.RPolarsVecDataFrame` = `$.RPolarsVecDataFrame`
-
-RPolarsRNullValues = new.env(parent = emptyenv())
-
-RPolarsRNullValues$new_all_columns = function(x) .Call(wrap__RPolarsRNullValues__new_all_columns, x)
-
-RPolarsRNullValues$new_columns = function(x) .Call(wrap__RPolarsRNullValues__new_columns, x)
-
-RPolarsRNullValues$new_named = function(robj) .Call(wrap__RPolarsRNullValues__new_named, robj)
+`$.RPolarsVecDataFrame` <- function (self, name) { func <- RPolarsVecDataFrame[[name]]; environment(func) <- environment(); func }
 
 #' @export
-`$.RPolarsRNullValues` = function(self, name) {
-  func = RPolarsRNullValues[[name]]
-  environment(func) = environment()
-  func
-}
+`[[.RPolarsVecDataFrame` <- `$.RPolarsVecDataFrame`
+
+RPolarsRNullValues <- new.env(parent = emptyenv())
+
+RPolarsRNullValues$new_all_columns <- function(x) .Call(wrap__RPolarsRNullValues__new_all_columns, x)
+
+RPolarsRNullValues$new_columns <- function(x) .Call(wrap__RPolarsRNullValues__new_columns, x)
+
+RPolarsRNullValues$new_named <- function(robj) .Call(wrap__RPolarsRNullValues__new_named, robj)
 
 #' @export
-`[[.RPolarsRNullValues` = `$.RPolarsRNullValues`
-
-RPolarsDataType = new.env(parent = emptyenv())
-
-RPolarsDataType$new = function(s) .Call(wrap__RPolarsDataType__new, s)
-
-RPolarsDataType$new_datetime = function(tu, tz) .Call(wrap__RPolarsDataType__new_datetime, tu, tz)
-
-RPolarsDataType$new_duration = function() .Call(wrap__RPolarsDataType__new_duration)
-
-RPolarsDataType$new_list = function(inner) .Call(wrap__RPolarsDataType__new_list, inner)
-
-RPolarsDataType$new_object = function() .Call(wrap__RPolarsDataType__new_object)
-
-RPolarsDataType$new_struct = function(l) .Call(wrap__RPolarsDataType__new_struct, l)
-
-RPolarsDataType$get_all_simple_type_names = function() .Call(wrap__RPolarsDataType__get_all_simple_type_names)
-
-RPolarsDataType$print = function() invisible(.Call(wrap__RPolarsDataType__print, self))
-
-RPolarsDataType$eq = function(other) .Call(wrap__RPolarsDataType__eq, self, other)
-
-RPolarsDataType$ne = function(other) .Call(wrap__RPolarsDataType__ne, self, other)
-
-RPolarsDataType$same_outer_datatype = function(other) .Call(wrap__RPolarsDataType__same_outer_datatype, self, other)
-
-RPolarsDataType$get_insides = function() .Call(wrap__RPolarsDataType__get_insides, self)
-
-RPolarsDataType$is_temporal = function() .Call(wrap__RPolarsDataType__is_temporal, self)
+`$.RPolarsRNullValues` <- function (self, name) { func <- RPolarsRNullValues[[name]]; environment(func) <- environment(); func }
 
 #' @export
-`$.RPolarsDataType` = function(self, name) {
-  func = RPolarsDataType[[name]]
-  environment(func) = environment()
-  func
-}
+`[[.RPolarsRNullValues` <- `$.RPolarsRNullValues`
+
+RPolarsDataType <- new.env(parent = emptyenv())
+
+RPolarsDataType$new <- function(s) .Call(wrap__RPolarsDataType__new, s)
+
+RPolarsDataType$new_datetime <- function(tu, tz) .Call(wrap__RPolarsDataType__new_datetime, tu, tz)
+
+RPolarsDataType$new_duration <- function() .Call(wrap__RPolarsDataType__new_duration)
+
+RPolarsDataType$new_list <- function(inner) .Call(wrap__RPolarsDataType__new_list, inner)
+
+RPolarsDataType$new_object <- function() .Call(wrap__RPolarsDataType__new_object)
+
+RPolarsDataType$new_struct <- function(l) .Call(wrap__RPolarsDataType__new_struct, l)
+
+RPolarsDataType$get_all_simple_type_names <- function() .Call(wrap__RPolarsDataType__get_all_simple_type_names)
+
+RPolarsDataType$print <- function() invisible(.Call(wrap__RPolarsDataType__print, self))
+
+RPolarsDataType$eq <- function(other) .Call(wrap__RPolarsDataType__eq, self, other)
+
+RPolarsDataType$ne <- function(other) .Call(wrap__RPolarsDataType__ne, self, other)
+
+RPolarsDataType$same_outer_datatype <- function(other) .Call(wrap__RPolarsDataType__same_outer_datatype, self, other)
+
+RPolarsDataType$get_insides <- function() .Call(wrap__RPolarsDataType__get_insides, self)
+
+RPolarsDataType$is_temporal <- function() .Call(wrap__RPolarsDataType__is_temporal, self)
 
 #' @export
-`[[.RPolarsDataType` = `$.RPolarsDataType`
-
-RPolarsDataTypeVector = new.env(parent = emptyenv())
-
-RPolarsDataTypeVector$new = function() .Call(wrap__RPolarsDataTypeVector__new)
-
-RPolarsDataTypeVector$push = function(colname, datatype) invisible(.Call(wrap__RPolarsDataTypeVector__push, self, colname, datatype))
-
-RPolarsDataTypeVector$print = function() invisible(.Call(wrap__RPolarsDataTypeVector__print, self))
-
-RPolarsDataTypeVector$from_rlist = function(list) .Call(wrap__RPolarsDataTypeVector__from_rlist, list)
+`$.RPolarsDataType` <- function (self, name) { func <- RPolarsDataType[[name]]; environment(func) <- environment(); func }
 
 #' @export
-`$.RPolarsDataTypeVector` = function(self, name) {
-  func = RPolarsDataTypeVector[[name]]
-  environment(func) = environment()
-  func
-}
+`[[.RPolarsDataType` <- `$.RPolarsDataType`
+
+RPolarsDataTypeVector <- new.env(parent = emptyenv())
+
+RPolarsDataTypeVector$new <- function() .Call(wrap__RPolarsDataTypeVector__new)
+
+RPolarsDataTypeVector$push <- function(colname, datatype) invisible(.Call(wrap__RPolarsDataTypeVector__push, self, colname, datatype))
+
+RPolarsDataTypeVector$print <- function() invisible(.Call(wrap__RPolarsDataTypeVector__print, self))
+
+RPolarsDataTypeVector$from_rlist <- function(list) .Call(wrap__RPolarsDataTypeVector__from_rlist, list)
 
 #' @export
-`[[.RPolarsDataTypeVector` = `$.RPolarsDataTypeVector`
-
-RPolarsRField = new.env(parent = emptyenv())
-
-RPolarsRField$new = function(name, datatype) .Call(wrap__RPolarsRField__new, name, datatype)
-
-RPolarsRField$print = function() invisible(.Call(wrap__RPolarsRField__print, self))
-
-RPolarsRField$clone = function() .Call(wrap__RPolarsRField__clone, self)
-
-RPolarsRField$get_name = function() .Call(wrap__RPolarsRField__get_name, self)
-
-RPolarsRField$get_datatype = function() .Call(wrap__RPolarsRField__get_datatype, self)
-
-RPolarsRField$set_name_mut = function(name) invisible(.Call(wrap__RPolarsRField__set_name_mut, self, name))
-
-RPolarsRField$set_datatype_mut = function(datatype) invisible(.Call(wrap__RPolarsRField__set_datatype_mut, self, datatype))
+`$.RPolarsDataTypeVector` <- function (self, name) { func <- RPolarsDataTypeVector[[name]]; environment(func) <- environment(); func }
 
 #' @export
-`$.RPolarsRField` = function(self, name) {
-  func = RPolarsRField[[name]]
-  environment(func) = environment()
-  func
-}
+`[[.RPolarsDataTypeVector` <- `$.RPolarsDataTypeVector`
+
+RPolarsRField <- new.env(parent = emptyenv())
+
+RPolarsRField$new <- function(name, datatype) .Call(wrap__RPolarsRField__new, name, datatype)
+
+RPolarsRField$print <- function() invisible(.Call(wrap__RPolarsRField__print, self))
+
+RPolarsRField$clone <- function() .Call(wrap__RPolarsRField__clone, self)
+
+RPolarsRField$get_name <- function() .Call(wrap__RPolarsRField__get_name, self)
+
+RPolarsRField$get_datatype <- function() .Call(wrap__RPolarsRField__get_datatype, self)
+
+RPolarsRField$set_name_mut <- function(name) invisible(.Call(wrap__RPolarsRField__set_name_mut, self, name))
+
+RPolarsRField$set_datatype_mut <- function(datatype) invisible(.Call(wrap__RPolarsRField__set_datatype_mut, self, datatype))
 
 #' @export
-`[[.RPolarsRField` = `$.RPolarsRField`
-
-RPolarsErr = new.env(parent = emptyenv())
-
-RPolarsErr$new = function() .Call(wrap__RPolarsErr__new)
-
-RPolarsErr$contexts = function() .Call(wrap__RPolarsErr__contexts, self)
-
-RPolarsErr$pretty_msg = function() .Call(wrap__RPolarsErr__pretty_msg, self)
-
-RPolarsErr$bad_arg = function(s) .Call(wrap__RPolarsErr__bad_arg, self, s)
-
-RPolarsErr$bad_robj = function(r) .Call(wrap__RPolarsErr__bad_robj, self, r)
-
-RPolarsErr$bad_val = function(s) .Call(wrap__RPolarsErr__bad_val, self, s)
-
-RPolarsErr$hint = function(s) .Call(wrap__RPolarsErr__hint, self, s)
-
-RPolarsErr$mistyped = function(s) .Call(wrap__RPolarsErr__mistyped, self, s)
-
-RPolarsErr$misvalued = function(s) .Call(wrap__RPolarsErr__misvalued, self, s)
-
-RPolarsErr$notachoice = function(s) .Call(wrap__RPolarsErr__notachoice, self, s)
-
-RPolarsErr$plain = function(s) .Call(wrap__RPolarsErr__plain, self, s)
-
-RPolarsErr$rcall = function(c) .Call(wrap__RPolarsErr__rcall, self, c)
-
-RPolarsErr$get_rcall = function() .Call(wrap__RPolarsErr__get_rcall, self)
-
-RPolarsErr$rinfo = function(i) .Call(wrap__RPolarsErr__rinfo, self, i)
-
-RPolarsErr$get_rinfo = function() .Call(wrap__RPolarsErr__get_rinfo, self)
-
-RPolarsErr$when = function(s) .Call(wrap__RPolarsErr__when, self, s)
+`$.RPolarsRField` <- function (self, name) { func <- RPolarsRField[[name]]; environment(func) <- environment(); func }
 
 #' @export
-`$.RPolarsErr` = function(self, name) {
-  func = RPolarsErr[[name]]
-  environment(func) = environment()
-  func
-}
+`[[.RPolarsRField` <- `$.RPolarsRField`
+
+RPolarsErr <- new.env(parent = emptyenv())
+
+RPolarsErr$new <- function() .Call(wrap__RPolarsErr__new)
+
+RPolarsErr$contexts <- function() .Call(wrap__RPolarsErr__contexts, self)
+
+RPolarsErr$pretty_msg <- function() .Call(wrap__RPolarsErr__pretty_msg, self)
+
+RPolarsErr$bad_arg <- function(s) .Call(wrap__RPolarsErr__bad_arg, self, s)
+
+RPolarsErr$bad_robj <- function(r) .Call(wrap__RPolarsErr__bad_robj, self, r)
+
+RPolarsErr$bad_val <- function(s) .Call(wrap__RPolarsErr__bad_val, self, s)
+
+RPolarsErr$hint <- function(s) .Call(wrap__RPolarsErr__hint, self, s)
+
+RPolarsErr$mistyped <- function(s) .Call(wrap__RPolarsErr__mistyped, self, s)
+
+RPolarsErr$misvalued <- function(s) .Call(wrap__RPolarsErr__misvalued, self, s)
+
+RPolarsErr$notachoice <- function(s) .Call(wrap__RPolarsErr__notachoice, self, s)
+
+RPolarsErr$plain <- function(s) .Call(wrap__RPolarsErr__plain, self, s)
+
+RPolarsErr$rcall <- function(c) .Call(wrap__RPolarsErr__rcall, self, c)
+
+RPolarsErr$get_rcall <- function() .Call(wrap__RPolarsErr__get_rcall, self)
+
+RPolarsErr$rinfo <- function(i) .Call(wrap__RPolarsErr__rinfo, self, i)
+
+RPolarsErr$get_rinfo <- function() .Call(wrap__RPolarsErr__get_rinfo, self)
+
+RPolarsErr$when <- function(s) .Call(wrap__RPolarsErr__when, self, s)
 
 #' @export
-`[[.RPolarsErr` = `$.RPolarsErr`
-
-RPolarsRThreadHandle = new.env(parent = emptyenv())
-
-RPolarsRThreadHandle$join = function() .Call(wrap__RPolarsRThreadHandle__join, self)
-
-RPolarsRThreadHandle$is_finished = function() .Call(wrap__RPolarsRThreadHandle__is_finished, self)
-
-RPolarsRThreadHandle$thread_description = function() .Call(wrap__RPolarsRThreadHandle__thread_description, self)
+`$.RPolarsErr` <- function (self, name) { func <- RPolarsErr[[name]]; environment(func) <- environment(); func }
 
 #' @export
-`$.RPolarsRThreadHandle` = function(self, name) {
-  func = RPolarsRThreadHandle[[name]]
-  environment(func) = environment()
-  func
-}
+`[[.RPolarsErr` <- `$.RPolarsErr`
+
+RPolarsRThreadHandle <- new.env(parent = emptyenv())
+
+RPolarsRThreadHandle$join <- function() .Call(wrap__RPolarsRThreadHandle__join, self)
+
+RPolarsRThreadHandle$is_finished <- function() .Call(wrap__RPolarsRThreadHandle__is_finished, self)
+
+RPolarsRThreadHandle$thread_description <- function() .Call(wrap__RPolarsRThreadHandle__thread_description, self)
 
 #' @export
-`[[.RPolarsRThreadHandle` = `$.RPolarsRThreadHandle`
-
-RPolarsWhen = new.env(parent = emptyenv())
-
-RPolarsWhen$new = function(condition) .Call(wrap__RPolarsWhen__new, condition)
-
-RPolarsWhen$then = function(statement) .Call(wrap__RPolarsWhen__then, self, statement)
+`$.RPolarsRThreadHandle` <- function (self, name) { func <- RPolarsRThreadHandle[[name]]; environment(func) <- environment(); func }
 
 #' @export
-`$.RPolarsWhen` = function(self, name) {
-  func = RPolarsWhen[[name]]
-  environment(func) = environment()
-  func
-}
+`[[.RPolarsRThreadHandle` <- `$.RPolarsRThreadHandle`
+
+RPolarsWhen <- new.env(parent = emptyenv())
+
+RPolarsWhen$new <- function(condition) .Call(wrap__RPolarsWhen__new, condition)
+
+RPolarsWhen$then <- function(statement) .Call(wrap__RPolarsWhen__then, self, statement)
 
 #' @export
-`[[.RPolarsWhen` = `$.RPolarsWhen`
-
-RPolarsThen = new.env(parent = emptyenv())
-
-RPolarsThen$when = function(condition) .Call(wrap__RPolarsThen__when, self, condition)
-
-RPolarsThen$otherwise = function(statement) .Call(wrap__RPolarsThen__otherwise, self, statement)
+`$.RPolarsWhen` <- function (self, name) { func <- RPolarsWhen[[name]]; environment(func) <- environment(); func }
 
 #' @export
-`$.RPolarsThen` = function(self, name) {
-  func = RPolarsThen[[name]]
-  environment(func) = environment()
-  func
-}
+`[[.RPolarsWhen` <- `$.RPolarsWhen`
+
+RPolarsThen <- new.env(parent = emptyenv())
+
+RPolarsThen$when <- function(condition) .Call(wrap__RPolarsThen__when, self, condition)
+
+RPolarsThen$otherwise <- function(statement) .Call(wrap__RPolarsThen__otherwise, self, statement)
 
 #' @export
-`[[.RPolarsThen` = `$.RPolarsThen`
-
-RPolarsChainedWhen = new.env(parent = emptyenv())
-
-RPolarsChainedWhen$then = function(statement) .Call(wrap__RPolarsChainedWhen__then, self, statement)
+`$.RPolarsThen` <- function (self, name) { func <- RPolarsThen[[name]]; environment(func) <- environment(); func }
 
 #' @export
-`$.RPolarsChainedWhen` = function(self, name) {
-  func = RPolarsChainedWhen[[name]]
-  environment(func) = environment()
-  func
-}
+`[[.RPolarsThen` <- `$.RPolarsThen`
+
+RPolarsChainedWhen <- new.env(parent = emptyenv())
+
+RPolarsChainedWhen$then <- function(statement) .Call(wrap__RPolarsChainedWhen__then, self, statement)
 
 #' @export
-`[[.RPolarsChainedWhen` = `$.RPolarsChainedWhen`
-
-RPolarsChainedThen = new.env(parent = emptyenv())
-
-RPolarsChainedThen$when = function(condition) .Call(wrap__RPolarsChainedThen__when, self, condition)
-
-RPolarsChainedThen$otherwise = function(statement) .Call(wrap__RPolarsChainedThen__otherwise, self, statement)
+`$.RPolarsChainedWhen` <- function (self, name) { func <- RPolarsChainedWhen[[name]]; environment(func) <- environment(); func }
 
 #' @export
-`$.RPolarsChainedThen` = function(self, name) {
-  func = RPolarsChainedThen[[name]]
-  environment(func) = environment()
-  func
-}
+`[[.RPolarsChainedWhen` <- `$.RPolarsChainedWhen`
+
+RPolarsChainedThen <- new.env(parent = emptyenv())
+
+RPolarsChainedThen$when <- function(condition) .Call(wrap__RPolarsChainedThen__when, self, condition)
+
+RPolarsChainedThen$otherwise <- function(statement) .Call(wrap__RPolarsChainedThen__otherwise, self, statement)
 
 #' @export
-`[[.RPolarsChainedThen` = `$.RPolarsChainedThen`
-
-RPolarsExpr = new.env(parent = emptyenv())
-
-RPolarsExpr$col = function(name) .Call(wrap__RPolarsExpr__col, name)
-
-RPolarsExpr$dtype_cols = function(dtypes) .Call(wrap__RPolarsExpr__dtype_cols, dtypes)
-
-RPolarsExpr$cols = function(names) .Call(wrap__RPolarsExpr__cols, names)
-
-RPolarsExpr$lit = function(robj) .Call(wrap__RPolarsExpr__lit, robj)
-
-RPolarsExpr$gt = function(other) .Call(wrap__RPolarsExpr__gt, self, other)
-
-RPolarsExpr$gt_eq = function(other) .Call(wrap__RPolarsExpr__gt_eq, self, other)
-
-RPolarsExpr$lt = function(other) .Call(wrap__RPolarsExpr__lt, self, other)
-
-RPolarsExpr$lt_eq = function(other) .Call(wrap__RPolarsExpr__lt_eq, self, other)
-
-RPolarsExpr$neq = function(other) .Call(wrap__RPolarsExpr__neq, self, other)
-
-RPolarsExpr$neq_missing = function(other) .Call(wrap__RPolarsExpr__neq_missing, self, other)
-
-RPolarsExpr$eq = function(other) .Call(wrap__RPolarsExpr__eq, self, other)
-
-RPolarsExpr$eq_missing = function(other) .Call(wrap__RPolarsExpr__eq_missing, self, other)
-
-RPolarsExpr$and = function(other) .Call(wrap__RPolarsExpr__and, self, other)
-
-RPolarsExpr$or = function(other) .Call(wrap__RPolarsExpr__or, self, other)
-
-RPolarsExpr$xor = function(other) .Call(wrap__RPolarsExpr__xor, self, other)
-
-RPolarsExpr$to_physical = function() .Call(wrap__RPolarsExpr__to_physical, self)
-
-RPolarsExpr$cast = function(data_type, strict) .Call(wrap__RPolarsExpr__cast, self, data_type, strict)
-
-RPolarsExpr$sort = function(descending, nulls_last) .Call(wrap__RPolarsExpr__sort, self, descending, nulls_last)
-
-RPolarsExpr$arg_sort = function(descending, nulls_last) .Call(wrap__RPolarsExpr__arg_sort, self, descending, nulls_last)
-
-RPolarsExpr$top_k = function(k) .Call(wrap__RPolarsExpr__top_k, self, k)
-
-RPolarsExpr$bottom_k = function(k) .Call(wrap__RPolarsExpr__bottom_k, self, k)
-
-RPolarsExpr$arg_max = function() .Call(wrap__RPolarsExpr__arg_max, self)
-
-RPolarsExpr$arg_min = function() .Call(wrap__RPolarsExpr__arg_min, self)
-
-RPolarsExpr$search_sorted = function(element) .Call(wrap__RPolarsExpr__search_sorted, self, element)
-
-RPolarsExpr$gather = function(idx) .Call(wrap__RPolarsExpr__gather, self, idx)
-
-RPolarsExpr$sort_by = function(by, descending) .Call(wrap__RPolarsExpr__sort_by, self, by, descending)
-
-RPolarsExpr$backward_fill = function(limit) .Call(wrap__RPolarsExpr__backward_fill, self, limit)
-
-RPolarsExpr$forward_fill = function(limit) .Call(wrap__RPolarsExpr__forward_fill, self, limit)
-
-RPolarsExpr$shift = function(periods) .Call(wrap__RPolarsExpr__shift, self, periods)
-
-RPolarsExpr$shift_and_fill = function(periods, fill_value) .Call(wrap__RPolarsExpr__shift_and_fill, self, periods, fill_value)
-
-RPolarsExpr$fill_null = function(expr) .Call(wrap__RPolarsExpr__fill_null, self, expr)
-
-RPolarsExpr$fill_null_with_strategy = function(strategy, limit) .Call(wrap__RPolarsExpr__fill_null_with_strategy, self, strategy, limit)
-
-RPolarsExpr$fill_nan = function(expr) .Call(wrap__RPolarsExpr__fill_nan, self, expr)
-
-RPolarsExpr$reverse = function() .Call(wrap__RPolarsExpr__reverse, self)
-
-RPolarsExpr$std = function(ddof) .Call(wrap__RPolarsExpr__std, self, ddof)
-
-RPolarsExpr$var = function(ddof) .Call(wrap__RPolarsExpr__var, self, ddof)
-
-RPolarsExpr$max = function() .Call(wrap__RPolarsExpr__max, self)
-
-RPolarsExpr$min = function() .Call(wrap__RPolarsExpr__min, self)
-
-RPolarsExpr$nan_min = function() .Call(wrap__RPolarsExpr__nan_min, self)
-
-RPolarsExpr$nan_max = function() .Call(wrap__RPolarsExpr__nan_max, self)
-
-RPolarsExpr$mean = function() .Call(wrap__RPolarsExpr__mean, self)
-
-RPolarsExpr$median = function() .Call(wrap__RPolarsExpr__median, self)
-
-RPolarsExpr$sum = function() .Call(wrap__RPolarsExpr__sum, self)
-
-RPolarsExpr$product = function() .Call(wrap__RPolarsExpr__product, self)
-
-RPolarsExpr$n_unique = function() .Call(wrap__RPolarsExpr__n_unique, self)
-
-RPolarsExpr$null_count = function() .Call(wrap__RPolarsExpr__null_count, self)
-
-RPolarsExpr$arg_unique = function() .Call(wrap__RPolarsExpr__arg_unique, self)
-
-RPolarsExpr$quantile = function(quantile, interpolation) .Call(wrap__RPolarsExpr__quantile, self, quantile, interpolation)
-
-RPolarsExpr$filter = function(predicate) .Call(wrap__RPolarsExpr__filter, self, predicate)
-
-RPolarsExpr$explode = function() .Call(wrap__RPolarsExpr__explode, self)
-
-RPolarsExpr$flatten = function() .Call(wrap__RPolarsExpr__flatten, self)
-
-RPolarsExpr$gather_every = function(n) .Call(wrap__RPolarsExpr__gather_every, self, n)
-
-RPolarsExpr$hash = function(seed, seed_1, seed_2, seed_3) .Call(wrap__RPolarsExpr__hash, self, seed, seed_1, seed_2, seed_3)
-
-RPolarsExpr$reinterpret = function(signed) .Call(wrap__RPolarsExpr__reinterpret, self, signed)
-
-RPolarsExpr$interpolate = function(method) .Call(wrap__RPolarsExpr__interpolate, self, method)
-
-RPolarsExpr$rolling_min = function(window_size, weights, min_periods, center, by_null, closed_null) .Call(wrap__RPolarsExpr__rolling_min, self, window_size, weights, min_periods, center, by_null, closed_null)
-
-RPolarsExpr$rolling_max = function(window_size, weights, min_periods, center, by_null, closed_null) .Call(wrap__RPolarsExpr__rolling_max, self, window_size, weights, min_periods, center, by_null, closed_null)
-
-RPolarsExpr$rolling_mean = function(window_size, weights, min_periods, center, by_null, closed_null) .Call(wrap__RPolarsExpr__rolling_mean, self, window_size, weights, min_periods, center, by_null, closed_null)
-
-RPolarsExpr$rolling_sum = function(window_size, weights, min_periods, center, by_null, closed_null) .Call(wrap__RPolarsExpr__rolling_sum, self, window_size, weights, min_periods, center, by_null, closed_null)
-
-RPolarsExpr$rolling_std = function(window_size, weights, min_periods, center, by_null, closed_null) .Call(wrap__RPolarsExpr__rolling_std, self, window_size, weights, min_periods, center, by_null, closed_null)
-
-RPolarsExpr$rolling_var = function(window_size, weights, min_periods, center, by_null, closed_null) .Call(wrap__RPolarsExpr__rolling_var, self, window_size, weights, min_periods, center, by_null, closed_null)
-
-RPolarsExpr$rolling_median = function(window_size, weights, min_periods, center, by_null, closed_null) .Call(wrap__RPolarsExpr__rolling_median, self, window_size, weights, min_periods, center, by_null, closed_null)
-
-RPolarsExpr$rolling_quantile = function(quantile, interpolation, window_size, weights, min_periods, center, by, closed) .Call(wrap__RPolarsExpr__rolling_quantile, self, quantile, interpolation, window_size, weights, min_periods, center, by, closed)
-
-RPolarsExpr$rolling_skew = function(window_size_f, bias) .Call(wrap__RPolarsExpr__rolling_skew, self, window_size_f, bias)
-
-RPolarsExpr$abs = function() .Call(wrap__RPolarsExpr__abs, self)
-
-RPolarsExpr$rank = function(method, descending) .Call(wrap__RPolarsExpr__rank, self, method, descending)
-
-RPolarsExpr$diff = function(n_float, null_behavior) .Call(wrap__RPolarsExpr__diff, self, n_float, null_behavior)
-
-RPolarsExpr$pct_change = function(n_float) .Call(wrap__RPolarsExpr__pct_change, self, n_float)
-
-RPolarsExpr$skew = function(bias) .Call(wrap__RPolarsExpr__skew, self, bias)
-
-RPolarsExpr$kurtosis = function(fisher, bias) .Call(wrap__RPolarsExpr__kurtosis, self, fisher, bias)
-
-RPolarsExpr$clip = function(min, max) .Call(wrap__RPolarsExpr__clip, self, min, max)
-
-RPolarsExpr$clip_min = function(min) .Call(wrap__RPolarsExpr__clip_min, self, min)
-
-RPolarsExpr$clip_max = function(max) .Call(wrap__RPolarsExpr__clip_max, self, max)
-
-RPolarsExpr$lower_bound = function() .Call(wrap__RPolarsExpr__lower_bound, self)
-
-RPolarsExpr$upper_bound = function() .Call(wrap__RPolarsExpr__upper_bound, self)
-
-RPolarsExpr$sign = function() .Call(wrap__RPolarsExpr__sign, self)
-
-RPolarsExpr$sin = function() .Call(wrap__RPolarsExpr__sin, self)
-
-RPolarsExpr$cos = function() .Call(wrap__RPolarsExpr__cos, self)
-
-RPolarsExpr$tan = function() .Call(wrap__RPolarsExpr__tan, self)
-
-RPolarsExpr$arcsin = function() .Call(wrap__RPolarsExpr__arcsin, self)
-
-RPolarsExpr$arccos = function() .Call(wrap__RPolarsExpr__arccos, self)
-
-RPolarsExpr$arctan = function() .Call(wrap__RPolarsExpr__arctan, self)
-
-RPolarsExpr$sinh = function() .Call(wrap__RPolarsExpr__sinh, self)
-
-RPolarsExpr$cosh = function() .Call(wrap__RPolarsExpr__cosh, self)
-
-RPolarsExpr$tanh = function() .Call(wrap__RPolarsExpr__tanh, self)
-
-RPolarsExpr$arcsinh = function() .Call(wrap__RPolarsExpr__arcsinh, self)
-
-RPolarsExpr$arccosh = function() .Call(wrap__RPolarsExpr__arccosh, self)
-
-RPolarsExpr$arctanh = function() .Call(wrap__RPolarsExpr__arctanh, self)
-
-RPolarsExpr$reshape = function(dims) .Call(wrap__RPolarsExpr__reshape, self, dims)
-
-RPolarsExpr$shuffle = function(seed) .Call(wrap__RPolarsExpr__shuffle, self, seed)
-
-RPolarsExpr$sample_n = function(n, with_replacement, shuffle, seed) .Call(wrap__RPolarsExpr__sample_n, self, n, with_replacement, shuffle, seed)
-
-RPolarsExpr$sample_frac = function(frac, with_replacement, shuffle, seed) .Call(wrap__RPolarsExpr__sample_frac, self, frac, with_replacement, shuffle, seed)
-
-RPolarsExpr$ewm_mean = function(alpha, adjust, min_periods, ignore_nulls) .Call(wrap__RPolarsExpr__ewm_mean, self, alpha, adjust, min_periods, ignore_nulls)
-
-RPolarsExpr$ewm_std = function(alpha, adjust, bias, min_periods, ignore_nulls) .Call(wrap__RPolarsExpr__ewm_std, self, alpha, adjust, bias, min_periods, ignore_nulls)
-
-RPolarsExpr$ewm_var = function(alpha, adjust, bias, min_periods, ignore_nulls) .Call(wrap__RPolarsExpr__ewm_var, self, alpha, adjust, bias, min_periods, ignore_nulls)
-
-RPolarsExpr$extend_constant = function(value, n) .Call(wrap__RPolarsExpr__extend_constant, self, value, n)
-
-RPolarsExpr$rep = function(n, rechunk) .Call(wrap__RPolarsExpr__rep, self, n, rechunk)
-
-RPolarsExpr$value_counts = function(sort, parallel) .Call(wrap__RPolarsExpr__value_counts, self, sort, parallel)
-
-RPolarsExpr$unique_counts = function() .Call(wrap__RPolarsExpr__unique_counts, self)
-
-RPolarsExpr$entropy = function(base, normalize) .Call(wrap__RPolarsExpr__entropy, self, base, normalize)
-
-RPolarsExpr$cumulative_eval = function(expr, min_periods, parallel) .Call(wrap__RPolarsExpr__cumulative_eval, self, expr, min_periods, parallel)
-
-RPolarsExpr$implode = function() .Call(wrap__RPolarsExpr__implode, self)
-
-RPolarsExpr$shrink_dtype = function() .Call(wrap__RPolarsExpr__shrink_dtype, self)
-
-RPolarsExpr$peak_min = function() .Call(wrap__RPolarsExpr__peak_min, self)
-
-RPolarsExpr$peak_max = function() .Call(wrap__RPolarsExpr__peak_max, self)
-
-RPolarsExpr$list_lengths = function() .Call(wrap__RPolarsExpr__list_lengths, self)
-
-RPolarsExpr$list_contains = function(other) .Call(wrap__RPolarsExpr__list_contains, self, other)
-
-RPolarsExpr$list_max = function() .Call(wrap__RPolarsExpr__list_max, self)
-
-RPolarsExpr$list_min = function() .Call(wrap__RPolarsExpr__list_min, self)
-
-RPolarsExpr$list_sum = function() .Call(wrap__RPolarsExpr__list_sum, self)
-
-RPolarsExpr$list_mean = function() .Call(wrap__RPolarsExpr__list_mean, self)
-
-RPolarsExpr$list_sort = function(descending) .Call(wrap__RPolarsExpr__list_sort, self, descending)
-
-RPolarsExpr$list_reverse = function() .Call(wrap__RPolarsExpr__list_reverse, self)
-
-RPolarsExpr$list_unique = function() .Call(wrap__RPolarsExpr__list_unique, self)
-
-RPolarsExpr$list_gather = function(index, null_on_oob) .Call(wrap__RPolarsExpr__list_gather, self, index, null_on_oob)
-
-RPolarsExpr$list_get = function(index) .Call(wrap__RPolarsExpr__list_get, self, index)
-
-RPolarsExpr$list_join = function(separator) .Call(wrap__RPolarsExpr__list_join, self, separator)
-
-RPolarsExpr$list_arg_min = function() .Call(wrap__RPolarsExpr__list_arg_min, self)
-
-RPolarsExpr$list_arg_max = function() .Call(wrap__RPolarsExpr__list_arg_max, self)
-
-RPolarsExpr$list_diff = function(n, null_behavior) .Call(wrap__RPolarsExpr__list_diff, self, n, null_behavior)
-
-RPolarsExpr$list_shift = function(periods) .Call(wrap__RPolarsExpr__list_shift, self, periods)
-
-RPolarsExpr$list_slice = function(offset, length) .Call(wrap__RPolarsExpr__list_slice, self, offset, length)
-
-RPolarsExpr$list_eval = function(expr, parallel) .Call(wrap__RPolarsExpr__list_eval, self, expr, parallel)
-
-RPolarsExpr$list_to_struct = function(n_field_strategy, name_gen, upper_bound) .Call(wrap__RPolarsExpr__list_to_struct, self, n_field_strategy, name_gen, upper_bound)
-
-RPolarsExpr$str_to_date = function(format, strict, exact, cache) .Call(wrap__RPolarsExpr__str_to_date, self, format, strict, exact, cache)
-
-RPolarsExpr$str_to_datetime = function(format, time_unit, time_zone, strict, exact, cache, ambiguous) .Call(wrap__RPolarsExpr__str_to_datetime, self, format, time_unit, time_zone, strict, exact, cache, ambiguous)
-
-RPolarsExpr$str_to_time = function(format, strict, cache) .Call(wrap__RPolarsExpr__str_to_time, self, format, strict, cache)
-
-RPolarsExpr$dt_truncate = function(every, offset) .Call(wrap__RPolarsExpr__dt_truncate, self, every, offset)
-
-RPolarsExpr$dt_round = function(every, offset) .Call(wrap__RPolarsExpr__dt_round, self, every, offset)
-
-RPolarsExpr$dt_time = function() .Call(wrap__RPolarsExpr__dt_time, self)
-
-RPolarsExpr$dt_combine = function(time, tu) .Call(wrap__RPolarsExpr__dt_combine, self, time, tu)
-
-RPolarsExpr$dt_strftime = function(fmt) .Call(wrap__RPolarsExpr__dt_strftime, self, fmt)
-
-RPolarsExpr$dt_year = function() .Call(wrap__RPolarsExpr__dt_year, self)
-
-RPolarsExpr$dt_iso_year = function() .Call(wrap__RPolarsExpr__dt_iso_year, self)
-
-RPolarsExpr$dt_quarter = function() .Call(wrap__RPolarsExpr__dt_quarter, self)
-
-RPolarsExpr$dt_month = function() .Call(wrap__RPolarsExpr__dt_month, self)
-
-RPolarsExpr$dt_week = function() .Call(wrap__RPolarsExpr__dt_week, self)
-
-RPolarsExpr$dt_weekday = function() .Call(wrap__RPolarsExpr__dt_weekday, self)
-
-RPolarsExpr$dt_day = function() .Call(wrap__RPolarsExpr__dt_day, self)
-
-RPolarsExpr$dt_ordinal_day = function() .Call(wrap__RPolarsExpr__dt_ordinal_day, self)
-
-RPolarsExpr$dt_hour = function() .Call(wrap__RPolarsExpr__dt_hour, self)
-
-RPolarsExpr$dt_minute = function() .Call(wrap__RPolarsExpr__dt_minute, self)
-
-RPolarsExpr$dt_second = function() .Call(wrap__RPolarsExpr__dt_second, self)
-
-RPolarsExpr$dt_millisecond = function() .Call(wrap__RPolarsExpr__dt_millisecond, self)
-
-RPolarsExpr$dt_microsecond = function() .Call(wrap__RPolarsExpr__dt_microsecond, self)
-
-RPolarsExpr$dt_nanosecond = function() .Call(wrap__RPolarsExpr__dt_nanosecond, self)
-
-RPolarsExpr$timestamp = function(tu) .Call(wrap__RPolarsExpr__timestamp, self, tu)
-
-RPolarsExpr$dt_epoch_seconds = function() .Call(wrap__RPolarsExpr__dt_epoch_seconds, self)
-
-RPolarsExpr$dt_with_time_unit = function(tu) .Call(wrap__RPolarsExpr__dt_with_time_unit, self, tu)
-
-RPolarsExpr$dt_cast_time_unit = function(tu) .Call(wrap__RPolarsExpr__dt_cast_time_unit, self, tu)
-
-RPolarsExpr$dt_convert_time_zone = function(tz) .Call(wrap__RPolarsExpr__dt_convert_time_zone, self, tz)
-
-RPolarsExpr$dt_replace_time_zone = function(tz, ambiguous) .Call(wrap__RPolarsExpr__dt_replace_time_zone, self, tz, ambiguous)
-
-RPolarsExpr$dt_total_days = function() .Call(wrap__RPolarsExpr__dt_total_days, self)
-
-RPolarsExpr$dt_total_hours = function() .Call(wrap__RPolarsExpr__dt_total_hours, self)
-
-RPolarsExpr$dt_total_minutes = function() .Call(wrap__RPolarsExpr__dt_total_minutes, self)
-
-RPolarsExpr$dt_total_seconds = function() .Call(wrap__RPolarsExpr__dt_total_seconds, self)
-
-RPolarsExpr$dt_total_milliseconds = function() .Call(wrap__RPolarsExpr__dt_total_milliseconds, self)
-
-RPolarsExpr$dt_total_microseconds = function() .Call(wrap__RPolarsExpr__dt_total_microseconds, self)
-
-RPolarsExpr$dt_total_nanoseconds = function() .Call(wrap__RPolarsExpr__dt_total_nanoseconds, self)
-
-RPolarsExpr$dt_offset_by = function(by) .Call(wrap__RPolarsExpr__dt_offset_by, self, by)
-
-RPolarsExpr$repeat_by = function(by) .Call(wrap__RPolarsExpr__repeat_by, self, by)
-
-RPolarsExpr$log10 = function() .Call(wrap__RPolarsExpr__log10, self)
-
-RPolarsExpr$log = function(base) .Call(wrap__RPolarsExpr__log, self, base)
-
-RPolarsExpr$exp = function() .Call(wrap__RPolarsExpr__exp, self)
-
-RPolarsExpr$exclude = function(columns) .Call(wrap__RPolarsExpr__exclude, self, columns)
-
-RPolarsExpr$exclude_dtype = function(columns) .Call(wrap__RPolarsExpr__exclude_dtype, self, columns)
-
-RPolarsExpr$alias = function(s) .Call(wrap__RPolarsExpr__alias, self, s)
-
-RPolarsExpr$drop_nulls = function() .Call(wrap__RPolarsExpr__drop_nulls, self)
-
-RPolarsExpr$drop_nans = function() .Call(wrap__RPolarsExpr__drop_nans, self)
-
-RPolarsExpr$cum_sum = function(reverse) .Call(wrap__RPolarsExpr__cum_sum, self, reverse)
-
-RPolarsExpr$cum_prod = function(reverse) .Call(wrap__RPolarsExpr__cum_prod, self, reverse)
-
-RPolarsExpr$cum_min = function(reverse) .Call(wrap__RPolarsExpr__cum_min, self, reverse)
-
-RPolarsExpr$cum_max = function(reverse) .Call(wrap__RPolarsExpr__cum_max, self, reverse)
-
-RPolarsExpr$cum_count = function(reverse) .Call(wrap__RPolarsExpr__cum_count, self, reverse)
-
-RPolarsExpr$floor = function() .Call(wrap__RPolarsExpr__floor, self)
-
-RPolarsExpr$ceil = function() .Call(wrap__RPolarsExpr__ceil, self)
-
-RPolarsExpr$round = function(decimals) .Call(wrap__RPolarsExpr__round, self, decimals)
-
-RPolarsExpr$dot = function(other) .Call(wrap__RPolarsExpr__dot, self, other)
-
-RPolarsExpr$mode = function() .Call(wrap__RPolarsExpr__mode, self)
-
-RPolarsExpr$first = function() .Call(wrap__RPolarsExpr__first, self)
-
-RPolarsExpr$last = function() .Call(wrap__RPolarsExpr__last, self)
-
-RPolarsExpr$head = function(n) .Call(wrap__RPolarsExpr__head, self, n)
-
-RPolarsExpr$tail = function(n) .Call(wrap__RPolarsExpr__tail, self, n)
-
-RPolarsExpr$unique = function() .Call(wrap__RPolarsExpr__unique, self)
-
-RPolarsExpr$unique_stable = function() .Call(wrap__RPolarsExpr__unique_stable, self)
-
-RPolarsExpr$agg_groups = function() .Call(wrap__RPolarsExpr__agg_groups, self)
-
-RPolarsExpr$all = function(drop_nulls) .Call(wrap__RPolarsExpr__all, self, drop_nulls)
-
-RPolarsExpr$any = function(drop_nulls) .Call(wrap__RPolarsExpr__any, self, drop_nulls)
-
-RPolarsExpr$is_duplicated = function() .Call(wrap__RPolarsExpr__is_duplicated, self)
-
-RPolarsExpr$is_finite = function() .Call(wrap__RPolarsExpr__is_finite, self)
-
-RPolarsExpr$is_first_distinct = function() .Call(wrap__RPolarsExpr__is_first_distinct, self)
-
-RPolarsExpr$is_in = function(other) .Call(wrap__RPolarsExpr__is_in, self, other)
-
-RPolarsExpr$is_infinite = function() .Call(wrap__RPolarsExpr__is_infinite, self)
-
-RPolarsExpr$is_last_distinct = function() .Call(wrap__RPolarsExpr__is_last_distinct, self)
-
-RPolarsExpr$is_nan = function() .Call(wrap__RPolarsExpr__is_nan, self)
-
-RPolarsExpr$is_not_null = function() .Call(wrap__RPolarsExpr__is_not_null, self)
-
-RPolarsExpr$is_not_nan = function() .Call(wrap__RPolarsExpr__is_not_nan, self)
-
-RPolarsExpr$is_null = function() .Call(wrap__RPolarsExpr__is_null, self)
-
-RPolarsExpr$is_unique = function() .Call(wrap__RPolarsExpr__is_unique, self)
-
-RPolarsExpr$not = function() .Call(wrap__RPolarsExpr__not, self)
-
-RPolarsExpr$count = function() .Call(wrap__RPolarsExpr__count, self)
-
-RPolarsExpr$len = function() .Call(wrap__RPolarsExpr__len, self)
-
-RPolarsExpr$slice = function(offset, length) .Call(wrap__RPolarsExpr__slice, self, offset, length)
-
-RPolarsExpr$append = function(other, upcast) .Call(wrap__RPolarsExpr__append, self, other, upcast)
-
-RPolarsExpr$rechunk = function() .Call(wrap__RPolarsExpr__rechunk, self)
-
-RPolarsExpr$add = function(other) .Call(wrap__RPolarsExpr__add, self, other)
-
-RPolarsExpr$floor_div = function(other) .Call(wrap__RPolarsExpr__floor_div, self, other)
-
-RPolarsExpr$rem = function(other) .Call(wrap__RPolarsExpr__rem, self, other)
-
-RPolarsExpr$mul = function(other) .Call(wrap__RPolarsExpr__mul, self, other)
-
-RPolarsExpr$sub = function(other) .Call(wrap__RPolarsExpr__sub, self, other)
-
-RPolarsExpr$div = function(other) .Call(wrap__RPolarsExpr__div, self, other)
-
-RPolarsExpr$pow = function(exponent) .Call(wrap__RPolarsExpr__pow, self, exponent)
-
-RPolarsExpr$over = function(proto_exprs) .Call(wrap__RPolarsExpr__over, self, proto_exprs)
-
-RPolarsExpr$print = function() invisible(.Call(wrap__RPolarsExpr__print, self))
-
-RPolarsExpr$map_batches = function(lambda, output_type, agg_list) .Call(wrap__RPolarsExpr__map_batches, self, lambda, output_type, agg_list)
-
-RPolarsExpr$map_batches_in_background = function(lambda, output_type, agg_list) .Call(wrap__RPolarsExpr__map_batches_in_background, self, lambda, output_type, agg_list)
-
-RPolarsExpr$map_elements_in_background = function(lambda, output_type) .Call(wrap__RPolarsExpr__map_elements_in_background, self, lambda, output_type)
-
-RPolarsExpr$approx_n_unique = function() .Call(wrap__RPolarsExpr__approx_n_unique, self)
-
-RPolarsExpr$name_keep = function() .Call(wrap__RPolarsExpr__name_keep, self)
-
-RPolarsExpr$name_suffix = function(suffix) .Call(wrap__RPolarsExpr__name_suffix, self, suffix)
-
-RPolarsExpr$name_prefix = function(prefix) .Call(wrap__RPolarsExpr__name_prefix, self, prefix)
-
-RPolarsExpr$name_to_lowercase = function() .Call(wrap__RPolarsExpr__name_to_lowercase, self)
-
-RPolarsExpr$name_to_uppercase = function() .Call(wrap__RPolarsExpr__name_to_uppercase, self)
-
-RPolarsExpr$name_map = function(lambda) .Call(wrap__RPolarsExpr__name_map, self, lambda)
-
-RPolarsExpr$str_len_bytes = function() .Call(wrap__RPolarsExpr__str_len_bytes, self)
-
-RPolarsExpr$str_len_chars = function() .Call(wrap__RPolarsExpr__str_len_chars, self)
-
-RPolarsExpr$str_concat = function(delimiter, ignore_nulls) .Call(wrap__RPolarsExpr__str_concat, self, delimiter, ignore_nulls)
-
-RPolarsExpr$str_to_uppercase = function() .Call(wrap__RPolarsExpr__str_to_uppercase, self)
-
-RPolarsExpr$str_to_lowercase = function() .Call(wrap__RPolarsExpr__str_to_lowercase, self)
-
-RPolarsExpr$str_to_titlecase = function() .Call(wrap__RPolarsExpr__str_to_titlecase, self)
-
-RPolarsExpr$str_strip_chars = function(matches) .Call(wrap__RPolarsExpr__str_strip_chars, self, matches)
-
-RPolarsExpr$str_strip_chars_end = function(matches) .Call(wrap__RPolarsExpr__str_strip_chars_end, self, matches)
-
-RPolarsExpr$str_strip_chars_start = function(matches) .Call(wrap__RPolarsExpr__str_strip_chars_start, self, matches)
-
-RPolarsExpr$str_zfill = function(alignment) .Call(wrap__RPolarsExpr__str_zfill, self, alignment)
-
-RPolarsExpr$str_pad_end = function(width, fillchar) .Call(wrap__RPolarsExpr__str_pad_end, self, width, fillchar)
-
-RPolarsExpr$str_pad_start = function(width, fillchar) .Call(wrap__RPolarsExpr__str_pad_start, self, width, fillchar)
-
-RPolarsExpr$str_contains = function(pat, literal, strict) .Call(wrap__RPolarsExpr__str_contains, self, pat, literal, strict)
-
-RPolarsExpr$str_ends_with = function(sub) .Call(wrap__RPolarsExpr__str_ends_with, self, sub)
-
-RPolarsExpr$str_starts_with = function(sub) .Call(wrap__RPolarsExpr__str_starts_with, self, sub)
-
-RPolarsExpr$str_json_path_match = function(pat) .Call(wrap__RPolarsExpr__str_json_path_match, self, pat)
-
-RPolarsExpr$str_json_extract = function(dtype, infer_schema_len) .Call(wrap__RPolarsExpr__str_json_extract, self, dtype, infer_schema_len)
-
-RPolarsExpr$str_hex_encode = function() .Call(wrap__RPolarsExpr__str_hex_encode, self)
-
-RPolarsExpr$str_hex_decode = function(strict) .Call(wrap__RPolarsExpr__str_hex_decode, self, strict)
-
-RPolarsExpr$str_base64_encode = function() .Call(wrap__RPolarsExpr__str_base64_encode, self)
-
-RPolarsExpr$str_base64_decode = function(strict) .Call(wrap__RPolarsExpr__str_base64_decode, self, strict)
-
-RPolarsExpr$str_extract = function(pattern, group_index) .Call(wrap__RPolarsExpr__str_extract, self, pattern, group_index)
-
-RPolarsExpr$str_extract_all = function(pattern) .Call(wrap__RPolarsExpr__str_extract_all, self, pattern)
-
-RPolarsExpr$str_count_matches = function(pattern, literal) .Call(wrap__RPolarsExpr__str_count_matches, self, pattern, literal)
-
-RPolarsExpr$str_split = function(by, inclusive) .Call(wrap__RPolarsExpr__str_split, self, by, inclusive)
-
-RPolarsExpr$str_split_exact = function(by, n, inclusive) .Call(wrap__RPolarsExpr__str_split_exact, self, by, n, inclusive)
-
-RPolarsExpr$str_splitn = function(by, n) .Call(wrap__RPolarsExpr__str_splitn, self, by, n)
-
-RPolarsExpr$str_replace = function(pattern, value, literal) .Call(wrap__RPolarsExpr__str_replace, self, pattern, value, literal)
-
-RPolarsExpr$str_replace_all = function(pattern, value, literal) .Call(wrap__RPolarsExpr__str_replace_all, self, pattern, value, literal)
-
-RPolarsExpr$str_slice = function(offset, length) .Call(wrap__RPolarsExpr__str_slice, self, offset, length)
-
-RPolarsExpr$str_explode = function() .Call(wrap__RPolarsExpr__str_explode, self)
-
-RPolarsExpr$str_parse_int = function(radix, strict) .Call(wrap__RPolarsExpr__str_parse_int, self, radix, strict)
-
-RPolarsExpr$bin_contains = function(lit) .Call(wrap__RPolarsExpr__bin_contains, self, lit)
-
-RPolarsExpr$bin_starts_with = function(sub) .Call(wrap__RPolarsExpr__bin_starts_with, self, sub)
-
-RPolarsExpr$bin_ends_with = function(sub) .Call(wrap__RPolarsExpr__bin_ends_with, self, sub)
-
-RPolarsExpr$bin_encode_hex = function() .Call(wrap__RPolarsExpr__bin_encode_hex, self)
-
-RPolarsExpr$bin_encode_base64 = function() .Call(wrap__RPolarsExpr__bin_encode_base64, self)
-
-RPolarsExpr$bin_decode_hex = function(strict) .Call(wrap__RPolarsExpr__bin_decode_hex, self, strict)
-
-RPolarsExpr$bin_decode_base64 = function(strict) .Call(wrap__RPolarsExpr__bin_decode_base64, self, strict)
-
-RPolarsExpr$struct_field_by_name = function(name) .Call(wrap__RPolarsExpr__struct_field_by_name, self, name)
-
-RPolarsExpr$struct_rename_fields = function(names) .Call(wrap__RPolarsExpr__struct_rename_fields, self, names)
-
-RPolarsExpr$meta_pop = function() .Call(wrap__RPolarsExpr__meta_pop, self)
-
-RPolarsExpr$meta_eq = function(other) .Call(wrap__RPolarsExpr__meta_eq, self, other)
-
-RPolarsExpr$meta_roots = function() .Call(wrap__RPolarsExpr__meta_roots, self)
-
-RPolarsExpr$meta_output_name = function() .Call(wrap__RPolarsExpr__meta_output_name, self)
-
-RPolarsExpr$meta_undo_aliases = function() .Call(wrap__RPolarsExpr__meta_undo_aliases, self)
-
-RPolarsExpr$meta_has_multiple_outputs = function() .Call(wrap__RPolarsExpr__meta_has_multiple_outputs, self)
-
-RPolarsExpr$meta_is_regex_projection = function() .Call(wrap__RPolarsExpr__meta_is_regex_projection, self)
-
-RPolarsExpr$meta_tree_format = function() .Call(wrap__RPolarsExpr__meta_tree_format, self)
-
-RPolarsExpr$cat_set_ordering = function(ordering) .Call(wrap__RPolarsExpr__cat_set_ordering, self, ordering)
-
-RPolarsExpr$cat_get_categories = function() .Call(wrap__RPolarsExpr__cat_get_categories, self)
-
-RPolarsExpr$new_count = function() .Call(wrap__RPolarsExpr__new_count)
-
-RPolarsExpr$new_first = function() .Call(wrap__RPolarsExpr__new_first)
-
-RPolarsExpr$new_last = function() .Call(wrap__RPolarsExpr__new_last)
-
-RPolarsExpr$cov = function(a, b, ddof) .Call(wrap__RPolarsExpr__cov, a, b, ddof)
-
-RPolarsExpr$rolling_cov = function(a, b, window_size, min_periods, ddof) .Call(wrap__RPolarsExpr__rolling_cov, a, b, window_size, min_periods, ddof)
-
-RPolarsExpr$corr = function(a, b, method, ddof, propagate_nans) .Call(wrap__RPolarsExpr__corr, a, b, method, ddof, propagate_nans)
-
-RPolarsExpr$rolling_corr = function(a, b, window_size, min_periods, ddof) .Call(wrap__RPolarsExpr__rolling_corr, a, b, window_size, min_periods, ddof)
-
-RPolarsExpr$rolling = function(index_column, period, offset, closed, check_sorted) .Call(wrap__RPolarsExpr__rolling, self, index_column, period, offset, closed, check_sorted)
+`$.RPolarsChainedThen` <- function (self, name) { func <- RPolarsChainedThen[[name]]; environment(func) <- environment(); func }
 
 #' @export
-`$.RPolarsExpr` = function(self, name) {
-  func = RPolarsExpr[[name]]
-  environment(func) = environment()
-  func
-}
+`[[.RPolarsChainedThen` <- `$.RPolarsChainedThen`
+
+RPolarsExpr <- new.env(parent = emptyenv())
+
+RPolarsExpr$col <- function(name) .Call(wrap__RPolarsExpr__col, name)
+
+RPolarsExpr$dtype_cols <- function(dtypes) .Call(wrap__RPolarsExpr__dtype_cols, dtypes)
+
+RPolarsExpr$cols <- function(names) .Call(wrap__RPolarsExpr__cols, names)
+
+RPolarsExpr$lit <- function(robj) .Call(wrap__RPolarsExpr__lit, robj)
+
+RPolarsExpr$gt <- function(other) .Call(wrap__RPolarsExpr__gt, self, other)
+
+RPolarsExpr$gt_eq <- function(other) .Call(wrap__RPolarsExpr__gt_eq, self, other)
+
+RPolarsExpr$lt <- function(other) .Call(wrap__RPolarsExpr__lt, self, other)
+
+RPolarsExpr$lt_eq <- function(other) .Call(wrap__RPolarsExpr__lt_eq, self, other)
+
+RPolarsExpr$neq <- function(other) .Call(wrap__RPolarsExpr__neq, self, other)
+
+RPolarsExpr$neq_missing <- function(other) .Call(wrap__RPolarsExpr__neq_missing, self, other)
+
+RPolarsExpr$eq <- function(other) .Call(wrap__RPolarsExpr__eq, self, other)
+
+RPolarsExpr$eq_missing <- function(other) .Call(wrap__RPolarsExpr__eq_missing, self, other)
+
+RPolarsExpr$and <- function(other) .Call(wrap__RPolarsExpr__and, self, other)
+
+RPolarsExpr$or <- function(other) .Call(wrap__RPolarsExpr__or, self, other)
+
+RPolarsExpr$xor <- function(other) .Call(wrap__RPolarsExpr__xor, self, other)
+
+RPolarsExpr$to_physical <- function() .Call(wrap__RPolarsExpr__to_physical, self)
+
+RPolarsExpr$cast <- function(data_type, strict) .Call(wrap__RPolarsExpr__cast, self, data_type, strict)
+
+RPolarsExpr$sort <- function(descending, nulls_last) .Call(wrap__RPolarsExpr__sort, self, descending, nulls_last)
+
+RPolarsExpr$arg_sort <- function(descending, nulls_last) .Call(wrap__RPolarsExpr__arg_sort, self, descending, nulls_last)
+
+RPolarsExpr$top_k <- function(k) .Call(wrap__RPolarsExpr__top_k, self, k)
+
+RPolarsExpr$bottom_k <- function(k) .Call(wrap__RPolarsExpr__bottom_k, self, k)
+
+RPolarsExpr$arg_max <- function() .Call(wrap__RPolarsExpr__arg_max, self)
+
+RPolarsExpr$arg_min <- function() .Call(wrap__RPolarsExpr__arg_min, self)
+
+RPolarsExpr$search_sorted <- function(element) .Call(wrap__RPolarsExpr__search_sorted, self, element)
+
+RPolarsExpr$gather <- function(idx) .Call(wrap__RPolarsExpr__gather, self, idx)
+
+RPolarsExpr$sort_by <- function(by, descending) .Call(wrap__RPolarsExpr__sort_by, self, by, descending)
+
+RPolarsExpr$backward_fill <- function(limit) .Call(wrap__RPolarsExpr__backward_fill, self, limit)
+
+RPolarsExpr$forward_fill <- function(limit) .Call(wrap__RPolarsExpr__forward_fill, self, limit)
+
+RPolarsExpr$shift <- function(periods) .Call(wrap__RPolarsExpr__shift, self, periods)
+
+RPolarsExpr$shift_and_fill <- function(periods, fill_value) .Call(wrap__RPolarsExpr__shift_and_fill, self, periods, fill_value)
+
+RPolarsExpr$fill_null <- function(expr) .Call(wrap__RPolarsExpr__fill_null, self, expr)
+
+RPolarsExpr$fill_null_with_strategy <- function(strategy, limit) .Call(wrap__RPolarsExpr__fill_null_with_strategy, self, strategy, limit)
+
+RPolarsExpr$fill_nan <- function(expr) .Call(wrap__RPolarsExpr__fill_nan, self, expr)
+
+RPolarsExpr$reverse <- function() .Call(wrap__RPolarsExpr__reverse, self)
+
+RPolarsExpr$std <- function(ddof) .Call(wrap__RPolarsExpr__std, self, ddof)
+
+RPolarsExpr$var <- function(ddof) .Call(wrap__RPolarsExpr__var, self, ddof)
+
+RPolarsExpr$max <- function() .Call(wrap__RPolarsExpr__max, self)
+
+RPolarsExpr$min <- function() .Call(wrap__RPolarsExpr__min, self)
+
+RPolarsExpr$nan_min <- function() .Call(wrap__RPolarsExpr__nan_min, self)
+
+RPolarsExpr$nan_max <- function() .Call(wrap__RPolarsExpr__nan_max, self)
+
+RPolarsExpr$mean <- function() .Call(wrap__RPolarsExpr__mean, self)
+
+RPolarsExpr$median <- function() .Call(wrap__RPolarsExpr__median, self)
+
+RPolarsExpr$sum <- function() .Call(wrap__RPolarsExpr__sum, self)
+
+RPolarsExpr$product <- function() .Call(wrap__RPolarsExpr__product, self)
+
+RPolarsExpr$n_unique <- function() .Call(wrap__RPolarsExpr__n_unique, self)
+
+RPolarsExpr$null_count <- function() .Call(wrap__RPolarsExpr__null_count, self)
+
+RPolarsExpr$arg_unique <- function() .Call(wrap__RPolarsExpr__arg_unique, self)
+
+RPolarsExpr$quantile <- function(quantile, interpolation) .Call(wrap__RPolarsExpr__quantile, self, quantile, interpolation)
+
+RPolarsExpr$filter <- function(predicate) .Call(wrap__RPolarsExpr__filter, self, predicate)
+
+RPolarsExpr$explode <- function() .Call(wrap__RPolarsExpr__explode, self)
+
+RPolarsExpr$flatten <- function() .Call(wrap__RPolarsExpr__flatten, self)
+
+RPolarsExpr$gather_every <- function(n) .Call(wrap__RPolarsExpr__gather_every, self, n)
+
+RPolarsExpr$hash <- function(seed, seed_1, seed_2, seed_3) .Call(wrap__RPolarsExpr__hash, self, seed, seed_1, seed_2, seed_3)
+
+RPolarsExpr$reinterpret <- function(signed) .Call(wrap__RPolarsExpr__reinterpret, self, signed)
+
+RPolarsExpr$interpolate <- function(method) .Call(wrap__RPolarsExpr__interpolate, self, method)
+
+RPolarsExpr$rolling_min <- function(window_size, weights, min_periods, center, by_null, closed_null) .Call(wrap__RPolarsExpr__rolling_min, self, window_size, weights, min_periods, center, by_null, closed_null)
+
+RPolarsExpr$rolling_max <- function(window_size, weights, min_periods, center, by_null, closed_null) .Call(wrap__RPolarsExpr__rolling_max, self, window_size, weights, min_periods, center, by_null, closed_null)
+
+RPolarsExpr$rolling_mean <- function(window_size, weights, min_periods, center, by_null, closed_null) .Call(wrap__RPolarsExpr__rolling_mean, self, window_size, weights, min_periods, center, by_null, closed_null)
+
+RPolarsExpr$rolling_sum <- function(window_size, weights, min_periods, center, by_null, closed_null) .Call(wrap__RPolarsExpr__rolling_sum, self, window_size, weights, min_periods, center, by_null, closed_null)
+
+RPolarsExpr$rolling_std <- function(window_size, weights, min_periods, center, by_null, closed_null) .Call(wrap__RPolarsExpr__rolling_std, self, window_size, weights, min_periods, center, by_null, closed_null)
+
+RPolarsExpr$rolling_var <- function(window_size, weights, min_periods, center, by_null, closed_null) .Call(wrap__RPolarsExpr__rolling_var, self, window_size, weights, min_periods, center, by_null, closed_null)
+
+RPolarsExpr$rolling_median <- function(window_size, weights, min_periods, center, by_null, closed_null) .Call(wrap__RPolarsExpr__rolling_median, self, window_size, weights, min_periods, center, by_null, closed_null)
+
+RPolarsExpr$rolling_quantile <- function(quantile, interpolation, window_size, weights, min_periods, center, by, closed) .Call(wrap__RPolarsExpr__rolling_quantile, self, quantile, interpolation, window_size, weights, min_periods, center, by, closed)
+
+RPolarsExpr$rolling_skew <- function(window_size_f, bias) .Call(wrap__RPolarsExpr__rolling_skew, self, window_size_f, bias)
+
+RPolarsExpr$abs <- function() .Call(wrap__RPolarsExpr__abs, self)
+
+RPolarsExpr$rank <- function(method, descending) .Call(wrap__RPolarsExpr__rank, self, method, descending)
+
+RPolarsExpr$diff <- function(n_float, null_behavior) .Call(wrap__RPolarsExpr__diff, self, n_float, null_behavior)
+
+RPolarsExpr$pct_change <- function(n_float) .Call(wrap__RPolarsExpr__pct_change, self, n_float)
+
+RPolarsExpr$skew <- function(bias) .Call(wrap__RPolarsExpr__skew, self, bias)
+
+RPolarsExpr$kurtosis <- function(fisher, bias) .Call(wrap__RPolarsExpr__kurtosis, self, fisher, bias)
+
+RPolarsExpr$clip <- function(min, max) .Call(wrap__RPolarsExpr__clip, self, min, max)
+
+RPolarsExpr$clip_min <- function(min) .Call(wrap__RPolarsExpr__clip_min, self, min)
+
+RPolarsExpr$clip_max <- function(max) .Call(wrap__RPolarsExpr__clip_max, self, max)
+
+RPolarsExpr$lower_bound <- function() .Call(wrap__RPolarsExpr__lower_bound, self)
+
+RPolarsExpr$upper_bound <- function() .Call(wrap__RPolarsExpr__upper_bound, self)
+
+RPolarsExpr$sign <- function() .Call(wrap__RPolarsExpr__sign, self)
+
+RPolarsExpr$sin <- function() .Call(wrap__RPolarsExpr__sin, self)
+
+RPolarsExpr$cos <- function() .Call(wrap__RPolarsExpr__cos, self)
+
+RPolarsExpr$tan <- function() .Call(wrap__RPolarsExpr__tan, self)
+
+RPolarsExpr$arcsin <- function() .Call(wrap__RPolarsExpr__arcsin, self)
+
+RPolarsExpr$arccos <- function() .Call(wrap__RPolarsExpr__arccos, self)
+
+RPolarsExpr$arctan <- function() .Call(wrap__RPolarsExpr__arctan, self)
+
+RPolarsExpr$sinh <- function() .Call(wrap__RPolarsExpr__sinh, self)
+
+RPolarsExpr$cosh <- function() .Call(wrap__RPolarsExpr__cosh, self)
+
+RPolarsExpr$tanh <- function() .Call(wrap__RPolarsExpr__tanh, self)
+
+RPolarsExpr$arcsinh <- function() .Call(wrap__RPolarsExpr__arcsinh, self)
+
+RPolarsExpr$arccosh <- function() .Call(wrap__RPolarsExpr__arccosh, self)
+
+RPolarsExpr$arctanh <- function() .Call(wrap__RPolarsExpr__arctanh, self)
+
+RPolarsExpr$reshape <- function(dims) .Call(wrap__RPolarsExpr__reshape, self, dims)
+
+RPolarsExpr$shuffle <- function(seed) .Call(wrap__RPolarsExpr__shuffle, self, seed)
+
+RPolarsExpr$sample_n <- function(n, with_replacement, shuffle, seed) .Call(wrap__RPolarsExpr__sample_n, self, n, with_replacement, shuffle, seed)
+
+RPolarsExpr$sample_frac <- function(frac, with_replacement, shuffle, seed) .Call(wrap__RPolarsExpr__sample_frac, self, frac, with_replacement, shuffle, seed)
+
+RPolarsExpr$ewm_mean <- function(alpha, adjust, min_periods, ignore_nulls) .Call(wrap__RPolarsExpr__ewm_mean, self, alpha, adjust, min_periods, ignore_nulls)
+
+RPolarsExpr$ewm_std <- function(alpha, adjust, bias, min_periods, ignore_nulls) .Call(wrap__RPolarsExpr__ewm_std, self, alpha, adjust, bias, min_periods, ignore_nulls)
+
+RPolarsExpr$ewm_var <- function(alpha, adjust, bias, min_periods, ignore_nulls) .Call(wrap__RPolarsExpr__ewm_var, self, alpha, adjust, bias, min_periods, ignore_nulls)
+
+RPolarsExpr$extend_constant <- function(value, n) .Call(wrap__RPolarsExpr__extend_constant, self, value, n)
+
+RPolarsExpr$rep <- function(n, rechunk) .Call(wrap__RPolarsExpr__rep, self, n, rechunk)
+
+RPolarsExpr$value_counts <- function(sort, parallel) .Call(wrap__RPolarsExpr__value_counts, self, sort, parallel)
+
+RPolarsExpr$unique_counts <- function() .Call(wrap__RPolarsExpr__unique_counts, self)
+
+RPolarsExpr$entropy <- function(base, normalize) .Call(wrap__RPolarsExpr__entropy, self, base, normalize)
+
+RPolarsExpr$cumulative_eval <- function(expr, min_periods, parallel) .Call(wrap__RPolarsExpr__cumulative_eval, self, expr, min_periods, parallel)
+
+RPolarsExpr$implode <- function() .Call(wrap__RPolarsExpr__implode, self)
+
+RPolarsExpr$shrink_dtype <- function() .Call(wrap__RPolarsExpr__shrink_dtype, self)
+
+RPolarsExpr$peak_min <- function() .Call(wrap__RPolarsExpr__peak_min, self)
+
+RPolarsExpr$peak_max <- function() .Call(wrap__RPolarsExpr__peak_max, self)
+
+RPolarsExpr$list_lengths <- function() .Call(wrap__RPolarsExpr__list_lengths, self)
+
+RPolarsExpr$list_contains <- function(other) .Call(wrap__RPolarsExpr__list_contains, self, other)
+
+RPolarsExpr$list_max <- function() .Call(wrap__RPolarsExpr__list_max, self)
+
+RPolarsExpr$list_min <- function() .Call(wrap__RPolarsExpr__list_min, self)
+
+RPolarsExpr$list_sum <- function() .Call(wrap__RPolarsExpr__list_sum, self)
+
+RPolarsExpr$list_mean <- function() .Call(wrap__RPolarsExpr__list_mean, self)
+
+RPolarsExpr$list_sort <- function(descending) .Call(wrap__RPolarsExpr__list_sort, self, descending)
+
+RPolarsExpr$list_reverse <- function() .Call(wrap__RPolarsExpr__list_reverse, self)
+
+RPolarsExpr$list_unique <- function() .Call(wrap__RPolarsExpr__list_unique, self)
+
+RPolarsExpr$list_gather <- function(index, null_on_oob) .Call(wrap__RPolarsExpr__list_gather, self, index, null_on_oob)
+
+RPolarsExpr$list_get <- function(index) .Call(wrap__RPolarsExpr__list_get, self, index)
+
+RPolarsExpr$list_join <- function(separator) .Call(wrap__RPolarsExpr__list_join, self, separator)
+
+RPolarsExpr$list_arg_min <- function() .Call(wrap__RPolarsExpr__list_arg_min, self)
+
+RPolarsExpr$list_arg_max <- function() .Call(wrap__RPolarsExpr__list_arg_max, self)
+
+RPolarsExpr$list_diff <- function(n, null_behavior) .Call(wrap__RPolarsExpr__list_diff, self, n, null_behavior)
+
+RPolarsExpr$list_shift <- function(periods) .Call(wrap__RPolarsExpr__list_shift, self, periods)
+
+RPolarsExpr$list_slice <- function(offset, length) .Call(wrap__RPolarsExpr__list_slice, self, offset, length)
+
+RPolarsExpr$list_eval <- function(expr, parallel) .Call(wrap__RPolarsExpr__list_eval, self, expr, parallel)
+
+RPolarsExpr$list_to_struct <- function(n_field_strategy, name_gen, upper_bound) .Call(wrap__RPolarsExpr__list_to_struct, self, n_field_strategy, name_gen, upper_bound)
+
+RPolarsExpr$str_to_date <- function(format, strict, exact, cache) .Call(wrap__RPolarsExpr__str_to_date, self, format, strict, exact, cache)
+
+RPolarsExpr$str_to_datetime <- function(format, time_unit, time_zone, strict, exact, cache, ambiguous) .Call(wrap__RPolarsExpr__str_to_datetime, self, format, time_unit, time_zone, strict, exact, cache, ambiguous)
+
+RPolarsExpr$str_to_time <- function(format, strict, cache) .Call(wrap__RPolarsExpr__str_to_time, self, format, strict, cache)
+
+RPolarsExpr$dt_truncate <- function(every, offset) .Call(wrap__RPolarsExpr__dt_truncate, self, every, offset)
+
+RPolarsExpr$dt_round <- function(every, offset) .Call(wrap__RPolarsExpr__dt_round, self, every, offset)
+
+RPolarsExpr$dt_time <- function() .Call(wrap__RPolarsExpr__dt_time, self)
+
+RPolarsExpr$dt_combine <- function(time, tu) .Call(wrap__RPolarsExpr__dt_combine, self, time, tu)
+
+RPolarsExpr$dt_strftime <- function(fmt) .Call(wrap__RPolarsExpr__dt_strftime, self, fmt)
+
+RPolarsExpr$dt_year <- function() .Call(wrap__RPolarsExpr__dt_year, self)
+
+RPolarsExpr$dt_iso_year <- function() .Call(wrap__RPolarsExpr__dt_iso_year, self)
+
+RPolarsExpr$dt_quarter <- function() .Call(wrap__RPolarsExpr__dt_quarter, self)
+
+RPolarsExpr$dt_month <- function() .Call(wrap__RPolarsExpr__dt_month, self)
+
+RPolarsExpr$dt_week <- function() .Call(wrap__RPolarsExpr__dt_week, self)
+
+RPolarsExpr$dt_weekday <- function() .Call(wrap__RPolarsExpr__dt_weekday, self)
+
+RPolarsExpr$dt_day <- function() .Call(wrap__RPolarsExpr__dt_day, self)
+
+RPolarsExpr$dt_ordinal_day <- function() .Call(wrap__RPolarsExpr__dt_ordinal_day, self)
+
+RPolarsExpr$dt_hour <- function() .Call(wrap__RPolarsExpr__dt_hour, self)
+
+RPolarsExpr$dt_minute <- function() .Call(wrap__RPolarsExpr__dt_minute, self)
+
+RPolarsExpr$dt_second <- function() .Call(wrap__RPolarsExpr__dt_second, self)
+
+RPolarsExpr$dt_millisecond <- function() .Call(wrap__RPolarsExpr__dt_millisecond, self)
+
+RPolarsExpr$dt_microsecond <- function() .Call(wrap__RPolarsExpr__dt_microsecond, self)
+
+RPolarsExpr$dt_nanosecond <- function() .Call(wrap__RPolarsExpr__dt_nanosecond, self)
+
+RPolarsExpr$timestamp <- function(tu) .Call(wrap__RPolarsExpr__timestamp, self, tu)
+
+RPolarsExpr$dt_epoch_seconds <- function() .Call(wrap__RPolarsExpr__dt_epoch_seconds, self)
+
+RPolarsExpr$dt_with_time_unit <- function(tu) .Call(wrap__RPolarsExpr__dt_with_time_unit, self, tu)
+
+RPolarsExpr$dt_cast_time_unit <- function(tu) .Call(wrap__RPolarsExpr__dt_cast_time_unit, self, tu)
+
+RPolarsExpr$dt_convert_time_zone <- function(tz) .Call(wrap__RPolarsExpr__dt_convert_time_zone, self, tz)
+
+RPolarsExpr$dt_replace_time_zone <- function(tz, ambiguous) .Call(wrap__RPolarsExpr__dt_replace_time_zone, self, tz, ambiguous)
+
+RPolarsExpr$dt_total_days <- function() .Call(wrap__RPolarsExpr__dt_total_days, self)
+
+RPolarsExpr$dt_total_hours <- function() .Call(wrap__RPolarsExpr__dt_total_hours, self)
+
+RPolarsExpr$dt_total_minutes <- function() .Call(wrap__RPolarsExpr__dt_total_minutes, self)
+
+RPolarsExpr$dt_total_seconds <- function() .Call(wrap__RPolarsExpr__dt_total_seconds, self)
+
+RPolarsExpr$dt_total_milliseconds <- function() .Call(wrap__RPolarsExpr__dt_total_milliseconds, self)
+
+RPolarsExpr$dt_total_microseconds <- function() .Call(wrap__RPolarsExpr__dt_total_microseconds, self)
+
+RPolarsExpr$dt_total_nanoseconds <- function() .Call(wrap__RPolarsExpr__dt_total_nanoseconds, self)
+
+RPolarsExpr$dt_offset_by <- function(by) .Call(wrap__RPolarsExpr__dt_offset_by, self, by)
+
+RPolarsExpr$repeat_by <- function(by) .Call(wrap__RPolarsExpr__repeat_by, self, by)
+
+RPolarsExpr$log10 <- function() .Call(wrap__RPolarsExpr__log10, self)
+
+RPolarsExpr$log <- function(base) .Call(wrap__RPolarsExpr__log, self, base)
+
+RPolarsExpr$exp <- function() .Call(wrap__RPolarsExpr__exp, self)
+
+RPolarsExpr$exclude <- function(columns) .Call(wrap__RPolarsExpr__exclude, self, columns)
+
+RPolarsExpr$exclude_dtype <- function(columns) .Call(wrap__RPolarsExpr__exclude_dtype, self, columns)
+
+RPolarsExpr$alias <- function(s) .Call(wrap__RPolarsExpr__alias, self, s)
+
+RPolarsExpr$drop_nulls <- function() .Call(wrap__RPolarsExpr__drop_nulls, self)
+
+RPolarsExpr$drop_nans <- function() .Call(wrap__RPolarsExpr__drop_nans, self)
+
+RPolarsExpr$cum_sum <- function(reverse) .Call(wrap__RPolarsExpr__cum_sum, self, reverse)
+
+RPolarsExpr$cum_prod <- function(reverse) .Call(wrap__RPolarsExpr__cum_prod, self, reverse)
+
+RPolarsExpr$cum_min <- function(reverse) .Call(wrap__RPolarsExpr__cum_min, self, reverse)
+
+RPolarsExpr$cum_max <- function(reverse) .Call(wrap__RPolarsExpr__cum_max, self, reverse)
+
+RPolarsExpr$cum_count <- function(reverse) .Call(wrap__RPolarsExpr__cum_count, self, reverse)
+
+RPolarsExpr$floor <- function() .Call(wrap__RPolarsExpr__floor, self)
+
+RPolarsExpr$ceil <- function() .Call(wrap__RPolarsExpr__ceil, self)
+
+RPolarsExpr$round <- function(decimals) .Call(wrap__RPolarsExpr__round, self, decimals)
+
+RPolarsExpr$dot <- function(other) .Call(wrap__RPolarsExpr__dot, self, other)
+
+RPolarsExpr$mode <- function() .Call(wrap__RPolarsExpr__mode, self)
+
+RPolarsExpr$first <- function() .Call(wrap__RPolarsExpr__first, self)
+
+RPolarsExpr$last <- function() .Call(wrap__RPolarsExpr__last, self)
+
+RPolarsExpr$head <- function(n) .Call(wrap__RPolarsExpr__head, self, n)
+
+RPolarsExpr$tail <- function(n) .Call(wrap__RPolarsExpr__tail, self, n)
+
+RPolarsExpr$unique <- function() .Call(wrap__RPolarsExpr__unique, self)
+
+RPolarsExpr$unique_stable <- function() .Call(wrap__RPolarsExpr__unique_stable, self)
+
+RPolarsExpr$agg_groups <- function() .Call(wrap__RPolarsExpr__agg_groups, self)
+
+RPolarsExpr$all <- function(drop_nulls) .Call(wrap__RPolarsExpr__all, self, drop_nulls)
+
+RPolarsExpr$any <- function(drop_nulls) .Call(wrap__RPolarsExpr__any, self, drop_nulls)
+
+RPolarsExpr$is_duplicated <- function() .Call(wrap__RPolarsExpr__is_duplicated, self)
+
+RPolarsExpr$is_finite <- function() .Call(wrap__RPolarsExpr__is_finite, self)
+
+RPolarsExpr$is_first_distinct <- function() .Call(wrap__RPolarsExpr__is_first_distinct, self)
+
+RPolarsExpr$is_in <- function(other) .Call(wrap__RPolarsExpr__is_in, self, other)
+
+RPolarsExpr$is_infinite <- function() .Call(wrap__RPolarsExpr__is_infinite, self)
+
+RPolarsExpr$is_last_distinct <- function() .Call(wrap__RPolarsExpr__is_last_distinct, self)
+
+RPolarsExpr$is_nan <- function() .Call(wrap__RPolarsExpr__is_nan, self)
+
+RPolarsExpr$is_not_null <- function() .Call(wrap__RPolarsExpr__is_not_null, self)
+
+RPolarsExpr$is_not_nan <- function() .Call(wrap__RPolarsExpr__is_not_nan, self)
+
+RPolarsExpr$is_null <- function() .Call(wrap__RPolarsExpr__is_null, self)
+
+RPolarsExpr$is_unique <- function() .Call(wrap__RPolarsExpr__is_unique, self)
+
+RPolarsExpr$not <- function() .Call(wrap__RPolarsExpr__not, self)
+
+RPolarsExpr$count <- function() .Call(wrap__RPolarsExpr__count, self)
+
+RPolarsExpr$len <- function() .Call(wrap__RPolarsExpr__len, self)
+
+RPolarsExpr$slice <- function(offset, length) .Call(wrap__RPolarsExpr__slice, self, offset, length)
+
+RPolarsExpr$append <- function(other, upcast) .Call(wrap__RPolarsExpr__append, self, other, upcast)
+
+RPolarsExpr$rechunk <- function() .Call(wrap__RPolarsExpr__rechunk, self)
+
+RPolarsExpr$add <- function(other) .Call(wrap__RPolarsExpr__add, self, other)
+
+RPolarsExpr$floor_div <- function(other) .Call(wrap__RPolarsExpr__floor_div, self, other)
+
+RPolarsExpr$rem <- function(other) .Call(wrap__RPolarsExpr__rem, self, other)
+
+RPolarsExpr$mul <- function(other) .Call(wrap__RPolarsExpr__mul, self, other)
+
+RPolarsExpr$sub <- function(other) .Call(wrap__RPolarsExpr__sub, self, other)
+
+RPolarsExpr$div <- function(other) .Call(wrap__RPolarsExpr__div, self, other)
+
+RPolarsExpr$pow <- function(exponent) .Call(wrap__RPolarsExpr__pow, self, exponent)
+
+RPolarsExpr$over <- function(proto_exprs) .Call(wrap__RPolarsExpr__over, self, proto_exprs)
+
+RPolarsExpr$print <- function() invisible(.Call(wrap__RPolarsExpr__print, self))
+
+RPolarsExpr$map_batches <- function(lambda, output_type, agg_list) .Call(wrap__RPolarsExpr__map_batches, self, lambda, output_type, agg_list)
+
+RPolarsExpr$map_batches_in_background <- function(lambda, output_type, agg_list) .Call(wrap__RPolarsExpr__map_batches_in_background, self, lambda, output_type, agg_list)
+
+RPolarsExpr$map_elements_in_background <- function(lambda, output_type) .Call(wrap__RPolarsExpr__map_elements_in_background, self, lambda, output_type)
+
+RPolarsExpr$approx_n_unique <- function() .Call(wrap__RPolarsExpr__approx_n_unique, self)
+
+RPolarsExpr$name_keep <- function() .Call(wrap__RPolarsExpr__name_keep, self)
+
+RPolarsExpr$name_suffix <- function(suffix) .Call(wrap__RPolarsExpr__name_suffix, self, suffix)
+
+RPolarsExpr$name_prefix <- function(prefix) .Call(wrap__RPolarsExpr__name_prefix, self, prefix)
+
+RPolarsExpr$name_to_lowercase <- function() .Call(wrap__RPolarsExpr__name_to_lowercase, self)
+
+RPolarsExpr$name_to_uppercase <- function() .Call(wrap__RPolarsExpr__name_to_uppercase, self)
+
+RPolarsExpr$name_map <- function(lambda) .Call(wrap__RPolarsExpr__name_map, self, lambda)
+
+RPolarsExpr$str_len_bytes <- function() .Call(wrap__RPolarsExpr__str_len_bytes, self)
+
+RPolarsExpr$str_len_chars <- function() .Call(wrap__RPolarsExpr__str_len_chars, self)
+
+RPolarsExpr$str_concat <- function(delimiter, ignore_nulls) .Call(wrap__RPolarsExpr__str_concat, self, delimiter, ignore_nulls)
+
+RPolarsExpr$str_to_uppercase <- function() .Call(wrap__RPolarsExpr__str_to_uppercase, self)
+
+RPolarsExpr$str_to_lowercase <- function() .Call(wrap__RPolarsExpr__str_to_lowercase, self)
+
+RPolarsExpr$str_to_titlecase <- function() .Call(wrap__RPolarsExpr__str_to_titlecase, self)
+
+RPolarsExpr$str_strip_chars <- function(matches) .Call(wrap__RPolarsExpr__str_strip_chars, self, matches)
+
+RPolarsExpr$str_strip_chars_end <- function(matches) .Call(wrap__RPolarsExpr__str_strip_chars_end, self, matches)
+
+RPolarsExpr$str_strip_chars_start <- function(matches) .Call(wrap__RPolarsExpr__str_strip_chars_start, self, matches)
+
+RPolarsExpr$str_zfill <- function(alignment) .Call(wrap__RPolarsExpr__str_zfill, self, alignment)
+
+RPolarsExpr$str_pad_end <- function(width, fillchar) .Call(wrap__RPolarsExpr__str_pad_end, self, width, fillchar)
+
+RPolarsExpr$str_pad_start <- function(width, fillchar) .Call(wrap__RPolarsExpr__str_pad_start, self, width, fillchar)
+
+RPolarsExpr$str_contains <- function(pat, literal, strict) .Call(wrap__RPolarsExpr__str_contains, self, pat, literal, strict)
+
+RPolarsExpr$str_ends_with <- function(sub) .Call(wrap__RPolarsExpr__str_ends_with, self, sub)
+
+RPolarsExpr$str_starts_with <- function(sub) .Call(wrap__RPolarsExpr__str_starts_with, self, sub)
+
+RPolarsExpr$str_json_path_match <- function(pat) .Call(wrap__RPolarsExpr__str_json_path_match, self, pat)
+
+RPolarsExpr$str_json_extract <- function(dtype, infer_schema_len) .Call(wrap__RPolarsExpr__str_json_extract, self, dtype, infer_schema_len)
+
+RPolarsExpr$str_hex_encode <- function() .Call(wrap__RPolarsExpr__str_hex_encode, self)
+
+RPolarsExpr$str_hex_decode <- function(strict) .Call(wrap__RPolarsExpr__str_hex_decode, self, strict)
+
+RPolarsExpr$str_base64_encode <- function() .Call(wrap__RPolarsExpr__str_base64_encode, self)
+
+RPolarsExpr$str_base64_decode <- function(strict) .Call(wrap__RPolarsExpr__str_base64_decode, self, strict)
+
+RPolarsExpr$str_extract <- function(pattern, group_index) .Call(wrap__RPolarsExpr__str_extract, self, pattern, group_index)
+
+RPolarsExpr$str_extract_all <- function(pattern) .Call(wrap__RPolarsExpr__str_extract_all, self, pattern)
+
+RPolarsExpr$str_count_matches <- function(pattern, literal) .Call(wrap__RPolarsExpr__str_count_matches, self, pattern, literal)
+
+RPolarsExpr$str_split <- function(by, inclusive) .Call(wrap__RPolarsExpr__str_split, self, by, inclusive)
+
+RPolarsExpr$str_split_exact <- function(by, n, inclusive) .Call(wrap__RPolarsExpr__str_split_exact, self, by, n, inclusive)
+
+RPolarsExpr$str_splitn <- function(by, n) .Call(wrap__RPolarsExpr__str_splitn, self, by, n)
+
+RPolarsExpr$str_replace <- function(pattern, value, literal) .Call(wrap__RPolarsExpr__str_replace, self, pattern, value, literal)
+
+RPolarsExpr$str_replace_all <- function(pattern, value, literal) .Call(wrap__RPolarsExpr__str_replace_all, self, pattern, value, literal)
+
+RPolarsExpr$str_slice <- function(offset, length) .Call(wrap__RPolarsExpr__str_slice, self, offset, length)
+
+RPolarsExpr$str_explode <- function() .Call(wrap__RPolarsExpr__str_explode, self)
+
+RPolarsExpr$str_parse_int <- function(radix, strict) .Call(wrap__RPolarsExpr__str_parse_int, self, radix, strict)
+
+RPolarsExpr$bin_contains <- function(lit) .Call(wrap__RPolarsExpr__bin_contains, self, lit)
+
+RPolarsExpr$bin_starts_with <- function(sub) .Call(wrap__RPolarsExpr__bin_starts_with, self, sub)
+
+RPolarsExpr$bin_ends_with <- function(sub) .Call(wrap__RPolarsExpr__bin_ends_with, self, sub)
+
+RPolarsExpr$bin_encode_hex <- function() .Call(wrap__RPolarsExpr__bin_encode_hex, self)
+
+RPolarsExpr$bin_encode_base64 <- function() .Call(wrap__RPolarsExpr__bin_encode_base64, self)
+
+RPolarsExpr$bin_decode_hex <- function(strict) .Call(wrap__RPolarsExpr__bin_decode_hex, self, strict)
+
+RPolarsExpr$bin_decode_base64 <- function(strict) .Call(wrap__RPolarsExpr__bin_decode_base64, self, strict)
+
+RPolarsExpr$struct_field_by_name <- function(name) .Call(wrap__RPolarsExpr__struct_field_by_name, self, name)
+
+RPolarsExpr$struct_rename_fields <- function(names) .Call(wrap__RPolarsExpr__struct_rename_fields, self, names)
+
+RPolarsExpr$meta_pop <- function() .Call(wrap__RPolarsExpr__meta_pop, self)
+
+RPolarsExpr$meta_eq <- function(other) .Call(wrap__RPolarsExpr__meta_eq, self, other)
+
+RPolarsExpr$meta_roots <- function() .Call(wrap__RPolarsExpr__meta_roots, self)
+
+RPolarsExpr$meta_output_name <- function() .Call(wrap__RPolarsExpr__meta_output_name, self)
+
+RPolarsExpr$meta_undo_aliases <- function() .Call(wrap__RPolarsExpr__meta_undo_aliases, self)
+
+RPolarsExpr$meta_has_multiple_outputs <- function() .Call(wrap__RPolarsExpr__meta_has_multiple_outputs, self)
+
+RPolarsExpr$meta_is_regex_projection <- function() .Call(wrap__RPolarsExpr__meta_is_regex_projection, self)
+
+RPolarsExpr$meta_tree_format <- function() .Call(wrap__RPolarsExpr__meta_tree_format, self)
+
+RPolarsExpr$cat_set_ordering <- function(ordering) .Call(wrap__RPolarsExpr__cat_set_ordering, self, ordering)
+
+RPolarsExpr$cat_get_categories <- function() .Call(wrap__RPolarsExpr__cat_get_categories, self)
+
+RPolarsExpr$new_count <- function() .Call(wrap__RPolarsExpr__new_count)
+
+RPolarsExpr$new_first <- function() .Call(wrap__RPolarsExpr__new_first)
+
+RPolarsExpr$new_last <- function() .Call(wrap__RPolarsExpr__new_last)
+
+RPolarsExpr$cov <- function(a, b, ddof) .Call(wrap__RPolarsExpr__cov, a, b, ddof)
+
+RPolarsExpr$rolling_cov <- function(a, b, window_size, min_periods, ddof) .Call(wrap__RPolarsExpr__rolling_cov, a, b, window_size, min_periods, ddof)
+
+RPolarsExpr$corr <- function(a, b, method, ddof, propagate_nans) .Call(wrap__RPolarsExpr__corr, a, b, method, ddof, propagate_nans)
+
+RPolarsExpr$rolling_corr <- function(a, b, window_size, min_periods, ddof) .Call(wrap__RPolarsExpr__rolling_corr, a, b, window_size, min_periods, ddof)
+
+RPolarsExpr$rolling <- function(index_column, period, offset, closed, check_sorted) .Call(wrap__RPolarsExpr__rolling, self, index_column, period, offset, closed, check_sorted)
 
 #' @export
-`[[.RPolarsExpr` = `$.RPolarsExpr`
-
-RPolarsProtoExprArray = new.env(parent = emptyenv())
-
-RPolarsProtoExprArray$new = function() .Call(wrap__RPolarsProtoExprArray__new)
-
-RPolarsProtoExprArray$push_back_str = function(s) invisible(.Call(wrap__RPolarsProtoExprArray__push_back_str, self, s))
-
-RPolarsProtoExprArray$push_back_rexpr = function(r) invisible(.Call(wrap__RPolarsProtoExprArray__push_back_rexpr, self, r))
-
-RPolarsProtoExprArray$print = function() invisible(.Call(wrap__RPolarsProtoExprArray__print, self))
+`$.RPolarsExpr` <- function (self, name) { func <- RPolarsExpr[[name]]; environment(func) <- environment(); func }
 
 #' @export
-`$.RPolarsProtoExprArray` = function(self, name) {
-  func = RPolarsProtoExprArray[[name]]
-  environment(func) = environment()
-  func
-}
+`[[.RPolarsExpr` <- `$.RPolarsExpr`
+
+RPolarsProtoExprArray <- new.env(parent = emptyenv())
+
+RPolarsProtoExprArray$new <- function() .Call(wrap__RPolarsProtoExprArray__new)
+
+RPolarsProtoExprArray$push_back_str <- function(s) invisible(.Call(wrap__RPolarsProtoExprArray__push_back_str, self, s))
+
+RPolarsProtoExprArray$push_back_rexpr <- function(r) invisible(.Call(wrap__RPolarsProtoExprArray__push_back_rexpr, self, r))
+
+RPolarsProtoExprArray$print <- function() invisible(.Call(wrap__RPolarsProtoExprArray__print, self))
 
 #' @export
-`[[.RPolarsProtoExprArray` = `$.RPolarsProtoExprArray`
-
-RPolarsLazyFrame = new.env(parent = emptyenv())
-
-RPolarsLazyFrame$print = function() .Call(wrap__RPolarsLazyFrame__print, self)
-
-RPolarsLazyFrame$describe_plan = function() invisible(.Call(wrap__RPolarsLazyFrame__describe_plan, self))
-
-RPolarsLazyFrame$debug_plan = function() .Call(wrap__RPolarsLazyFrame__debug_plan, self)
-
-RPolarsLazyFrame$describe_optimized_plan = function() .Call(wrap__RPolarsLazyFrame__describe_optimized_plan, self)
-
-RPolarsLazyFrame$collect = function() .Call(wrap__RPolarsLazyFrame__collect, self)
-
-RPolarsLazyFrame$collect_in_background = function() .Call(wrap__RPolarsLazyFrame__collect_in_background, self)
-
-RPolarsLazyFrame$sink_parquet = function(path, compression_method, compression_level, statistics, row_group_size, data_pagesize_limit, maintain_order) .Call(wrap__RPolarsLazyFrame__sink_parquet, self, path, compression_method, compression_level, statistics, row_group_size, data_pagesize_limit, maintain_order)
-
-RPolarsLazyFrame$sink_ipc = function(path, compression_method, maintain_order) .Call(wrap__RPolarsLazyFrame__sink_ipc, self, path, compression_method, maintain_order)
-
-RPolarsLazyFrame$sink_csv = function(path, include_bom, include_header, separator, line_terminator, quote, batch_size, datetime_format, date_format, time_format, float_precision, null_value, quote_style, maintain_order) .Call(wrap__RPolarsLazyFrame__sink_csv, self, path, include_bom, include_header, separator, line_terminator, quote, batch_size, datetime_format, date_format, time_format, float_precision, null_value, quote_style, maintain_order)
-
-RPolarsLazyFrame$first = function() .Call(wrap__RPolarsLazyFrame__first, self)
-
-RPolarsLazyFrame$last = function() .Call(wrap__RPolarsLazyFrame__last, self)
-
-RPolarsLazyFrame$max = function() .Call(wrap__RPolarsLazyFrame__max, self)
-
-RPolarsLazyFrame$min = function() .Call(wrap__RPolarsLazyFrame__min, self)
-
-RPolarsLazyFrame$mean = function() .Call(wrap__RPolarsLazyFrame__mean, self)
-
-RPolarsLazyFrame$median = function() .Call(wrap__RPolarsLazyFrame__median, self)
-
-RPolarsLazyFrame$sum = function() .Call(wrap__RPolarsLazyFrame__sum, self)
-
-RPolarsLazyFrame$std = function(ddof) .Call(wrap__RPolarsLazyFrame__std, self, ddof)
-
-RPolarsLazyFrame$var = function(ddof) .Call(wrap__RPolarsLazyFrame__var, self, ddof)
-
-RPolarsLazyFrame$quantile = function(quantile, interpolation) .Call(wrap__RPolarsLazyFrame__quantile, self, quantile, interpolation)
-
-RPolarsLazyFrame$shift = function(periods) .Call(wrap__RPolarsLazyFrame__shift, self, periods)
-
-RPolarsLazyFrame$shift_and_fill = function(fill_value, periods) .Call(wrap__RPolarsLazyFrame__shift_and_fill, self, fill_value, periods)
-
-RPolarsLazyFrame$reverse = function() .Call(wrap__RPolarsLazyFrame__reverse, self)
-
-RPolarsLazyFrame$drop = function(columns) .Call(wrap__RPolarsLazyFrame__drop, self, columns)
-
-RPolarsLazyFrame$fill_nan = function(fill_value) .Call(wrap__RPolarsLazyFrame__fill_nan, self, fill_value)
-
-RPolarsLazyFrame$fill_null = function(fill_value) .Call(wrap__RPolarsLazyFrame__fill_null, self, fill_value)
-
-RPolarsLazyFrame$slice = function(offset, length) .Call(wrap__RPolarsLazyFrame__slice, self, offset, length)
-
-RPolarsLazyFrame$with_columns = function(exprs) .Call(wrap__RPolarsLazyFrame__with_columns, self, exprs)
-
-RPolarsLazyFrame$unnest = function(names) .Call(wrap__RPolarsLazyFrame__unnest, self, names)
-
-RPolarsLazyFrame$select = function(exprs) .Call(wrap__RPolarsLazyFrame__select, self, exprs)
-
-RPolarsLazyFrame$select_str_as_lit = function(exprs) .Call(wrap__RPolarsLazyFrame__select_str_as_lit, self, exprs)
-
-RPolarsLazyFrame$limit = function(n) .Call(wrap__RPolarsLazyFrame__limit, self, n)
-
-RPolarsLazyFrame$tail = function(n) .Call(wrap__RPolarsLazyFrame__tail, self, n)
-
-RPolarsLazyFrame$filter = function(expr) .Call(wrap__RPolarsLazyFrame__filter, self, expr)
-
-RPolarsLazyFrame$drop_nulls = function(subset) .Call(wrap__RPolarsLazyFrame__drop_nulls, self, subset)
-
-RPolarsLazyFrame$unique = function(subset, keep, maintain_order) .Call(wrap__RPolarsLazyFrame__unique, self, subset, keep, maintain_order)
-
-RPolarsLazyFrame$group_by = function(exprs, maintain_order) .Call(wrap__RPolarsLazyFrame__group_by, self, exprs, maintain_order)
-
-RPolarsLazyFrame$with_row_count = function(name, offset) .Call(wrap__RPolarsLazyFrame__with_row_count, self, name, offset)
-
-RPolarsLazyFrame$join_asof = function(other, left_on, right_on, left_by, right_by, allow_parallel, force_parallel, suffix, strategy, tolerance, tolerance_str) .Call(wrap__RPolarsLazyFrame__join_asof, self, other, left_on, right_on, left_by, right_by, allow_parallel, force_parallel, suffix, strategy, tolerance, tolerance_str)
-
-RPolarsLazyFrame$join = function(other, left_on, right_on, how, suffix, allow_parallel, force_parallel) .Call(wrap__RPolarsLazyFrame__join, self, other, left_on, right_on, how, suffix, allow_parallel, force_parallel)
-
-RPolarsLazyFrame$sort_by_exprs = function(by, dotdotdot, descending, nulls_last, maintain_order) .Call(wrap__RPolarsLazyFrame__sort_by_exprs, self, by, dotdotdot, descending, nulls_last, maintain_order)
-
-RPolarsLazyFrame$melt = function(id_vars, value_vars, value_name, variable_name, streamable) .Call(wrap__RPolarsLazyFrame__melt, self, id_vars, value_vars, value_name, variable_name, streamable)
-
-RPolarsLazyFrame$rename = function(existing, new) .Call(wrap__RPolarsLazyFrame__rename, self, existing, new)
-
-RPolarsLazyFrame$schema = function() .Call(wrap__RPolarsLazyFrame__schema, self)
-
-RPolarsLazyFrame$fetch = function(n_rows) .Call(wrap__RPolarsLazyFrame__fetch, self, n_rows)
-
-RPolarsLazyFrame$set_optimization_toggle = function(type_coercion, predicate_pushdown, projection_pushdown, simplify_expression, slice_pushdown, comm_subplan_elim, comm_subexpr_elim, streaming, eager) .Call(wrap__RPolarsLazyFrame__set_optimization_toggle, self, type_coercion, predicate_pushdown, projection_pushdown, simplify_expression, slice_pushdown, comm_subplan_elim, comm_subexpr_elim, streaming, eager)
-
-RPolarsLazyFrame$get_optimization_toggle = function() .Call(wrap__RPolarsLazyFrame__get_optimization_toggle, self)
-
-RPolarsLazyFrame$profile = function() .Call(wrap__RPolarsLazyFrame__profile, self)
-
-RPolarsLazyFrame$explode = function(dotdotdot) .Call(wrap__RPolarsLazyFrame__explode, self, dotdotdot)
-
-RPolarsLazyFrame$clone_in_rust = function() .Call(wrap__RPolarsLazyFrame__clone_in_rust, self)
-
-RPolarsLazyFrame$with_context = function(contexts) .Call(wrap__RPolarsLazyFrame__with_context, self, contexts)
+`$.RPolarsProtoExprArray` <- function (self, name) { func <- RPolarsProtoExprArray[[name]]; environment(func) <- environment(); func }
 
 #' @export
-`$.RPolarsLazyFrame` = function(self, name) {
-  func = RPolarsLazyFrame[[name]]
-  environment(func) = environment()
-  func
-}
+`[[.RPolarsProtoExprArray` <- `$.RPolarsProtoExprArray`
+
+RPolarsLazyFrame <- new.env(parent = emptyenv())
+
+RPolarsLazyFrame$print <- function() .Call(wrap__RPolarsLazyFrame__print, self)
+
+RPolarsLazyFrame$describe_plan <- function() invisible(.Call(wrap__RPolarsLazyFrame__describe_plan, self))
+
+RPolarsLazyFrame$debug_plan <- function() .Call(wrap__RPolarsLazyFrame__debug_plan, self)
+
+RPolarsLazyFrame$describe_optimized_plan <- function() .Call(wrap__RPolarsLazyFrame__describe_optimized_plan, self)
+
+RPolarsLazyFrame$collect <- function() .Call(wrap__RPolarsLazyFrame__collect, self)
+
+RPolarsLazyFrame$collect_in_background <- function() .Call(wrap__RPolarsLazyFrame__collect_in_background, self)
+
+RPolarsLazyFrame$sink_parquet <- function(path, compression_method, compression_level, statistics, row_group_size, data_pagesize_limit, maintain_order) .Call(wrap__RPolarsLazyFrame__sink_parquet, self, path, compression_method, compression_level, statistics, row_group_size, data_pagesize_limit, maintain_order)
+
+RPolarsLazyFrame$sink_ipc <- function(path, compression_method, maintain_order) .Call(wrap__RPolarsLazyFrame__sink_ipc, self, path, compression_method, maintain_order)
+
+RPolarsLazyFrame$sink_csv <- function(path, include_bom, include_header, separator, line_terminator, quote, batch_size, datetime_format, date_format, time_format, float_precision, null_value, quote_style, maintain_order) .Call(wrap__RPolarsLazyFrame__sink_csv, self, path, include_bom, include_header, separator, line_terminator, quote, batch_size, datetime_format, date_format, time_format, float_precision, null_value, quote_style, maintain_order)
+
+RPolarsLazyFrame$first <- function() .Call(wrap__RPolarsLazyFrame__first, self)
+
+RPolarsLazyFrame$last <- function() .Call(wrap__RPolarsLazyFrame__last, self)
+
+RPolarsLazyFrame$max <- function() .Call(wrap__RPolarsLazyFrame__max, self)
+
+RPolarsLazyFrame$min <- function() .Call(wrap__RPolarsLazyFrame__min, self)
+
+RPolarsLazyFrame$mean <- function() .Call(wrap__RPolarsLazyFrame__mean, self)
+
+RPolarsLazyFrame$median <- function() .Call(wrap__RPolarsLazyFrame__median, self)
+
+RPolarsLazyFrame$sum <- function() .Call(wrap__RPolarsLazyFrame__sum, self)
+
+RPolarsLazyFrame$std <- function(ddof) .Call(wrap__RPolarsLazyFrame__std, self, ddof)
+
+RPolarsLazyFrame$var <- function(ddof) .Call(wrap__RPolarsLazyFrame__var, self, ddof)
+
+RPolarsLazyFrame$quantile <- function(quantile, interpolation) .Call(wrap__RPolarsLazyFrame__quantile, self, quantile, interpolation)
+
+RPolarsLazyFrame$shift <- function(periods) .Call(wrap__RPolarsLazyFrame__shift, self, periods)
+
+RPolarsLazyFrame$shift_and_fill <- function(fill_value, periods) .Call(wrap__RPolarsLazyFrame__shift_and_fill, self, fill_value, periods)
+
+RPolarsLazyFrame$reverse <- function() .Call(wrap__RPolarsLazyFrame__reverse, self)
+
+RPolarsLazyFrame$drop <- function(columns) .Call(wrap__RPolarsLazyFrame__drop, self, columns)
+
+RPolarsLazyFrame$fill_nan <- function(fill_value) .Call(wrap__RPolarsLazyFrame__fill_nan, self, fill_value)
+
+RPolarsLazyFrame$fill_null <- function(fill_value) .Call(wrap__RPolarsLazyFrame__fill_null, self, fill_value)
+
+RPolarsLazyFrame$slice <- function(offset, length) .Call(wrap__RPolarsLazyFrame__slice, self, offset, length)
+
+RPolarsLazyFrame$with_columns <- function(exprs) .Call(wrap__RPolarsLazyFrame__with_columns, self, exprs)
+
+RPolarsLazyFrame$unnest <- function(names) .Call(wrap__RPolarsLazyFrame__unnest, self, names)
+
+RPolarsLazyFrame$select <- function(exprs) .Call(wrap__RPolarsLazyFrame__select, self, exprs)
+
+RPolarsLazyFrame$select_str_as_lit <- function(exprs) .Call(wrap__RPolarsLazyFrame__select_str_as_lit, self, exprs)
+
+RPolarsLazyFrame$limit <- function(n) .Call(wrap__RPolarsLazyFrame__limit, self, n)
+
+RPolarsLazyFrame$tail <- function(n) .Call(wrap__RPolarsLazyFrame__tail, self, n)
+
+RPolarsLazyFrame$filter <- function(expr) .Call(wrap__RPolarsLazyFrame__filter, self, expr)
+
+RPolarsLazyFrame$drop_nulls <- function(subset) .Call(wrap__RPolarsLazyFrame__drop_nulls, self, subset)
+
+RPolarsLazyFrame$unique <- function(subset, keep, maintain_order) .Call(wrap__RPolarsLazyFrame__unique, self, subset, keep, maintain_order)
+
+RPolarsLazyFrame$group_by <- function(exprs, maintain_order) .Call(wrap__RPolarsLazyFrame__group_by, self, exprs, maintain_order)
+
+RPolarsLazyFrame$with_row_count <- function(name, offset) .Call(wrap__RPolarsLazyFrame__with_row_count, self, name, offset)
+
+RPolarsLazyFrame$join_asof <- function(other, left_on, right_on, left_by, right_by, allow_parallel, force_parallel, suffix, strategy, tolerance, tolerance_str) .Call(wrap__RPolarsLazyFrame__join_asof, self, other, left_on, right_on, left_by, right_by, allow_parallel, force_parallel, suffix, strategy, tolerance, tolerance_str)
+
+RPolarsLazyFrame$join <- function(other, left_on, right_on, how, suffix, allow_parallel, force_parallel) .Call(wrap__RPolarsLazyFrame__join, self, other, left_on, right_on, how, suffix, allow_parallel, force_parallel)
+
+RPolarsLazyFrame$sort_by_exprs <- function(by, dotdotdot, descending, nulls_last, maintain_order) .Call(wrap__RPolarsLazyFrame__sort_by_exprs, self, by, dotdotdot, descending, nulls_last, maintain_order)
+
+RPolarsLazyFrame$melt <- function(id_vars, value_vars, value_name, variable_name, streamable) .Call(wrap__RPolarsLazyFrame__melt, self, id_vars, value_vars, value_name, variable_name, streamable)
+
+RPolarsLazyFrame$rename <- function(existing, new) .Call(wrap__RPolarsLazyFrame__rename, self, existing, new)
+
+RPolarsLazyFrame$schema <- function() .Call(wrap__RPolarsLazyFrame__schema, self)
+
+RPolarsLazyFrame$fetch <- function(n_rows) .Call(wrap__RPolarsLazyFrame__fetch, self, n_rows)
+
+RPolarsLazyFrame$set_optimization_toggle <- function(type_coercion, predicate_pushdown, projection_pushdown, simplify_expression, slice_pushdown, comm_subplan_elim, comm_subexpr_elim, streaming, eager) .Call(wrap__RPolarsLazyFrame__set_optimization_toggle, self, type_coercion, predicate_pushdown, projection_pushdown, simplify_expression, slice_pushdown, comm_subplan_elim, comm_subexpr_elim, streaming, eager)
+
+RPolarsLazyFrame$get_optimization_toggle <- function() .Call(wrap__RPolarsLazyFrame__get_optimization_toggle, self)
+
+RPolarsLazyFrame$profile <- function() .Call(wrap__RPolarsLazyFrame__profile, self)
+
+RPolarsLazyFrame$explode <- function(dotdotdot) .Call(wrap__RPolarsLazyFrame__explode, self, dotdotdot)
+
+RPolarsLazyFrame$clone_in_rust <- function() .Call(wrap__RPolarsLazyFrame__clone_in_rust, self)
+
+RPolarsLazyFrame$with_context <- function(contexts) .Call(wrap__RPolarsLazyFrame__with_context, self, contexts)
 
 #' @export
-`[[.RPolarsLazyFrame` = `$.RPolarsLazyFrame`
-
-RPolarsLazyGroupBy = new.env(parent = emptyenv())
-
-RPolarsLazyGroupBy$print = function() invisible(.Call(wrap__RPolarsLazyGroupBy__print, self))
-
-RPolarsLazyGroupBy$clone_in_rust = function() .Call(wrap__RPolarsLazyGroupBy__clone_in_rust, self)
-
-RPolarsLazyGroupBy$ungroup = function() .Call(wrap__RPolarsLazyGroupBy__ungroup, self)
-
-RPolarsLazyGroupBy$agg = function(exprs) .Call(wrap__RPolarsLazyGroupBy__agg, self, exprs)
-
-RPolarsLazyGroupBy$head = function(n) .Call(wrap__RPolarsLazyGroupBy__head, self, n)
-
-RPolarsLazyGroupBy$tail = function(n) .Call(wrap__RPolarsLazyGroupBy__tail, self, n)
+`$.RPolarsLazyFrame` <- function (self, name) { func <- RPolarsLazyFrame[[name]]; environment(func) <- environment(); func }
 
 #' @export
-`$.RPolarsLazyGroupBy` = function(self, name) {
-  func = RPolarsLazyGroupBy[[name]]
-  environment(func) = environment()
-  func
-}
+`[[.RPolarsLazyFrame` <- `$.RPolarsLazyFrame`
+
+RPolarsLazyGroupBy <- new.env(parent = emptyenv())
+
+RPolarsLazyGroupBy$print <- function() invisible(.Call(wrap__RPolarsLazyGroupBy__print, self))
+
+RPolarsLazyGroupBy$clone_in_rust <- function() .Call(wrap__RPolarsLazyGroupBy__clone_in_rust, self)
+
+RPolarsLazyGroupBy$ungroup <- function() .Call(wrap__RPolarsLazyGroupBy__ungroup, self)
+
+RPolarsLazyGroupBy$agg <- function(exprs) .Call(wrap__RPolarsLazyGroupBy__agg, self, exprs)
+
+RPolarsLazyGroupBy$head <- function(n) .Call(wrap__RPolarsLazyGroupBy__head, self, n)
+
+RPolarsLazyGroupBy$tail <- function(n) .Call(wrap__RPolarsLazyGroupBy__tail, self, n)
 
 #' @export
-`[[.RPolarsLazyGroupBy` = `$.RPolarsLazyGroupBy`
-
-RPolarsSeries = new.env(parent = emptyenv())
-
-RPolarsSeries$new = function(x, name) .Call(wrap__RPolarsSeries__new, x, name)
-
-RPolarsSeries$clone = function() .Call(wrap__RPolarsSeries__clone, self)
-
-RPolarsSeries$sleep = function(millis) .Call(wrap__RPolarsSeries__sleep, self, millis)
-
-RPolarsSeries$panic = function() .Call(wrap__RPolarsSeries__panic, self)
-
-RPolarsSeries$to_r = function() .Call(wrap__RPolarsSeries__to_r, self)
-
-RPolarsSeries$rename_mut = function(name) invisible(.Call(wrap__RPolarsSeries__rename_mut, self, name))
-
-RPolarsSeries$dtype = function() .Call(wrap__RPolarsSeries__dtype, self)
-
-RPolarsSeries$n_unique = function() .Call(wrap__RPolarsSeries__n_unique, self)
-
-RPolarsSeries$name = function() .Call(wrap__RPolarsSeries__name, self)
-
-RPolarsSeries$sort_mut = function(descending) .Call(wrap__RPolarsSeries__sort_mut, self, descending)
-
-RPolarsSeries$value_counts = function(sort, parallel) .Call(wrap__RPolarsSeries__value_counts, self, sort, parallel)
-
-RPolarsSeries$arg_min = function() .Call(wrap__RPolarsSeries__arg_min, self)
-
-RPolarsSeries$arg_max = function() .Call(wrap__RPolarsSeries__arg_max, self)
-
-RPolarsSeries$is_sorted_flag = function() .Call(wrap__RPolarsSeries__is_sorted_flag, self)
-
-RPolarsSeries$is_sorted_reverse_flag = function() .Call(wrap__RPolarsSeries__is_sorted_reverse_flag, self)
-
-RPolarsSeries$is_sorted = function(descending) .Call(wrap__RPolarsSeries__is_sorted, self, descending)
-
-RPolarsSeries$series_equal = function(other, null_equal, strict) .Call(wrap__RPolarsSeries__series_equal, self, other, null_equal, strict)
-
-RPolarsSeries$get_fmt = function(index, str_length) .Call(wrap__RPolarsSeries__get_fmt, self, index, str_length)
-
-RPolarsSeries$to_fmt_char = function(str_length) .Call(wrap__RPolarsSeries__to_fmt_char, self, str_length)
-
-RPolarsSeries$compare = function(other, op) .Call(wrap__RPolarsSeries__compare, self, other, op)
-
-RPolarsSeries$rep = function(n, rechunk) .Call(wrap__RPolarsSeries__rep, self, n, rechunk)
-
-RPolarsSeries$shape = function() .Call(wrap__RPolarsSeries__shape, self)
-
-RPolarsSeries$len = function() .Call(wrap__RPolarsSeries__len, self)
-
-RPolarsSeries$chunk_lengths = function() .Call(wrap__RPolarsSeries__chunk_lengths, self)
-
-RPolarsSeries$abs = function() .Call(wrap__RPolarsSeries__abs, self)
-
-RPolarsSeries$alias = function(name) .Call(wrap__RPolarsSeries__alias, self, name)
-
-RPolarsSeries$all = function() .Call(wrap__RPolarsSeries__all, self)
-
-RPolarsSeries$any = function() .Call(wrap__RPolarsSeries__any, self)
-
-RPolarsSeries$add = function(other) .Call(wrap__RPolarsSeries__add, self, other)
-
-RPolarsSeries$sub = function(other) .Call(wrap__RPolarsSeries__sub, self, other)
-
-RPolarsSeries$mul = function(other) .Call(wrap__RPolarsSeries__mul, self, other)
-
-RPolarsSeries$div = function(other) .Call(wrap__RPolarsSeries__div, self, other)
-
-RPolarsSeries$rem = function(other) .Call(wrap__RPolarsSeries__rem, self, other)
-
-RPolarsSeries$append_mut = function(other) .Call(wrap__RPolarsSeries__append_mut, self, other)
-
-RPolarsSeries$map_elements = function(robj, rdatatype, strict, allow_fail_eval) .Call(wrap__RPolarsSeries__map_elements, self, robj, rdatatype, strict, allow_fail_eval)
-
-RPolarsSeries$mean = function() .Call(wrap__RPolarsSeries__mean, self)
-
-RPolarsSeries$median = function() .Call(wrap__RPolarsSeries__median, self)
-
-RPolarsSeries$min = function() .Call(wrap__RPolarsSeries__min, self)
-
-RPolarsSeries$max = function() .Call(wrap__RPolarsSeries__max, self)
-
-RPolarsSeries$sum = function() .Call(wrap__RPolarsSeries__sum, self)
-
-RPolarsSeries$std = function(ddof) .Call(wrap__RPolarsSeries__std, self, ddof)
-
-RPolarsSeries$var = function(ddof) .Call(wrap__RPolarsSeries__var, self, ddof)
-
-RPolarsSeries$ceil = function() .Call(wrap__RPolarsSeries__ceil, self)
-
-RPolarsSeries$floor = function() .Call(wrap__RPolarsSeries__floor, self)
-
-RPolarsSeries$print = function() invisible(.Call(wrap__RPolarsSeries__print, self))
-
-RPolarsSeries$cum_sum = function(reverse) .Call(wrap__RPolarsSeries__cum_sum, self, reverse)
-
-RPolarsSeries$to_frame = function() .Call(wrap__RPolarsSeries__to_frame, self)
-
-RPolarsSeries$set_sorted_mut = function(descending) invisible(.Call(wrap__RPolarsSeries__set_sorted_mut, self, descending))
-
-RPolarsSeries$from_arrow = function(name, array) .Call(wrap__RPolarsSeries__from_arrow, name, array)
+`$.RPolarsLazyGroupBy` <- function (self, name) { func <- RPolarsLazyGroupBy[[name]]; environment(func) <- environment(); func }
 
 #' @export
-`$.RPolarsSeries` = function(self, name) {
-  func = RPolarsSeries[[name]]
-  environment(func) = environment()
-  func
-}
+`[[.RPolarsLazyGroupBy` <- `$.RPolarsLazyGroupBy`
+
+RPolarsSeries <- new.env(parent = emptyenv())
+
+RPolarsSeries$new <- function(x, name) .Call(wrap__RPolarsSeries__new, x, name)
+
+RPolarsSeries$clone <- function() .Call(wrap__RPolarsSeries__clone, self)
+
+RPolarsSeries$sleep <- function(millis) .Call(wrap__RPolarsSeries__sleep, self, millis)
+
+RPolarsSeries$panic <- function() .Call(wrap__RPolarsSeries__panic, self)
+
+RPolarsSeries$to_r <- function() .Call(wrap__RPolarsSeries__to_r, self)
+
+RPolarsSeries$rename_mut <- function(name) invisible(.Call(wrap__RPolarsSeries__rename_mut, self, name))
+
+RPolarsSeries$dtype <- function() .Call(wrap__RPolarsSeries__dtype, self)
+
+RPolarsSeries$n_unique <- function() .Call(wrap__RPolarsSeries__n_unique, self)
+
+RPolarsSeries$name <- function() .Call(wrap__RPolarsSeries__name, self)
+
+RPolarsSeries$sort_mut <- function(descending) .Call(wrap__RPolarsSeries__sort_mut, self, descending)
+
+RPolarsSeries$value_counts <- function(sort, parallel) .Call(wrap__RPolarsSeries__value_counts, self, sort, parallel)
+
+RPolarsSeries$arg_min <- function() .Call(wrap__RPolarsSeries__arg_min, self)
+
+RPolarsSeries$arg_max <- function() .Call(wrap__RPolarsSeries__arg_max, self)
+
+RPolarsSeries$is_sorted_flag <- function() .Call(wrap__RPolarsSeries__is_sorted_flag, self)
+
+RPolarsSeries$is_sorted_reverse_flag <- function() .Call(wrap__RPolarsSeries__is_sorted_reverse_flag, self)
+
+RPolarsSeries$is_sorted <- function(descending) .Call(wrap__RPolarsSeries__is_sorted, self, descending)
+
+RPolarsSeries$series_equal <- function(other, null_equal, strict) .Call(wrap__RPolarsSeries__series_equal, self, other, null_equal, strict)
+
+RPolarsSeries$get_fmt <- function(index, str_length) .Call(wrap__RPolarsSeries__get_fmt, self, index, str_length)
+
+RPolarsSeries$to_fmt_char <- function(str_length) .Call(wrap__RPolarsSeries__to_fmt_char, self, str_length)
+
+RPolarsSeries$compare <- function(other, op) .Call(wrap__RPolarsSeries__compare, self, other, op)
+
+RPolarsSeries$rep <- function(n, rechunk) .Call(wrap__RPolarsSeries__rep, self, n, rechunk)
+
+RPolarsSeries$shape <- function() .Call(wrap__RPolarsSeries__shape, self)
+
+RPolarsSeries$len <- function() .Call(wrap__RPolarsSeries__len, self)
+
+RPolarsSeries$chunk_lengths <- function() .Call(wrap__RPolarsSeries__chunk_lengths, self)
+
+RPolarsSeries$abs <- function() .Call(wrap__RPolarsSeries__abs, self)
+
+RPolarsSeries$alias <- function(name) .Call(wrap__RPolarsSeries__alias, self, name)
+
+RPolarsSeries$all <- function() .Call(wrap__RPolarsSeries__all, self)
+
+RPolarsSeries$any <- function() .Call(wrap__RPolarsSeries__any, self)
+
+RPolarsSeries$add <- function(other) .Call(wrap__RPolarsSeries__add, self, other)
+
+RPolarsSeries$sub <- function(other) .Call(wrap__RPolarsSeries__sub, self, other)
+
+RPolarsSeries$mul <- function(other) .Call(wrap__RPolarsSeries__mul, self, other)
+
+RPolarsSeries$div <- function(other) .Call(wrap__RPolarsSeries__div, self, other)
+
+RPolarsSeries$rem <- function(other) .Call(wrap__RPolarsSeries__rem, self, other)
+
+RPolarsSeries$append_mut <- function(other) .Call(wrap__RPolarsSeries__append_mut, self, other)
+
+RPolarsSeries$map_elements <- function(robj, rdatatype, strict, allow_fail_eval) .Call(wrap__RPolarsSeries__map_elements, self, robj, rdatatype, strict, allow_fail_eval)
+
+RPolarsSeries$mean <- function() .Call(wrap__RPolarsSeries__mean, self)
+
+RPolarsSeries$median <- function() .Call(wrap__RPolarsSeries__median, self)
+
+RPolarsSeries$min <- function() .Call(wrap__RPolarsSeries__min, self)
+
+RPolarsSeries$max <- function() .Call(wrap__RPolarsSeries__max, self)
+
+RPolarsSeries$sum <- function() .Call(wrap__RPolarsSeries__sum, self)
+
+RPolarsSeries$std <- function(ddof) .Call(wrap__RPolarsSeries__std, self, ddof)
+
+RPolarsSeries$var <- function(ddof) .Call(wrap__RPolarsSeries__var, self, ddof)
+
+RPolarsSeries$ceil <- function() .Call(wrap__RPolarsSeries__ceil, self)
+
+RPolarsSeries$floor <- function() .Call(wrap__RPolarsSeries__floor, self)
+
+RPolarsSeries$print <- function() invisible(.Call(wrap__RPolarsSeries__print, self))
+
+RPolarsSeries$cum_sum <- function(reverse) .Call(wrap__RPolarsSeries__cum_sum, self, reverse)
+
+RPolarsSeries$to_frame <- function() .Call(wrap__RPolarsSeries__to_frame, self)
+
+RPolarsSeries$set_sorted_mut <- function(descending) invisible(.Call(wrap__RPolarsSeries__set_sorted_mut, self, descending))
+
+RPolarsSeries$from_arrow <- function(name, array) .Call(wrap__RPolarsSeries__from_arrow, name, array)
 
 #' @export
-`[[.RPolarsSeries` = `$.RPolarsSeries`
-
-RPolarsSQLContext = new.env(parent = emptyenv())
-
-RPolarsSQLContext$new = function() .Call(wrap__RPolarsSQLContext__new)
-
-RPolarsSQLContext$execute = function(query) .Call(wrap__RPolarsSQLContext__execute, self, query)
-
-RPolarsSQLContext$get_tables = function() .Call(wrap__RPolarsSQLContext__get_tables, self)
-
-RPolarsSQLContext$register = function(name, lf) .Call(wrap__RPolarsSQLContext__register, self, name, lf)
-
-RPolarsSQLContext$unregister = function(name) .Call(wrap__RPolarsSQLContext__unregister, self, name)
+`$.RPolarsSeries` <- function (self, name) { func <- RPolarsSeries[[name]]; environment(func) <- environment(); func }
 
 #' @export
-`$.RPolarsSQLContext` = function(self, name) {
-  func = RPolarsSQLContext[[name]]
-  environment(func) = environment()
-  func
-}
+`[[.RPolarsSeries` <- `$.RPolarsSeries`
+
+RPolarsSQLContext <- new.env(parent = emptyenv())
+
+RPolarsSQLContext$new <- function() .Call(wrap__RPolarsSQLContext__new)
+
+RPolarsSQLContext$execute <- function(query) .Call(wrap__RPolarsSQLContext__execute, self, query)
+
+RPolarsSQLContext$get_tables <- function() .Call(wrap__RPolarsSQLContext__get_tables, self)
+
+RPolarsSQLContext$register <- function(name, lf) .Call(wrap__RPolarsSQLContext__register, self, name, lf)
+
+RPolarsSQLContext$unregister <- function(name) .Call(wrap__RPolarsSQLContext__unregister, self, name)
 
 #' @export
-`[[.RPolarsSQLContext` = `$.RPolarsSQLContext`
-
-RPolarsStringCacheHolder = new.env(parent = emptyenv())
-
-RPolarsStringCacheHolder$hold = function() .Call(wrap__RPolarsStringCacheHolder__hold)
-
-RPolarsStringCacheHolder$release = function() .Call(wrap__RPolarsStringCacheHolder__release, self)
+`$.RPolarsSQLContext` <- function (self, name) { func <- RPolarsSQLContext[[name]]; environment(func) <- environment(); func }
 
 #' @export
-`$.RPolarsStringCacheHolder` = function(self, name) {
-  func = RPolarsStringCacheHolder[[name]]
-  environment(func) = environment()
-  func
-}
+`[[.RPolarsSQLContext` <- `$.RPolarsSQLContext`
+
+RPolarsStringCacheHolder <- new.env(parent = emptyenv())
+
+RPolarsStringCacheHolder$hold <- function() .Call(wrap__RPolarsStringCacheHolder__hold)
+
+RPolarsStringCacheHolder$release <- function() .Call(wrap__RPolarsStringCacheHolder__release, self)
 
 #' @export
-`[[.RPolarsStringCacheHolder` = `$.RPolarsStringCacheHolder`
+`$.RPolarsStringCacheHolder` <- function (self, name) { func <- RPolarsStringCacheHolder[[name]]; environment(func) <- environment(); func }
+
+#' @export
+`[[.RPolarsStringCacheHolder` <- `$.RPolarsStringCacheHolder`
 
 
 # nolint end

--- a/R/functions__lazy.R
+++ b/R/functions__lazy.R
@@ -479,7 +479,7 @@ pl$approx_n_unique = function(column) { #-> int or Expr
 #' df$with_columns(pl$sum("*"))
 pl$sum = function(..., verbose = TRUE) {
   column = list2(...)
-  if (length(column) == 1L) column <- column[[1L]]
+  if (length(column) == 1L) column = column[[1L]]
   if (inherits(column, "RPolarsSeries") || inherits(column, "RPolarsExpr")) {
     return(column$sum())
   }
@@ -520,7 +520,7 @@ pl$sum = function(..., verbose = TRUE) {
 #'
 pl$min = function(..., verbose = TRUE) {
   column = list2(...)
-  if (length(column) == 1L) column <- column[[1L]]
+  if (length(column) == 1L) column = column[[1L]]
   if (inherits(column, "RPolarsSeries") || inherits(column, "RPolarsExpr")) {
     return(column$min())
   }
@@ -565,7 +565,7 @@ pl$min = function(..., verbose = TRUE) {
 #'
 pl$max = function(..., verbose = TRUE) {
   column = list2(...)
-  if (length(column) == 1L) column <- column[[1L]]
+  if (length(column) == 1L) column = column[[1L]]
   if (inherits(column, "RPolarsSeries") || inherits(column, "RPolarsExpr")) {
     return(column$max())
   }

--- a/R/parquet.R
+++ b/R/parquet.R
@@ -53,9 +53,7 @@ pl$scan_parquet = function(
     row_count_offset = 0L,
     low_memory = FALSE,
     use_statistics = TRUE,
-    hive_partitioning = TRUE
-  ) {
-
+    hive_partitioning = TRUE) {
   new_from_parquet(
     path = file,
     n_rows = n_rows,
@@ -64,7 +62,7 @@ pl$scan_parquet = function(
     rechunk = rechunk,
     row_name = row_count_name,
     row_count = row_count_offset,
-    #storage_options = storage_options, # not supported yet
+    # storage_options = storage_options, # not supported yet
     low_memory = low_memory,
     use_statistics = use_statistics,
     hive_partitioning = hive_partitioning
@@ -76,23 +74,23 @@ pl$scan_parquet = function(
 #' @rdname IO_read_parquet
 #' @inheritParams scan_parquet
 #' @return DataFrame
-read_parquet = function( # remapped to pl$read_parquet, a hack to support roxygen2 @inheritsParams
-  file,
-  n_rows = NULL,
-  cache = TRUE,
-  parallel = c(
-    "Auto", # default
-    "None",
-    "Columns",
-    "RowGroups"
-  ),
-  rechunk = TRUE,
-  row_count_name = NULL,
-  row_count_offset = 0L,
-  low_memory = FALSE,
-  use_statistics = TRUE,
-  hive_partitioning = TRUE) {
-
+read_parquet = function(
+    # remapped to pl$read_parquet, a hack to support roxygen2 @inheritsParams
+    file,
+    n_rows = NULL,
+    cache = TRUE,
+    parallel = c(
+      "Auto", # default
+      "None",
+      "Columns",
+      "RowGroups"
+    ),
+    rechunk = TRUE,
+    row_count_name = NULL,
+    row_count_offset = 0L,
+    low_memory = FALSE,
+    use_statistics = TRUE,
+    hive_partitioning = TRUE) {
   args = as.list(environment())
   result({
     do.call(pl$scan_parquet, args)$collect()

--- a/R/rust_result.R
+++ b/R/rust_result.R
@@ -56,7 +56,7 @@ Err = function(x) {
 #' @param f a closure that takes the err part as input
 #' @return same R object wrapped in a Err-result
 map_err = function(x, f) {
-  if (is_err(x)) x$err <- f(x$err)
+  if (is_err(x)) x$err = f(x$err)
   x
 }
 
@@ -66,7 +66,7 @@ map_err = function(x, f) {
 #' @return same R object wrapped in a Err-result
 #' @noRd
 map = function(x, f) {
-  if (is_ok(x)) x$ok <- f(x$ok)
+  if (is_ok(x)) x$ok = f(x$ok)
   x
 }
 

--- a/R/series__series.R
+++ b/R/series__series.R
@@ -366,7 +366,7 @@ Series_map_elements = function(
 }
 
 Series_apply = function(f, datatype = NULL, strict_return_type = TRUE,
-                         allow_fail_eval = FALSE) {
+                        allow_fail_eval = FALSE) {
   warning("$apply() is deprecated and will be removed in 0.13.0. Use $map_elements() instead.")
   Series_map_elements(f,
     datatype = datatype, strict_return_type = strict_return_type,

--- a/altdoc/altdoc_preprocessing.R
+++ b/altdoc/altdoc_preprocessing.R
@@ -9,7 +9,7 @@ library(pkgload)
 
 pkgload::load_all(".")
 
-yml <- read_yaml("altdoc/mkdocs_static.yml")
+yml = read_yaml("altdoc/mkdocs_static.yml")
 
 is_internal = function(file) {
   y = capture.output(tools::Rd2latex(file))
@@ -77,13 +77,13 @@ hierarchy = append(out, setNames(list(tmp), "Other"))
 hierarchy = append(list("Reference" = "reference_home.md"), hierarchy)
 
 # Insert the links in the settings
-yml$nav[[3]]$Reference <- hierarchy
+yml$nav[[3]]$Reference = hierarchy
 
 # These two elements should be lists in the yaml format, not single elements,
 # otherwise mkdocs breaks
 for (i in c("extra_css", "plugins")) {
   if (!is.null(yml[[i]]) && !is.list(length(yml[[i]]))) {
-    yml[[i]] <- as.list(yml[[i]])
+    yml[[i]] = as.list(yml[[i]])
   }
 }
 

--- a/dev/styler_utils.R
+++ b/dev/styler_utils.R
@@ -6,11 +6,17 @@ rpolars_style = function() {
   # derive from tidyverse
   transformers = styler::tidyverse_style()
   transformers$style_guide_name = "rpolars_style"
-  transformers$style_guide_version = "0.1.0"
+  transformers$style_guide_version = "0.1.1"
 
   # reverse tranformer to make <- into =
   transformers$token$force_assignment_op = function(pd) {
     to_replace = pd$token == "LEFT_ASSIGN"
+
+    # pretect against changing globalAssign operator, which does not have a unique defined token.
+    if (any(to_replace)) {
+      to_replace = to_replace & pd$text != "<<-"
+    }
+
     pd$token[to_replace] = "EQ_ASSIGN"
     pd$text[to_replace] = "="
     pd

--- a/dev/styler_utils.R
+++ b/dev/styler_utils.R
@@ -175,3 +175,12 @@ style_files = function(
   }
   invisible(NULL)
 }
+
+#' rpolars style entire package
+#' @return NULL
+#' style_entire_pkg()
+style_entire_pkg = function() {
+  list.files(".", full.names = TRUE, pattern = "\\.R$|\\.Rmd$", recursive = TRUE) |>
+    setdiff("./R/extendr-wrappers.R") |>
+    style_files()
+}

--- a/inst/misc/develop_polars.R
+++ b/inst/misc/develop_polars.R
@@ -290,15 +290,15 @@ run_all_examples_collect_errors = \(skip_these = character(), time_examples = FA
 
 
   out = lapply(paths, \(path) {
-    cat("\n",path)
-    if(time_examples) t1 = Sys.time()
+    cat("\n", path)
+    if (time_examples) t1 = Sys.time()
     txt = capture.output({
       err = polars:::result(pkgload::run_example(path = path))$err
     })
-    if(time_examples) {
+    if (time_examples) {
       t2 = Sys.time()
-      duration = difftime(t2,t1, units = "secs")
-      if(duration >.1) cat(" ", duration,"s")
+      duration = difftime(t2, t1, units = "secs")
+      if (duration > .1) cat(" ", duration, "s")
     }
     if (!is.null(err)) list(err = err, txt = txt)
   })

--- a/inst/misc/develop_polars.R
+++ b/inst/misc/develop_polars.R
@@ -15,7 +15,7 @@ load_polars = function(
     RPOLARS_CARGO_CLEAN_DEPS = "false",
     RPOLARS_PROFILE = "release",
     ...,
-    .packages = c("arrow", "nanoarrow")) {
+    .packages = c("arrow", "nanoarrow", "knitr")) {
   # bundle all envvars
   args = c(
     list(
@@ -48,7 +48,7 @@ build_polars = function(
     RPOLARS_CARGO_CLEAN_DEPS = "false",
     RPOLARS_PROFILE = "release",
     ...,
-    .packages = c("arrow", "nanoarrow")) {
+    .packages = c("arrow", "nanoarrow", "knitr")) {
   # bundle all envvars
   args = c(
     list(

--- a/inst/misc/examples/from_arrow.R
+++ b/inst/misc/examples/from_arrow.R
@@ -7,44 +7,46 @@ library(nycflights13)
 # for(i in names(which(sapply(nyx,is.character)))) {
 #   nyx[[i]] = NULL
 # }
-big_arrow_table = do.call(rbind,lapply(1:25, \(x) arrow::arrow_table(nycflights13::flights)))
-(dim(big_arrow_table)/c(1E6,1)) |> paste(c("million rows", "cols"))
-cat("total n chunks:", ncol(big_arrow_table)* big_arrow_table$column(1)$num_chunks)
+big_arrow_table = do.call(rbind, lapply(1:25, \(x) arrow::arrow_table(nycflights13::flights)))
+(dim(big_arrow_table) / c(1E6, 1)) |> paste(c("million rows", "cols"))
+cat("total n chunks:", ncol(big_arrow_table) * big_arrow_table$column(1)$num_chunks)
 
 library(nanoarrow)
 library(bench)
 
 # via arrow API
 system.time({
-   rbr = as_record_batch_reader(big_arrow_table)
-      df = polars:::rb_list_to_df(rbr$batches(),rbr$schema$names)
+  rbr = as_record_batch_reader(big_arrow_table)
+  df = polars:::rb_list_to_df(rbr$batches(), rbr$schema$names)
 })
 
 system.time({
-   rbr = as_record_batch_reader(big_arrow_table)
-   df = pl$from_arrow(rbr)
+  rbr = as_record_batch_reader(big_arrow_table)
+  df = pl$from_arrow(rbr)
 })
 
 # via r-polars conversion full copy
 big_df = as.data.frame(big_arrow_table)
-system.time({df_simple = pl$DataFrame(big_df)})
-#about 40 times speed up
+system.time({
+  df_simple = pl$DataFrame(big_df)
+})
+# about 40 times speed up
 
 
 x = bench::mark(
   # much faster because strings are never materialized to R
   to_arrow = {
-      rbr = as_record_batch_reader(big_arrow_table)
-      df = polars:::rb_list_to_df(rbr$batches(),rbr$schema$names)
+    rbr = as_record_batch_reader(big_arrow_table)
+    df = polars:::rb_list_to_df(rbr$batches(), rbr$schema$names)
   },
   from_arrow = {
-      pl$from_arrow(big_arrow_table)
+    pl$from_arrow(big_arrow_table)
   },
   from_arrow_no_rechunk = {
-      pl$from_arrow(big_arrow_table,rechunk = FALSE)
+    pl$from_arrow(big_arrow_table, rechunk = FALSE)
   },
-  from_arrow_all_series ={
-    lapply(big_arrow_table$columns, pl$from_arrow, rechunk=FALSE)
+  from_arrow_all_series = {
+    lapply(big_arrow_table$columns, pl$from_arrow, rechunk = FALSE)
   },
 
   # ,
@@ -57,27 +59,27 @@ x = bench::mark(
 
 x
 
-#a not very smooth to way to do rechunk in arrow
+# a not very smooth to way to do rechunk in arrow
 bat = arrow::Table$create(
-  do.call(data.frame,lapply(big_arrow_table$columns, \(x) as.vector(as_arrow_array(x))) )
+  do.call(data.frame, lapply(big_arrow_table$columns, \(x) as.vector(as_arrow_array(x))))
 )
 
 
 y = bench::mark(
   # much faster because strings are never materialized to R
   to_arrow = {
-      rbr = as_record_batch_reader(bat)
-      df = polars:::rb_list_to_df(rbr$batches(),rbr$schema$names)
+    rbr = as_record_batch_reader(bat)
+    df = polars:::rb_list_to_df(rbr$batches(), rbr$schema$names)
   },
   from_arrow = {
-      pl$from_arrow(bat)
+    pl$from_arrow(bat)
   },
-  from_arrow_all_series ={
-    lapply(big_arrow_table$columns, pl$from_arrow, rechunk=FALSE)
+  from_arrow_all_series = {
+    lapply(big_arrow_table$columns, pl$from_arrow, rechunk = FALSE)
   },
   to_arrow2 = {
-      rbr = as_record_batch_reader(bat)
-      df = polars:::rb_list_to_df(rbr$batches(),rbr$schema$names)
+    rbr = as_record_batch_reader(bat)
+    df = polars:::rb_list_to_df(rbr$batches(), rbr$schema$names)
   },
   # ,
   # DataFrame = {
@@ -91,11 +93,3 @@ print(x)
 print(y)
 
 arrow:::as_arrow_array.ChunkedArray(big_arrow_table$column(1))
-
-
-
-
-
-
-
-

--- a/inst/misc/renv_mentions.R
+++ b/inst/misc/renv_mentions.R
@@ -1,1 +1,0 @@
-library("styler.equals")

--- a/inst/misc/simple_benchmark.R
+++ b/inst/misc/simple_benchmark.R
@@ -3,12 +3,12 @@ library(polars)
 library(nanoarrow)
 library(bench)
 
-df <- pl$DataFrame(nycflights13::flights)
+df = pl$DataFrame(nycflights13::flights)
 nyf = nycflights13::flights
-for(i in  names(nyf)[sapply(nyf,is.character)]) nyf[[i]]<-NULL
-df_no_char <- pl$DataFrame(nyf)
+for (i in names(nyf)[sapply(nyf, is.character)]) nyf[[i]] = NULL
+df_no_char = pl$DataFrame(nyf)
 
-n <- df$shape[1]
+n = df$shape[1]
 
 x = bench::mark(
   nanoarrow = {
@@ -21,14 +21,14 @@ x = bench::mark(
   arrow_table = {
     as.data.frame(as.data.frame(arrow::as_arrow_table(df)))
   },
-  df2 <- pl$DataFrame(nycflights13::flights),
-  df3 <- pl$DataFrame(nyf),
-  df4 <- .pr$DataFrame$new_par_from_list(as.list(nycflights13::flights)),
-  df5 <- .pr$DataFrame$new_par_from_list(as.list(nyf)),
-  df_fa1 <- pl$from_arrow(arrow_table(nycflights13::flights)),
-  df_fa2 <- pl$from_arrow(arrow_table(nyf)),
-  df6 <- pl$DataFrame(nycflights13::flights,parallel = TRUE),
-  df7 <- pl$DataFrame(nyf,parallel = TRUE),
+  df2 = pl$DataFrame(nycflights13::flights),
+  df3 = pl$DataFrame(nyf),
+  df4 = .pr$DataFrame$new_par_from_list(as.list(nycflights13::flights)),
+  df5 = .pr$DataFrame$new_par_from_list(as.list(nyf)),
+  df_fa1 = pl$from_arrow(arrow_table(nycflights13::flights)),
+  df_fa2 = pl$from_arrow(arrow_table(nyf)),
+  df6 = pl$DataFrame(nycflights13::flights, parallel = TRUE),
+  df7 = pl$DataFrame(nyf, parallel = TRUE),
   polars_df = df$to_data_frame(),
   polars_list = df$to_list(),
   polars_list_no_char = df_no_char$to_list(),

--- a/tests/testthat/_snaps/knitr.md
+++ b/tests/testthat/_snaps/knitr.md
@@ -102,7 +102,9 @@
     Output
       
       ```r
-      nycflights13::flights |> to_html_table(5, 5) |> writeLines()
+      nycflights13::flights |>
+        to_html_table(5, 5) |>
+        writeLines()
       ```
       
       <div><style>

--- a/tests/testthat/files/flights.Rmd
+++ b/tests/testthat/files/flights.Rmd
@@ -1,4 +1,6 @@
 ```{r}
 #| results: asis
-nycflights13::flights |> to_html_table(5, 5) |> writeLines()
+nycflights13::flights |>
+  to_html_table(5, 5) |>
+  writeLines()
 ```

--- a/tests/testthat/test-arrow_extendr_polars.R
+++ b/tests/testthat/test-arrow_extendr_polars.R
@@ -33,7 +33,7 @@ test_that("rust-polars DataFrame import/export via arrow stream", {
   # check imported/exported df's are identical
   expect_identical(df_import$to_list(), df_export$to_list())
 
-  ##UNSAFE / Undefined behavior / will blow up eventually /  STUFF NOT TO DO
+  ## UNSAFE / Undefined behavior / will blow up eventually /  STUFF NOT TO DO
   # examples below of did segfault ~every 5-10th time, during development
 
   # 1: DO NOT EXPORT TO STREAM MORE THAN ONCE
@@ -45,8 +45,8 @@ test_that("rust-polars DataFrame import/export via arrow stream", {
   # 2: DO NOT IMPORT FROM STREAM MORE THAN ONCE
   # reading from released(exhuasted) stream results in error most times
   # BUT THIS SEGFAULTs sometimes
-  #ctx = arrow_stream_to_df(str_ptr)$err$contexts()
-  #expect_equal(
+  # ctx = arrow_stream_to_df(str_ptr)$err$contexts()
+  # expect_equal(
   # ctx$PlainErrorMessage,
   # r"{InvalidArgumentError("The C stream was already released")}"
   # )
@@ -67,5 +67,4 @@ test_that("rust-polars DataFrame import/export via arrow stream", {
   # print(df_import)
   # str_ptr = new_arrow_stream()
   # rsess$get_result()
-
 })

--- a/tests/testthat/test-context.R
+++ b/tests/testthat/test-context.R
@@ -1,8 +1,8 @@
 make_cases = function() {
   tibble::tribble(
-    ~.test_name, ~pola,   ~base,
-    "mean",       "mean",   mean,
-    "median",     "median", median,
+    ~.test_name, ~pola, ~base,
+    "mean", "mean", mean,
+    "median", "median", median,
   )
 }
 

--- a/tests/testthat/test-expr_arr.R
+++ b/tests/testthat/test-expr_arr.R
@@ -309,7 +309,7 @@ test_that("slice", {
   df = pl$DataFrame(l)
 
   r_slice = function(x, o, n = NULL) {
-    if (is.null(n)) n <- max(length(x) - o, 1L)
+    if (is.null(n)) n = max(length(x) - o, 1L)
     if (o >= 0) {
       o = o + 1
     } else {

--- a/tests/testthat/test-expr_expr.R
+++ b/tests/testthat/test-expr_expr.R
@@ -1770,7 +1770,7 @@ test_that("Expr_pct_change", {
 
 test_that("skew", {
   R_skewness = function(x, bias = TRUE, na.rm = FALSE) {
-    if (na.rm) x <- x[!is.na(x)]
+    if (na.rm) x = x[!is.na(x)]
     n = length(x)
     m2 = sum((x - mean(x))^2) / n
     m3 = sum((x - mean(x))^3) / n
@@ -1804,7 +1804,7 @@ test_that("skew", {
 
 test_that("kurtosis", {
   R_kurtosis = function(x, fisher = TRUE, bias = TRUE, na.rm = TRUE) {
-    if (na.rm) x <- x[!is.na(x)]
+    if (na.rm) x = x[!is.na(x)]
     n = length(x)
     m2 = sum((x - mean(x))^2) / n
     m4 = sum((x - mean(x))^4) / n
@@ -2213,7 +2213,7 @@ test_that("unique_counts", {
 test_that("entropy", {
   # https://stackoverflow.com/questions/27254550/calculating-entropy
   r_entropy = function(x, base = exp(1), normalize = TRUE) {
-    if (normalize) x <- x / sum(x)
+    if (normalize) x = x / sum(x)
     -sum(x * log(x) / log(base))
   }
 

--- a/tests/testthat/test-parquet.R
+++ b/tests/testthat/test-parquet.R
@@ -59,5 +59,4 @@ test_that("scan read parquet - parallel strategies", {
   expect_identical(ctx$BadArgument, "parallel")
   ctx = pl$read_parquet(tmpf, parallel = 42) |> get_err_ctx()
   expect_identical(ctx$NotAChoice, "input is not a character vector")
-
 })

--- a/tests/testthat/test-s3_methods.R
+++ b/tests/testthat/test-s3_methods.R
@@ -40,7 +40,7 @@ patrick::with_parameters_test_that("inspection",
     d = pl$DataFrame(mtcars)
     x = FUN(mtcars)
     y = FUN(d)
-    if (inherits(y, "RPolarsDataFrame")) y <- y$to_data_frame()
+    if (inherits(y, "RPolarsDataFrame")) y = y$to_data_frame()
     expect_equal(x, y, ignore_attr = TRUE)
     if (.test_name == "as.matrix") {
       z = FUN(d$lazy())
@@ -79,8 +79,8 @@ patrick::with_parameters_test_that("RPolarsSeries",
     x = base(mtcars$mpg)
     y = base(d)
     z = d[[pola]]()
-    if (inherits(y, "RPolarsSeries")) y <- y$to_vector()
-    if (inherits(z, "RPolarsSeries")) z <- z$to_vector()
+    if (inherits(y, "RPolarsSeries")) y = y$to_vector()
+    if (inherits(z, "RPolarsSeries")) z = z$to_vector()
     expect_equal(x, y, ignore_attr = TRUE)
     expect_equal(x, z, ignore_attr = TRUE)
   },

--- a/tests/testthat/test-series.R
+++ b/tests/testthat/test-series.R
@@ -140,7 +140,7 @@ test_that("Series_append", {
   pl$reset_options()
 
   expect_error(
-    s_new <- s_mut$append(pl$Series(1:3), immutable = FALSE),
+    s_new = s_mut$append(pl$Series(1:3), immutable = FALSE),
     regexp = "breaks immutability"
   )
 })
@@ -521,7 +521,7 @@ patrick::with_parameters_test_that("mean, median, std, var",
     s = pl$Series(rnorm(100))
     a = s[[.test_name]]()
     # upstream .std_as_series() does not appear to return Series
-    if (inherits(a, "RPolarsSeries")) a <- a$to_vector()
+    if (inherits(a, "RPolarsSeries")) a = a$to_vector()
     b = base(s$to_vector())
     expect_equal(a, b)
   },

--- a/tests/testthat/test-series.R
+++ b/tests/testthat/test-series.R
@@ -140,7 +140,7 @@ test_that("Series_append", {
   pl$reset_options()
 
   expect_error(
-    s_new = s_mut$append(pl$Series(1:3), immutable = FALSE),
+    s_mut$append(pl$Series(1:3), immutable = FALSE),
     regexp = "breaks immutability"
   )
 })


### PR DESCRIPTION
update to rpolars_style  to not convert  the `<<-`  operator to `=` in e.g. `utils.R`