### PR TITLE
build: add Taskfile.yml to use task as a build tool

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -28,3 +28,4 @@
 ^DEVELOPMENT\.md$
 
 ^\.venv_altdoc$
+^Taskfile\.yml$

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ src/Makevars
 # Python
 .venv
 
+# Task cache
+.task
+
 # Binary files
 tools/libr_polars.a
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -176,6 +176,7 @@ tasks:
       - Rscript -e 'if (desc::desc_get("RoxygenNote") < packageVersion("roxygen2")) quit(status = 1)'
     deps:
       - build-extendr-wrappers
+      - format-r
     cmds:
       - Rscript -e
         '{{.R_FUNC_IMPORT_REQUIRED_PKGS}};
@@ -190,6 +191,8 @@ tasks:
       - "{{.MANIFEST}}"
       - "{{.CARGO_LOCK}}"
       - "{{.RUST_SOURCE}}"
+    deps:
+      - format-rs
     generates:
       - R/extendr-wrappers.R
     status:
@@ -245,8 +248,49 @@ tasks:
     deps:
       - install-package
       - build-readme
+      - build-altdoc-ref-home
     cmds:
       - Rscript -e
         'future::plan(future::multicore);
         source("altdoc/altdoc_preprocessing.R");
         altdoc::render_docs(freeze = FALSE, parallel = TRUE, verbose = TRUE)'
+
+  build-altdoc-ref-home:
+    internal: true
+    desc: Build the altdoc reference home markdown
+    sources:
+      - "{{.R_SOURCE}}"
+      - src/Makevars*
+      - configure*
+      - "{{.MANIFEST}}"
+      - "{{.CARGO_LOCK}}"
+      - "{{.RUST_SOURCE}}"
+    generates:
+      - altdoc/reference_home.md
+    deps:
+      - install-package
+    cmds:
+      - Rscript -e
+        'library({{.PACKAGE_NAME}});
+        rmarkdown::render("altdoc/reference_home.Rmd")'
+
+  format-r:
+    desc: Format R source files.
+    vars:
+      FORMATER_SCRIPT: dev/styler_utils.R
+    sources:
+      - "{{.R_SOURCE}}"
+      - "{{.FORMATER_SCRIPT}}"
+    generates:
+      - "{{.R_SOURCE}}"
+      - exclude: R/extendr-wrappers.R
+    cmds:
+      - Rscript -e
+        'source("{{.FORMATER_SCRIPT}}"); style_files()'
+
+  format-rs:
+    desc: Format Rust source files.
+    sources:
+      - "{{.RUST_SOURCE}}"
+    cmds:
+      - cargo fmt --manifest-path "{{.MANIFEST}}"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -24,11 +24,11 @@ tasks:
   setup-dev:
     desc: Install tools for development.
     deps:
-      - install-r-tools
-      - install-rust-tools
-      - install-python-tools
+      - setup-r-tools
+      - setup-rust-tools
+      - setup-python-tools
 
-  install-r-tools:
+  setup-r-tools:
     internal: true
     env:
       PKG_SYSREQS: FALSE
@@ -38,9 +38,18 @@ tasks:
         'pak::repo_add("https://cloud.r-project.org/");
         pak::local_install_deps(dependencies = c("all", "Config/Needs/dev", "Config/Needs/website"))'
 
-  install-rust-tools:
+  setup-rust-tools:
     internal: true
     desc: Install Rust tools for development.
+    vars:
+      RUST_TOOLCHAIN_VERSION:
+        sh: Rscript -e 'read.dcf("DESCRIPTION", fields = "Config/polars/RustToolchainVersion", all = TRUE)[1, 1] |> cat()'
+    cmds:
+      - task: setup-rust-toolchain
+      - task: setup-cargo-tools
+
+  setup-rust-toolchain:
+    desc: Install Rust toolchain.
     vars:
       RUST_TOOLCHAIN_VERSION:
         sh: Rscript -e 'read.dcf("DESCRIPTION", fields = "Config/polars/RustToolchainVersion", all = TRUE)[1, 1] |> cat()'
@@ -49,8 +58,12 @@ tasks:
       - rustup default {{.RUST_TOOLCHAIN_VERSION}}{{if eq OS "windows"}}-gnu{{end}}
       - rustup component add rustfmt
       - rustup component add clippy
-      # - cargo install cargo-binstall
-      # - cargo binstall cargo-license cargo-outdated
+
+  setup-cargo-tools:
+    desc: Install cargo tools for development.
+    cmds:
+      - cargo install cargo-binstall
+      - cargo binstall cargo-license cargo-outdated
 
   setup-venv:
     desc: Setup Python venv for development.
@@ -60,7 +73,7 @@ tasks:
     cmds:
       - python3 -m venv {{.VENV_DIR}}
 
-  install-python-tools:
+  setup-python-tools:
     internal: true
     desc: Install Python tools for development.
     deps:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -226,6 +226,7 @@ tasks:
       - man/*.Rd
       - altdoc/altdoc_preprocessing.R
       - altdoc/*.yml
+      - vignettes/*.Rmd
     generates:
       - docs/**
     deps:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -226,7 +226,7 @@ tasks:
       - man/*.Rd
       - altdoc/altdoc_preprocessing.R
       - altdoc/*.yml
-      - vignettes/*.Rmd
+      - "{{.VIGNETTES}}"
     generates:
       - docs/**
     deps:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -149,6 +149,9 @@ tasks:
   test-vignettes:
     desc: Check if vignettes can be rendered.
     internal: true
+    vars:
+      ITEMS:
+        sh: find vignettes -type f -name '*.Rmd'
     sources:
       - "{{.VIGNETTES}}"
       - "{{.R_SOURCE}}"
@@ -160,10 +163,10 @@ tasks:
     deps:
       - install-package
     cmds:
-      - Rscript -e
-        'library({{.PACKAGE_NAME}});
-        list.files("vignettes/", pattern = r"(\.Rmd$)", recursive = TRUE, full.names = TRUE) |>
-        purrr::walk(\(x) rmarkdown::render(x, output_dir = tempdir()))'
+      - for: { var: ITEMS }
+        cmd: Rscript -e
+          'library({{.PACKAGE_NAME}});
+          rmarkdown::render("{{.ITEM}}", output_dir = tempdir())'
 
   build-documents:
     desc: Build the R package and generate documents.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -203,7 +203,8 @@ tasks:
     cmds:
       - Rscript -e
         '{{.R_FUNC_IMPORT_REQUIRED_PKGS}};
-        rextendr::document()'
+        withr::local_envvar(devtools::r_env_vars());
+        rextendr::register_extendr()'
 
   build-readme:
     internal: true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,238 @@
+version: "3"
+
+env:
+  NOT_CRAN: "true"
+  LIBR_POLARS_BUILD: "true"
+  RPOLARS_FULL_FEATURES: "true"
+
+vars:
+  PACKAGE_NAME: polars
+  REQUIRE_R_PKGS: "arrow,nanoarrow,knitr"
+  VENV_DIR: .venv_altdoc
+  VENV_BIN:
+    sh: echo '{{.VENV_DIR}}/{{if eq OS "windows"}}Scripts{{else}}bin{{end}}'
+
+  MANIFEST: src/rust/Cargo.toml
+  CARGO_LOCK: src/rust/Cargo.lock
+  R_SOURCE: R/*
+  VIGNETTES: vignettes/**/*.Rmd
+  RUST_SOURCE: src/rust/src/**/*.rs
+
+  R_FUNC_IMPORT_REQUIRED_PKGS: strsplit("{{.REQUIRE_R_PKGS}}", ",") |> unlist() |> lapply(require, character.only = TRUE) |> invisible()
+
+tasks:
+  setup-dev:
+    desc: Install tools for development.
+    deps:
+      - install-r-tools
+      - install-rust-tools
+      - install-python-tools
+
+  install-r-tools:
+    internal: true
+    env:
+      PKG_SYSREQS: FALSE
+    desc: Install R packages for development.
+    cmds:
+      - Rscript -e
+        'pak::repo_add("https://cloud.r-project.org/");
+        pak::local_install_deps(dependencies = c("all", "Config/Needs/dev", "Config/Needs/website"))'
+
+  install-rust-tools:
+    internal: true
+    desc: Install Rust tools for development.
+    vars:
+      RUST_TOOLCHAIN_VERSION:
+        sh: Rscript -e 'read.dcf("DESCRIPTION", fields = "Config/polars/RustToolchainVersion", all = TRUE)[1, 1] |> cat()'
+    cmds:
+      - rustup toolchain install {{.RUST_TOOLCHAIN_VERSION}}{{if eq OS "windows"}}-gnu{{end}}
+      - rustup default {{.RUST_TOOLCHAIN_VERSION}}{{if eq OS "windows"}}-gnu{{end}}
+      - rustup component add rustfmt
+      - rustup component add clippy
+      # - cargo install cargo-binstall
+      # - cargo binstall cargo-license cargo-outdated
+
+  setup-venv:
+    desc: Setup Python venv for development.
+    internal: true
+    generates:
+      - "{{.VENV_BIN}}"
+    cmds:
+      - python3 -m venv {{.VENV_DIR}}
+
+  install-python-tools:
+    internal: true
+    desc: Install Python tools for development.
+    deps:
+      - setup-venv
+    cmds:
+      - "{{.VENV_BIN}}/python -m pip install --upgrade pip"
+      - "{{.VENV_BIN}}/python -m pip install --upgrade mkdocs"
+      - "{{.VENV_BIN}}/python -m pip install --upgrade mkdocs-material"
+
+  build-lib-sums:
+    desc: Build lib-sums.tsv.
+    sources:
+      - dev/generate-lib-sums.R
+      - tools/prep-lib.R
+      - DESCRIPTION
+      - "{{.CARGO_LOCK}}"
+    generates:
+      - tools/lib-sums.tsv
+    cmds:
+      - Rscript dev/generate-lib-sums.R
+
+  build-all:
+    desc: Build the R package, generate documents, run all tests, and update files.
+    deps:
+      - build-lib-sums
+      - build-documents
+    cmds:
+      - task: test-all
+      - task: build-readme
+
+  test-all:
+    desc: Run all tests.
+    cmds:
+      - task: test-source
+      - task: test-examples
+      - task: test-vignettes
+
+  test-source:
+    desc: Run all tests for source.
+    internal: true
+    env:
+      POLARS_MAX_THREADS: 2 # workaround for https://github.com/pola-rs/polars/issues/13202
+    sources:
+      - tests/**/*
+      - "{{.R_SOURCE}}"
+      - src/Makevars*
+      - configure*
+      - "{{.MANIFEST}}"
+      - "{{.CARGO_LOCK}}"
+      - "{{.RUST_SOURCE}}"
+    deps:
+      - install-package
+    cmds:
+      - Rscript -e 'devtools::test()'
+
+  test-examples:
+    desc: Check if examples can be run.
+    internal: true
+    env:
+      POLARS_MAX_THREADS: 2 # workaround for https://github.com/pola-rs/polars/issues/13202
+    sources:
+      - "{{.R_SOURCE}}"
+      - src/Makevars*
+      - configure*
+      - "{{.MANIFEST}}"
+      - "{{.CARGO_LOCK}}"
+      - "{{.RUST_SOURCE}}"
+    deps:
+      - install-package
+    cmds:
+      - Rscript -e 'devtools::run_examples(document = FALSE)'
+
+  test-vignettes:
+    desc: Check if vignettes can be rendered.
+    internal: true
+    sources:
+      - "{{.VIGNETTES}}"
+      - "{{.R_SOURCE}}"
+      - src/Makevars*
+      - configure*
+      - "{{.MANIFEST}}"
+      - "{{.CARGO_LOCK}}"
+      - "{{.RUST_SOURCE}}"
+    deps:
+      - install-package
+    cmds:
+      - Rscript -e
+        'library({{.PACKAGE_NAME}});
+        list.files("vignettes/", pattern = r"(\.Rmd$)", recursive = TRUE, full.names = TRUE) |>
+        purrr::walk(\(x) rmarkdown::render(x, output_dir = tempdir()))'
+
+  build-documents:
+    desc: Build the R package and generate documents.
+    internal: true
+    sources:
+      - "{{.R_SOURCE}}"
+    generates:
+      - man/*.Rd
+    status:
+      - Rscript -e 'if (desc::desc_get("RoxygenNote") < packageVersion("roxygen2")) quit(status = 1)'
+    deps:
+      - build-extendr-wrappers
+    cmds:
+      - Rscript -e
+        '{{.R_FUNC_IMPORT_REQUIRED_PKGS}};
+        devtools::document()'
+
+  build-extendr-wrappers:
+    internal: true
+    desc: Build the extendr wrappers.
+    sources:
+      - src/Makevars*
+      - configure*
+      - "{{.MANIFEST}}"
+      - "{{.CARGO_LOCK}}"
+      - "{{.RUST_SOURCE}}"
+    generates:
+      - R/extendr-wrappers.R
+    status:
+      - Rscript -e 'if (desc::desc_get("Config/rextendr/version") < packageVersion("rextendr")) quit(status = 1)'
+    cmds:
+      - Rscript -e
+        '{{.R_FUNC_IMPORT_REQUIRED_PKGS}};
+        rextendr::document()'
+
+  build-readme:
+    internal: true
+    desc: Build README.md
+    sources:
+      - README.Rmd
+      - "{{.R_SOURCE}}"
+      - src/Makevars*
+      - configure*
+      - "{{.MANIFEST}}"
+      - "{{.CARGO_LOCK}}"
+      - "{{.RUST_SOURCE}}"
+    generates:
+      - README.md
+    deps:
+      - install-package
+    cmds:
+      - Rscript -e
+        'library({{.PACKAGE_NAME}});
+        rmarkdown::render(input = "README.Rmd", output_file = "README.md")'
+
+  install-package:
+    desc: Install the R package.
+    sources:
+      - "{{.R_SOURCE}}"
+      - src/Makevars*
+      - configure*
+      - "{{.MANIFEST}}"
+      - "{{.CARGO_LOCK}}"
+      - "{{.RUST_SOURCE}}"
+    deps:
+      - build-documents
+    cmds:
+      - R CMD INSTALL --no-multiarch --with-keep.source .
+
+  build-website:
+    desc: Build the website.
+    sources:
+      - man/*.Rd
+      - altdoc/altdoc_preprocessing.R
+      - altdoc/*.yml
+    generates:
+      - docs/**
+    deps:
+      - install-package
+      - build-readme
+    cmds:
+      - Rscript -e
+        'future::plan(future::multicore);
+        source("altdoc/altdoc_preprocessing.R");
+        altdoc::render_docs(freeze = FALSE, parallel = TRUE, verbose = TRUE)'


### PR DESCRIPTION
A part of #556

Allows use of `task` instead of `make`.
Most of the content was copied from the prqlr repository.