### PR TITLE
Fix vignette absence

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,7 @@ Suggests:
     vctrs,
     withr
 Config/Needs/website:
-    etiennebacher/altdoc@debugging2,
+    etiennebacher/altdoc@8f68103,
     future.apply,
     here,
     magrittr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,7 @@ Suggests:
     vctrs,
     withr
 Config/Needs/website:
-    etiennebacher/altdoc@5c69f3b,
+    etiennebacher/altdoc@debugging2,
     future.apply,
     here,
     magrittr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,7 @@ Suggests:
     vctrs,
     withr
 Config/Needs/website:
-    etiennebacher/altdoc@8f68103,
+    etiennebacher/altdoc@c75ec50,
     future.apply,
     here,
     magrittr,

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ all: fmt tools/lib-sums.tsv build test README.md LICENSE.note ## build -> test -
 
 .PHONY: docs
 docs: build install README.md altdoc/reference_home.md ## Generate docs
-	Rscript -e 'future::plan(future::multicore); source("altdoc/altdoc_preprocessing.R"); altdoc::render_docs(freeze = FALSE, parallel = TRUE)'
+	Rscript -e 'future::plan(future::multicore); source("altdoc/altdoc_preprocessing.R"); altdoc::render_docs(freeze = FALSE, parallel = TRUE, verbose = TRUE)'
 
 .PHONY: docs-preview
 docs-preview: ## Preview docs on local server. Needs `make docs`


### PR DESCRIPTION
Related to #605 

From what I can see in https://github.com/rpolars/rpolars.github.io/tree/main/vignettes, vignettes are well rendered to markdown, but for some reason `mkdocs` doesn't build their HTML page. This PR uses a debugging branch in altdoc that prints the output of `mkdocs build`.