### PR TITLE
Fix error message in reprex

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -34,7 +34,7 @@ check_no_missing_args = function(
 #' @param class_name NULLs
 #' @noRd
 #' @return invisible(NULL)
-verify_method_call = function(Class_env, Method_name, call = sys.call(1L), class_name = NULL) {
+verify_method_call = function(Class_env, Method_name, call = sys.call(sys.nframe() - 2L), class_name = NULL) {
   if (polars_optenv$debug_polars) {
     class_name = class_name %||% as.character(as.list(match.call())$Class_env)
     cat("[", format(subtimer_ms(), digits = 4), "ms]\n", class_name, "$", Method_name, "() -> ", sep = "")


### PR DESCRIPTION
Close #281 

Error message is now identical when the code is run interactively and in `reprex()`:

``` r
library(polars)
pl$DataFrame(iris)$foo()
#> Error: syntax error: foo is not a method/attribute of the class RPolarsDataFrame 
#>  when calling method:
#>  pl$DataFrame(iris)$foo
```

<sup>Created on 2023-12-29 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>