### PR TITLE
build: fix devcontainer updateContentCommand not to hang

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -63,7 +63,7 @@ tasks:
     desc: Install cargo tools for development.
     cmds:
       - cargo install cargo-binstall
-      - cargo binstall cargo-license cargo-outdated
+      - cargo binstall -y cargo-license cargo-outdated
 
   setup-venv:
     desc: Setup Python venv for development.


### PR DESCRIPTION
I noticed that I can't use it with Codespaces because the devcontainer build stops if the `-y` option of `cargo binstall` is not set.