### PR TITLE
refactor: minor refactoring of the check_feature functon

### DIFF
--- a/R/error__rpolarserr.R
+++ b/R/error__rpolarserr.R
@@ -54,7 +54,7 @@ bad_robj = function(r) {
 }
 
 Err_plain = function(...) {
-  Err(.pr$Err$new()$plain(paste(..., collapse = " ")))
+  Err(.pr$Err$new()$plain(paste0(..., collapse = " ")))
 }
 
 # short hand for extracting an error context in unit testing, will raise error if not an RPolarsErr

--- a/R/info.R
+++ b/R/info.R
@@ -57,7 +57,7 @@ print.polars_info = function(x, ...) {
 #'   error = \(e) cat(as.character(e))
 #' )
 check_feature = function(feature_name, context = NULL, call = sys.call(1L)) {
-  if (!pl$polars_info()$features[[feature_name]]) {
+  if (!cargo_rpolars_feature_info()[[feature_name]]) {
     Err_plain(
       "\nFeature '", feature_name, "' is not enabled.\n",
       "Please check the documentation about installation\n",


### PR DESCRIPTION
This includes reducing extraneous function calls and improving error messages.

Related to #241 (after this change, the `check_feature` function does not invoke Polars, so the number of threads can be changed after the `check_feature` function is called)