### PR TITLE
Fix absence of "Usage" section for Expr subnamespaces

### DIFF
--- a/R/expr__binary.R
+++ b/R/expr__binary.R
@@ -5,7 +5,7 @@
 
 
 #' contains
-#' @name ExprBin_contains
+#'
 #' @aliases expr_bin_contains
 #' @description R Check if binaries in Series contain a binary substring.
 #' @keywords ExprBin
@@ -17,7 +17,7 @@ ExprBin_contains = function(lit) {
 
 
 #' starts_with
-#' @name ExprBin_starts_with
+#'
 #' @aliases expr_bin_starts_with
 #' @description   Check if values starts with a binary substring.
 #' @keywords ExprBin
@@ -29,7 +29,7 @@ ExprBin_starts_with = function(sub) {
 
 
 #' ends_with
-#' @name ExprBin_ends_with
+#'
 #' @aliases expr_bin_ends_with
 #' @description   Check if string values end with a binary substring.
 #' @keywords ExprBin
@@ -41,7 +41,7 @@ ExprBin_ends_with = function(sub) {
 
 
 #' encode
-#' @name ExprBin_encode
+#'
 #' @aliases expr_bin_encode
 #' @description  Encode a value using the provided encoding.
 #' @keywords ExprBin
@@ -57,7 +57,7 @@ ExprBin_encode = function(encoding) {
 }
 
 #' decode
-#' @name ExprBin_decode
+#'
 #' @aliases expr_bin_decode
 #' @description Decode a value using the provided encoding.
 #' @keywords ExprBin

--- a/R/expr__binary.R
+++ b/R/expr__binary.R
@@ -31,11 +31,12 @@ ExprBin_starts_with = function(sub) {
 #' ends_with
 #'
 #' @aliases expr_bin_ends_with
-#' @description   Check if string values end with a binary substring.
+#' @description Check if string values end with a binary substring.
+#' @param suffix Suffix substring.
 #' @keywords ExprBin
 #' @return Expr returning a Boolean
-ExprBin_ends_with = function(sub) {
-  unwrap(.pr$Expr$bin_ends_with(self, sub))
+ExprBin_ends_with = function(suffix) {
+  unwrap(.pr$Expr$bin_ends_with(self, suffix))
 }
 
 

--- a/R/expr__categorical.R
+++ b/R/expr__categorical.R
@@ -1,5 +1,5 @@
 #' Set Ordering
-#' @name ExprCat_set_ordering
+#'
 #' @aliases expr_cat_set_ordering
 #' @description Determine how this categorical series should be sorted.
 #' @keywords ExprCat
@@ -23,7 +23,7 @@ ExprCat_set_ordering = function(ordering) {
 
 
 #' Get the categories stored in this data type
-#' @name ExprCat_get_categories
+#'
 #' @keywords ExprCat
 #' @return A polars DataFrame with the categories for each categorical Series.
 #' @examples

--- a/R/expr__datetime.R
+++ b/R/expr__datetime.R
@@ -1,7 +1,7 @@
 #' Truncate datetime
 #' @description  Divide the date/datetime range into buckets.
 #' Each date/datetime is mapped to the start of its bucket.
-#' @name ExprDT_truncate
+#'
 #' @param every string encoding duration see details.
 #' @param offset optional string encoding duration see details.
 #'
@@ -46,7 +46,7 @@ ExprDT_truncate = function(every, offset = NULL) {
 #' is mapped to the start of its bucket.
 #' Each date/datetime in the second half of the interval
 #' is mapped to the end of its bucket.
-#' @name ExprDT_round
+#'
 #'
 #' @param every string encoding duration see details.
 #' @param ofset optional string encoding duration see details.
@@ -99,7 +99,7 @@ ExprDT_round = function(every, offset = NULL) {
 #' is mapped to the start of its bucket.
 #' Each date/datetime in the second half of the interval
 #' is mapped to the end of its bucket.
-#' @name ExprDT_combine
+#'
 #'
 #' @param tm Expr or numeric or PTime, the number of epoch since or before(if negative) the Date
 #' or tm is an Expr e.g. a column of DataType 'Time' or something into an Expr.
@@ -142,7 +142,7 @@ ExprDT_combine = function(tm, tu = "us") {
 #' Format Date/Datetime with a formatting rule.
 #' See `chrono strftime/strptime
 #' <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>`_.
-#' @name ExprDT_strftime
+#'
 #'
 #' @param format string format very much like in R passed to chrono
 #'
@@ -163,7 +163,7 @@ ExprDT_strftime = function(format) {
 #' Extract year from underlying Date representation.
 #' Applies to Date and Datetime columns.
 #' Returns the year number in the calendar date.
-#' @name ExprDT_year
+#'
 #'
 #' @return Expr of Year as Int32
 #' @keywords ExprDT
@@ -194,7 +194,7 @@ ExprDT_year = function() {
 #' Applies to Date and Datetime columns.
 #' Returns the year number in the ISO standard.
 #' This may not correspond with the calendar year.
-#' @name ExprDT_iso_year
+#'
 #'
 #'
 #' @return Expr of iso_year as Int32
@@ -226,7 +226,7 @@ ExprDT_iso_year = function() {
 #' Extract quarter from underlying Date representation.
 #' Applies to Date and Datetime columns.
 #' Returns the quarter ranging from 1 to 4.
-#' @name ExprDT_quarter
+#'
 #' @return Expr of quarter as UInt32
 #' @keywords ExprDT
 #' @format function
@@ -255,7 +255,7 @@ ExprDT_quarter = function() {
 #' Applies to Date and Datetime columns.
 #' Returns the month number starting from 1.
 #' The return value ranges from 1 to 12.
-#' @name ExprDT_month
+#'
 #' @return Expr of month as UInt32
 #' @keywords ExprDT
 #' @format function
@@ -285,7 +285,7 @@ ExprDT_month = function() {
 #' Applies to Date and Datetime columns.
 #' Returns the ISO week number starting from 1.
 #' The return value ranges from 1 to 53. (The last week of year differs by years.)
-#' @name ExprDT_week
+#'
 #' @return Expr of week as UInt32
 #' @keywords ExprDT
 #' @format function
@@ -313,7 +313,7 @@ ExprDT_week = function() {
 #' Extract the week day from the underlying Date representation.
 #' Applies to Date and Datetime columns.
 #' Returns the ISO weekday number where monday = 1 and sunday = 7
-#' @name ExprDT_weekday
+#'
 #' @return Expr of weekday as UInt32
 #' @keywords ExprDT
 #' @format function
@@ -343,7 +343,7 @@ ExprDT_weekday = function() {
 #' Applies to Date and Datetime columns.
 #' Returns the day of month starting from 1.
 #' The return value ranges from 1 to 31. (The last day of month differs by months.)
-#' @name ExprDT_day
+#'
 #' @return Expr of day as UInt32
 #' @keywords ExprDT
 #' @format function
@@ -372,7 +372,7 @@ ExprDT_day = function() {
 #' Applies to Date and Datetime columns.
 #' Returns the day of year starting from 1.
 #' The return value ranges from 1 to 366. (The last day of year differs by years.)
-#' @name ExprDT_ordinal_day
+#'
 #' @return Expr of ordinal_day as UInt32
 #' @keywords ExprDT
 #' @format function
@@ -401,7 +401,7 @@ ExprDT_ordinal_day = function() {
 #' Extract hour from underlying Datetime representation.
 #' Applies to Datetime columns.
 #' Returns the hour number from 0 to 23.
-#' @name ExprDT_hour
+#'
 #' @return Expr of hour as UInt32
 #' @keywords ExprDT
 #' @format function
@@ -429,7 +429,7 @@ ExprDT_hour = function() {
 #' Extract minutes from underlying Datetime representation.
 #' Applies to Datetime columns.
 #' Returns the minute number from 0 to 59.
-#' @name ExprDT_minute
+#'
 #' @return Expr of minute as UInt32
 #' @keywords ExprDT
 #' @format function
@@ -459,7 +459,7 @@ ExprDT_minute = function() {
 #' Returns the integer second number from 0 to 59, or a floating
 #' point number from 0 < 60 if ``fractional=True`` that includes
 #' any milli/micro/nanosecond component.
-#' @name ExprDT_second
+#'
 #' @return Expr of second as UInt32
 #' @keywords ExprDT
 #' @format function
@@ -489,7 +489,7 @@ ExprDT_second = function(fractional = FALSE) {
 #' @description
 #' Extract milliseconds from underlying Datetime representation.
 #' Applies to Datetime columns.
-#' @name ExprDT_millisecond
+#'
 #' @return Expr of millisecond as Int64
 #' @keywords ExprDT
 #' @format function
@@ -514,7 +514,7 @@ ExprDT_millisecond = function() {
 #' @description
 #' Extract microseconds from underlying Datetime representation.
 #' Applies to Datetime columns.
-#' @name ExprDT_microsecond
+#'
 #' @return Expr of microsecond as Int64
 #' @keywords ExprDT
 #' @format function
@@ -546,7 +546,7 @@ ExprDT_microsecond = function() {
 #' Returns the integer second number from 0 to 59, or a floating
 #' point number from 0 < 60 if ``fractional=True`` that includes
 #' any milli/micro/nanosecond component.
-#' @name ExprDT_nanosecond
+#'
 #' @return Expr of second as Int64
 #' @keywords ExprDT
 #' @format function
@@ -572,7 +572,7 @@ ExprDT_nanosecond = function() {
 #' Epoch
 #' @description
 #' Get the time passed since the Unix EPOCH in the give time unit.
-#' @name ExprDT_epoch
+#'
 #' @param tu string option either 'ns', 'us', 'ms', 's' or  'd'
 #' @details ns and perhaps us will exceed integerish limit if returning to
 #' R as flaot64/double.
@@ -608,7 +608,7 @@ ExprDT_epoch = function(tu = c("us", "ns", "ms", "s", "d")) {
 
 #' timestamp
 #' @description Return a timestamp in the given time unit.
-#' @name ExprDT_timestamp
+#'
 #' @param tu string option either 'ns', 'us', or 'ms'
 #' @return Expr of i64
 #' @keywords ExprDT
@@ -640,7 +640,7 @@ ExprDT_timestamp = function(tu = c("ns", "us", "ms")) {
 #' @description  Set time unit of a Series of dtype Datetime or Duration.
 #' This does not modify underlying data, and should be used to fix an incorrect time unit.
 #' The corresponding global timepoint will change.
-#' @name ExprDT_with_time_unit
+#'
 #' @param tu string option either 'ns', 'us', or 'ms'
 #' @return Expr of i64
 #' @keywords ExprDT
@@ -673,7 +673,7 @@ ExprDT_with_time_unit = function(tu = c("ns", "us", "ms")) {
 #' Cast the underlying data to another time unit. This may lose precision.
 #' The corresponding global timepoint will stay unchanged +/- precision.
 #'
-#' @name ExprDT_cast_time_unit
+#'
 #' @param tu string option either 'ns', 'us', or 'ms'
 #' @return Expr of i64
 #' @keywords ExprDT
@@ -703,7 +703,7 @@ ExprDT_cast_time_unit = function(tu = c("ns", "us", "ms")) {
 #' With Time Zone
 #' @description Set time zone for a Series of type Datetime.
 #' Use to change time zone annotation, but keep the corresponding global timepoint.
-#' @name ExprDT_convert_time_zone
+#'
 #' @param tz String time zone from base::OlsonNames()
 #' @return Expr of i64
 #' @keywords ExprDT
@@ -740,7 +740,7 @@ ExprDT_convert_time_zone = function(tz) {
 #' Different from ``convert_time_zone``, this will also modify the underlying timestamp.
 #' Use to correct a wrong time zone annotation. This will change the corresponding global timepoint.
 #'
-#' @name ExprDT_replace_time_zone
+#'
 #' @param tz NULL or string time zone from [base::OlsonNames()]
 #' @param ambiguous Determine how to deal with ambiguous datetimes:
 #' * `"raise"` (default): raise
@@ -782,7 +782,7 @@ ExprDT_replace_time_zone = function(tz, ambiguous = "raise") {
 
 #' Days
 #' @description Extract the days from a Duration type.
-#' @name ExprDT_total_days
+#'
 #' @return Expr of i64
 #' @examples
 #' df = pl$DataFrame(
@@ -804,7 +804,7 @@ ExprDT_total_days = function() {
 
 #' Hours
 #' @description Extract the hours from a Duration type.
-#' @name ExprDT_total_hours
+#'
 #' @return Expr of i64
 #' @examples
 #' df = pl$DataFrame(
@@ -826,7 +826,7 @@ ExprDT_total_hours = function() {
 
 #' Minutes
 #' @description Extract the minutes from a Duration type.
-#' @name ExprDT_total_minutes
+#'
 #' @return Expr of i64
 #' @examples
 #' df = pl$DataFrame(
@@ -848,7 +848,7 @@ ExprDT_total_minutes = function() {
 
 #' Seconds
 #' @description Extract the seconds from a Duration type.
-#' @name ExprDT_total_seconds
+#'
 #' @return Expr of i64
 #' @examples
 #' df = pl$DataFrame(date = pl$date_range(
@@ -868,7 +868,7 @@ ExprDT_total_seconds = function() {
 
 #' milliseconds
 #' @description Extract the milliseconds from a Duration type.
-#' @name ExprDT_total_milliseconds
+#'
 #' @return Expr of i64
 #' @examples
 #' df = pl$DataFrame(date = pl$date_range(
@@ -888,7 +888,7 @@ ExprDT_total_milliseconds = function() {
 
 #' microseconds
 #' @description Extract the microseconds from a Duration type.
-#' @name ExprDT_total_microseconds
+#'
 #' @return Expr of i64
 #' @examples
 #' df = pl$DataFrame(date = pl$date_range(
@@ -908,7 +908,7 @@ ExprDT_total_microseconds = function() {
 
 #' nanoseconds
 #' @description Extract the nanoseconds from a Duration type.
-#' @name ExprDT_total_nanoseconds
+#'
 #' @return Expr of i64
 #' @examples
 #' df = pl$DataFrame(date = pl$date_range(
@@ -931,7 +931,7 @@ ExprDT_total_nanoseconds = function() {
 #' This differs from ``pl$col("foo_datetime_tu") + value_tu`` in that it can
 #' take months and leap years into account. Note that only a single minus
 #' sign is allowed in the ``by`` string, as the first character.
-#' @name ExprDT_offset_by
+#'
 #'
 #' @param by optional string encoding duration see details.
 #'
@@ -997,7 +997,7 @@ ExprDT_offset_by = function(by) {
 #'
 #' @return A Time Expr
 #'
-#' @name ExprDT_time
+#'
 #' @examples
 #' df = pl$DataFrame(dates = pl$date_range(
 #'   as.Date("2000-1-1"),

--- a/R/expr__list.R
+++ b/R/expr__list.R
@@ -8,7 +8,7 @@
 
 #' Lengths arrays in list
 #' @rdname ExprList_lengths
-#' @name ExprList_lengths
+#'
 #' @description
 #' Get the length of the arrays as UInt32
 #' @keywords ExprList
@@ -21,7 +21,7 @@
 ExprList_lengths = function() .pr$Expr$list_lengths(self)
 
 #' Sum lists
-#' @name ExprList_sum
+#'
 #' @description
 #' Sum all the lists in the array.
 #' @keywords ExprList
@@ -34,7 +34,7 @@ ExprList_lengths = function() .pr$Expr$list_lengths(self)
 ExprList_sum = function() .pr$Expr$list_sum(self)
 
 #' Max lists
-#' @name ExprList_max
+#'
 #' @description
 #' Compute the max value of the lists in the array.
 #' @keywords ExprList
@@ -47,7 +47,7 @@ ExprList_sum = function() .pr$Expr$list_sum(self)
 ExprList_max = function() .pr$Expr$list_max(self)
 
 #'  #' Min lists
-#' @name ExprList_min
+#'
 #' @description
 #' Compute the min value of the lists in the array.
 #' @keywords ExprList
@@ -60,7 +60,7 @@ ExprList_max = function() .pr$Expr$list_max(self)
 ExprList_min = function() .pr$Expr$list_min(self)
 
 #' Mean of lists
-#' @name ExprList_mean
+#'
 #' @description
 #' Compute the mean value of the lists in the array.
 #' @keywords ExprList
@@ -74,11 +74,11 @@ ExprList_mean = function() .pr$Expr$list_mean(self)
 
 #' @inherit Expr_sort title description return
 #' @param descending Sort values in descending order
-#' @name ExprList_sort
+#'
 ExprList_sort = function(descending = FALSE) .pr$Expr$list_sort(self, descending)
 
 #' Reverse list
-#' @name ExprList_reverse
+#'
 #' @description
 #' Reverse the arrays in the list.
 #' @keywords ExprList
@@ -93,7 +93,7 @@ ExprList_sort = function(descending = FALSE) .pr$Expr$list_sort(self, descending
 ExprList_reverse = function() .pr$Expr$list_reverse(self)
 
 #' Unique list
-#' @name ExprList_unique
+#'
 #' @description
 #' Get the unique/distinct values in the list.
 #' @keywords ExprList
@@ -109,7 +109,7 @@ ExprList_unique = function() .pr$Expr$list_unique(self)
 #' concat another list
 #' @description Concat the arrays in a Series dtype List in linear time.
 #' @param other Rlist, Expr or column of same type as self.
-#' @name ExprList_concat
+#'
 #' @keywords ExprList
 #' @format function
 #' @return Expr
@@ -129,7 +129,7 @@ ExprList_concat = function(other) {
 }
 
 #' Get list
-#' @name ExprList_get
+#'
 #' @description Get the value by index in the sublists.
 #' @param index numeric vector or Expr of length 1 or same length of Series.
 #' if length 1 pick same value from each sublist, if length as Series/column,
@@ -165,7 +165,7 @@ ExprList_get = function(index) .pr$Expr$list_get(self, wrap_e(index, str_to_lit 
 
 
 #' take in sublists
-#' @name ExprList_gather
+#'
 #' @description Get the take value of the sublists.
 #' @keywords ExprList
 #' @param index R list of integers for each sub-element or Expr or Series of type `List[usize]`
@@ -190,7 +190,7 @@ ExprList_gather = function(index, null_on_oob = FALSE) {
 }
 
 #' First in sublists
-#' @name ExprList_first
+#'
 #' @description Get the first value of the sublists.
 #' @keywords ExprList
 #' @format function
@@ -202,7 +202,7 @@ ExprList_gather = function(index, null_on_oob = FALSE) {
 ExprList_first = function() .pr$Expr$list_get(self, wrap_e(0L, str_to_lit = FALSE))
 
 #' Last in sublists
-#' @name ExprList_last
+#'
 #' @description Get the last value of the sublists.
 #' @keywords ExprList
 #' @format function
@@ -214,7 +214,7 @@ ExprList_first = function() .pr$Expr$list_get(self, wrap_e(0L, str_to_lit = FALS
 ExprList_last = function() .pr$Expr$list_get(self, wrap_e(-1L, str_to_lit = FALSE))
 
 #' Sublists contains
-#' @name ExprList_contains
+#'
 #' @description Check if sublists contain the given item.
 #' @param item any into Expr/literal
 #' @keywords ExprList
@@ -228,7 +228,7 @@ ExprList_contains = function(item) .pr$Expr$list_contains(self, wrap_e(item))
 
 
 #' Join sublists
-#' @name ExprList_join
+#'
 #' @description
 #' Join all string items in a sublist and place a separator between them.
 #' This errors if inner type of list `!= Utf8`.
@@ -246,7 +246,7 @@ ExprList_join = function(separator) {
 }
 
 #' Arg min sublists
-#' @name ExprList_arg_min
+#'
 #' @description Retrieve the index of the minimal value in every sublist.
 #' @keywords ExprList
 #' @format function
@@ -258,7 +258,7 @@ ExprList_join = function(separator) {
 ExprList_arg_min = function() .pr$Expr$list_arg_min(self)
 
 #' Arg max sublists
-#' @name ExprList_arg_max
+#'
 #' @description Retrieve the index of the maximum value in every sublist.
 #' @keywords ExprList
 #' @format function
@@ -273,7 +273,7 @@ ExprList_arg_max = function() .pr$Expr$list_arg_max(self)
 ## TODO contribute polars support negative n values for Diff sublist
 
 #' Diff sublists
-#' @name ExprList_diff
+#'
 #' @description Calculate the n-th discrete difference of every sublist.
 #' @param n Number of slots to shift
 #' @param null_behavior choice "ignore"(default) "drop"
@@ -290,7 +290,7 @@ ExprList_diff = function(n = 1, null_behavior = c("ignore", "drop")) {
 }
 
 #' Shift sublists
-#' @name ExprList_shift
+#'
 #' @description Shift values by the given period.
 #' @param periods Value. Number of places to shift (may be negative).
 #' @keywords ExprList
@@ -303,7 +303,7 @@ ExprList_diff = function(n = 1, null_behavior = c("ignore", "drop")) {
 ExprList_shift = function(periods = 1) unwrap(.pr$Expr$list_shift(self, periods))
 
 #' Slice sublists
-#' @name ExprList_slice
+#'
 #' @description Slice every sublist.
 #' @param offset value or Expr.  Start index. Negative indexing is supported.
 #' @param length value or Expr.
@@ -328,7 +328,7 @@ ExprList_slice = function(offset, length = NULL) {
 # TODO contribute polars let head and tail support negative indicies also regular head tail
 
 #' Heads of sublists
-#' @name ExprList_head
+#'
 #' @description head the first `n` values of every sublist.
 #' @param n Numeric or Expr, number of values to return for each sublist.
 #' @keywords ExprList
@@ -343,7 +343,7 @@ ExprList_head = function(n = 5L) {
 }
 
 #' Tails of sublists
-#' @name ExprList_tail
+#'
 #' @description tail the first `n` values of every sublist.
 #' @param n Numeric or Expr, number of values to return for each sublist.
 #' @keywords ExprList
@@ -379,7 +379,7 @@ ExprList_tail = function(n = 5L) {
 #' determine which columns to select. It is advised to set this value in a lazy
 #' query.
 #'
-#' @name ExprList_to_struct
+#'
 #' @keywords ExprList
 #' @format function
 #' @return Expr
@@ -401,7 +401,7 @@ ExprList_to_struct = function(
 }
 
 #' eval sublists (kinda like lapply)
-#' @name ExprList_eval
+#'
 #' @description Run any polars expression against the lists' elements.
 #' @param expr Expression to run. Note that you can select an element with
 #' `pl$first()`, or `pl$col()`

--- a/R/expr__list.R
+++ b/R/expr__list.R
@@ -199,7 +199,7 @@ ExprList_gather = function(index, null_on_oob = FALSE) {
 #' @examples
 #' df = pl$DataFrame(list(a = list(3:1, NULL, 1:2))) # NULL or integer() or list()
 #' df$select(pl$col("a")$list$first())
-ExprList_first = function(index) .pr$Expr$list_get(self, wrap_e(0L, str_to_lit = FALSE))
+ExprList_first = function() .pr$Expr$list_get(self, wrap_e(0L, str_to_lit = FALSE))
 
 #' Last in sublists
 #' @name ExprList_last
@@ -211,7 +211,7 @@ ExprList_first = function(index) .pr$Expr$list_get(self, wrap_e(0L, str_to_lit =
 #' @examples
 #' df = pl$DataFrame(list(a = list(3:1, NULL, 1:2))) # NULL or integer() or list()
 #' df$select(pl$col("a")$list$last())
-ExprList_last = function(index) .pr$Expr$list_get(self, wrap_e(-1L, str_to_lit = FALSE))
+ExprList_last = function() .pr$Expr$list_get(self, wrap_e(-1L, str_to_lit = FALSE))
 
 #' Sublists contains
 #' @name ExprList_contains
@@ -224,7 +224,7 @@ ExprList_last = function(index) .pr$Expr$list_get(self, wrap_e(-1L, str_to_lit =
 #' @examples
 #' df = pl$DataFrame(list(a = list(3:1, NULL, 1:2))) # NULL or integer() or list()
 #' df$select(pl$col("a")$list$contains(1L))
-ExprList_contains = function(other) .pr$Expr$list_contains(self, wrap_e(other))
+ExprList_contains = function(item) .pr$Expr$list_contains(self, wrap_e(item))
 
 
 #' Join sublists
@@ -403,13 +403,12 @@ ExprList_to_struct = function(
 #' eval sublists (kinda like lapply)
 #' @name ExprList_eval
 #' @description Run any polars expression against the lists' elements.
-#' @param Expr Expression to run. Note that you can select an element with `pl$first()`, or
-#' `pl$col()`
-#' @param parallel bool
-#' Run all expression parallel. Don't activate this blindly.
-#'             Parallelism is worth it if there is enough work to do per thread.
-#'             This likely should not be use in the groupby context, because we already
-#'             parallel execution per group
+#' @param expr Expression to run. Note that you can select an element with
+#' `pl$first()`, or `pl$col()`
+#' @param parallel Run all expression parallel. Don't activate this blindly.
+#' Parallelism is worth it if there is enough work to do per thread. This likely
+#' should not be use in the groupby context, because we already do parallel
+#' execution per group.
 #' @keywords ExprList
 #' @format function
 #' @return Expr

--- a/R/expr__meta.R
+++ b/R/expr__meta.R
@@ -1,5 +1,5 @@
 #' Meta Equal
-#' @name ExprMeta_eq
+#'
 #' @aliases expr_meta_equal
 #' @description Are two expressions on a meta level equal
 #' @keywords ExprMeta
@@ -28,7 +28,7 @@ ExprMeta_eq = function(other) {
 
 
 #' Meta Not Equal
-#' @name ExprMeta_neq
+#'
 #' @aliases expr_meta_not_equal
 #' @description Are two expressions on a meta level NOT equal
 #' @keywords ExprMeta
@@ -56,7 +56,7 @@ ExprMeta_neq = function(other) {
 }
 
 #' Pop
-#' @name ExprMeta_pop
+#'
 #' @aliases expr_meta_pop
 #' @description Pop the latest expression and return the input(s) of the popped expression.
 #' @keywords ExprMeta
@@ -76,7 +76,7 @@ ExprMeta_pop = function() {
 
 
 #' Root Name
-#' @name ExprMeta_root_names
+#'
 #' @aliases expr_meta_root_names
 #' @description Get a vector with the root column name
 #' @keywords ExprMeta
@@ -91,7 +91,7 @@ ExprMeta_root_names = function() {
 }
 
 #' Output Name
-#' @name ExprMeta_output_name
+#'
 #' @aliases expr_meta_output_names
 #' @description Get the column name that this expression would produce.
 #' It might not always be possible to determine the output name
@@ -109,7 +109,7 @@ ExprMeta_output_name = function() {
 }
 
 #' Undo aliases
-#' @name ExprMeta_undo_aliases
+#'
 #' @aliases expr_meta_undo_aliases
 #' @description Undo any renaming operation like ``alias`` or ``keep_name``.
 #' @keywords ExprMeta
@@ -125,7 +125,7 @@ ExprMeta_undo_aliases = function() {
 
 
 #' Has multiple outputs
-#' @name ExprMeta_has_multiple_outputs
+#'
 #' @aliases expr_has_multiple_outputs
 #' @description Whether this expression expands into multiple expressions.
 #' @keywords ExprMeta
@@ -139,7 +139,7 @@ ExprMeta_has_multiple_outputs = function() {
 
 
 #' Is regex projection.
-#' @name ExprMeta_is_regex_projection
+#'
 #' @aliases expr_is_regex_projection
 #' @description Whether this expression expands to columns that match a regex pattern.
 #' @keywords ExprMeta
@@ -162,7 +162,7 @@ ExprMeta_is_regex_projection = function() {
 #' If `return_as_string` is `FALSE`, prints the tree in the console but doesn't
 #' return any value.
 #'
-#' @name ExprMeta_tree_format
+#'
 #' @examples
 #' my_expr = (pl$col("foo") * pl$col("bar"))$sum()$over(pl$col("ham")) / 2
 #' my_expr$meta$tree_format()

--- a/R/expr__name.R
+++ b/R/expr__name.R
@@ -4,7 +4,7 @@
 #' @return Expr
 #' @seealso
 #' [`$prefix()`][ExprName_prefix] to add a prefix
-#' @name ExprName_suffix
+#'
 #' @examples
 #' dat = pl$DataFrame(mtcars)
 #'
@@ -24,7 +24,7 @@ ExprName_suffix = function(suffix) {
 #' @return Expr
 #' @seealso
 #' [`$suffix()`][ExprName_suffix] to add a suffix
-#' @name ExprName_prefix
+#'
 #' @examples
 #' dat = pl$DataFrame(mtcars)
 #'
@@ -43,7 +43,7 @@ ExprName_prefix = function(prefix) {
 #' Keep the original root name of the expression.
 #'
 #' @return Expr
-#' @name ExprName_keep
+#'
 #' @examples
 #' pl$DataFrame(list(alice = 1:3))$select(pl$col("alice")$alias("bob")$name$keep())
 ExprName_keep = function() {
@@ -59,7 +59,7 @@ ExprName_keep = function() {
 #'
 #' @param fun an R function which takes a string as input and return a string
 #' @return Expr
-#' @name ExprName_map
+#'
 #' @examples
 #' pl$DataFrame(list(alice = 1:3))$select(
 #'   pl$col("alice")$alias("joe_is_not_root")$name$map(\(x) paste0(x, "_and_bob"))
@@ -87,7 +87,7 @@ ExprName_map = function(fun) {
 #' expression in a chain.
 #'
 #' @return Expr
-#' @name ExprName_to_lowercase
+#'
 #' @examples
 #' pl$DataFrame(Alice = 1:3)$with_columns(pl$col("Alice")$name$to_lowercase())
 ExprName_to_lowercase = function() {
@@ -100,7 +100,7 @@ ExprName_to_lowercase = function() {
 #' @inherit ExprName_to_lowercase description
 #'
 #' @return Expr
-#' @name ExprName_to_uppercase
+#'
 #' @examples
 #' pl$DataFrame(Alice = 1:3)$with_columns(pl$col("Alice")$name$to_uppercase())
 ExprName_to_uppercase = function() {

--- a/R/expr__string.R
+++ b/R/expr__string.R
@@ -518,8 +518,8 @@ ExprStr_json_decode = function(dtype, infer_schema_length = 100) {
 #'   json_val = c('{"a":"1"}', NA, '{"a":2}', '{"a":2.1}', '{"a":true}')
 #' )
 #' df$select(pl$col("json_val")$str$json_path_match("$.a"))
-ExprStr_json_path_match = function(pat) {
-  .pr$Expr$str_json_path_match(self, pat) |>
+ExprStr_json_path_match = function(json_path) {
+  .pr$Expr$str_json_path_match(self, json_path) |>
     unwrap("in str$json_path_match(): ")
 }
 

--- a/R/expr__string.R
+++ b/R/expr__string.R
@@ -6,7 +6,7 @@
 
 #' Convert a Utf8 column into a Date/Datetime/Time column.
 #'
-#' @name ExprStr_strptime
+#'
 #' @param datatype The data type to convert into. Can be either Date, Datetime,
 #' or Time.
 #' @param format Format to use for conversion. See `?strptime` for possible
@@ -110,7 +110,7 @@ ExprStr_strptime = function(
 #' conversion.
 #'
 #' @return Expr
-#' @name ExprStr_to_date
+#'
 #'
 #' @examples
 #' pl$DataFrame(str_date = c("2009-01-02", "2009-01-03", "2009-1-4", "2009 05 01"))$
@@ -132,7 +132,7 @@ ExprStr_to_date = function(format = NULL, strict = TRUE, exact = TRUE, cache = T
 #' conversion.
 #'
 #' @return Expr
-#' @name ExprStr_to_time
+#'
 #'
 #' @examples
 #' pl$DataFrame(str_time = c("01:20:01", "28:00:02", "03:00:02"))$
@@ -163,7 +163,7 @@ ExprStr_to_time = function(format = NULL, strict = TRUE, cache = TRUE) {
 #' * `"latest"`: use the latest datetime
 #'
 #' @return Expr
-#' @name ExprStr_to_datetime
+#'
 #'
 #' @examples
 #' pl$DataFrame(str_date = c("2009-01-02 01:00", "2009-01-03 02:00", "2009-1-4 3:00"))$
@@ -186,7 +186,7 @@ ExprStr_to_datetime = function(
 #' @description
 #' Get length of the strings as UInt32 (as number of bytes). Use `$str$len_chars()`
 #' to get the number of characters.
-#' @name ExprStr_len_bytes
+#'
 #' @keywords ExprStr
 #' @details
 #' If you know that you are working with ASCII text, `lengths` will be
@@ -208,7 +208,7 @@ ExprStr_len_bytes = function() {
 #' @description
 #' Get length of the strings as UInt32 (as number of characters). Use
 #' `$str$len_bytes()` to get the number of bytes.
-#' @name ExprStr_len_chars
+#'
 #' @keywords ExprStr
 #' @inherit ExprStr_len_bytes examples details return
 ExprStr_len_chars = function() {
@@ -216,7 +216,7 @@ ExprStr_len_chars = function() {
 }
 
 #' Vertically concatenate values of a Series
-#' @name ExprStr_concat
+#'
 #' @description Vertically concatenate the values in the Series to a single
 #' string value.
 #' @param delimiter The delimiter to insert between consecutive string values.
@@ -239,7 +239,7 @@ ExprStr_concat = function(delimiter = "-", ignore_nulls = TRUE) {
 }
 
 #' Convert a string to uppercase
-#' @name ExprStr_to_uppercase
+#'
 #' @description Transform to uppercase variant.
 #' @keywords ExprStr
 #' @return Expr of Utf8 uppercase chars
@@ -250,7 +250,7 @@ ExprStr_to_uppercase = function() {
 }
 
 #' Convert a string to lowercase
-#' @name ExprStr_to_lowercase
+#'
 #' @description Transform to lowercase variant.
 #' @keywords ExprStr
 #' @return Expr of Utf8 lowercase chars
@@ -261,7 +261,7 @@ ExprStr_to_lowercase = function() {
 }
 
 #' Convert a string to titlecase
-#' @name ExprStr_to_titlecase
+#'
 #' @description Transform to titlecase variant.
 #' @keywords ExprStr
 #' @return Expr of Utf8 titlecase chars
@@ -282,7 +282,7 @@ ExprStr_to_titlecase = function() {
 
 #' Strip leading and trailing characters
 #'
-#' @name ExprStr_strip_chars
+#'
 #' @aliases expr_str_strip_chars
 #' @description  Remove leading and trailing characters.
 #'
@@ -308,7 +308,7 @@ ExprStr_strip_chars = function(matches = NULL) {
 
 #' Strip leading characters
 #'
-#' @name ExprStr_strip_chars_start
+#'
 #' @aliases expr_str_strip_chars_start
 #' @description  Remove leading characters.
 #'
@@ -332,7 +332,7 @@ ExprStr_strip_chars_start = function(matches = NULL) {
 
 #' Strip trailing characters
 #'
-#' @name ExprStr_strip_chars_end
+#'
 #' @aliases expr_str_strip_chars_end
 #' @description  Remove trailing characters.
 #'
@@ -357,7 +357,7 @@ ExprStr_strip_chars_end = function(matches = NULL) {
 
 
 #' Fills the string with zeroes.
-#' @name ExprStr_zfill
+#'
 #' @aliases expr_str_zfill
 #' @description Add zeroes to a string until it reaches `n` characters. If the
 #' number of characters is already greater than `n`, the string is not modified.
@@ -388,7 +388,7 @@ ExprStr_zfill = function(alignment) {
 
 
 #' Left justify strings
-#' @name ExprStr_pad_end
+#'
 #' @description Return the string left justified in a string of length `width`.
 #' @keywords ExprStr
 #' @param width Justify left to this length.
@@ -406,7 +406,7 @@ ExprStr_pad_end = function(width, fillchar = " ") {
 
 
 #' Right justify strings
-#' @name ExprStr_pad_start
+#'
 #' @description Return the string right justified in a string of length `width`.
 #' @keywords ExprStr
 #' @param width Justify right to this length.
@@ -422,7 +422,7 @@ ExprStr_pad_start = function(width, fillchar = " ") {
 
 
 #' Check if string contains a regex
-#' @name ExprStr_contains
+#'
 #' @description Check if string contains a substring that matches a regex.
 #' @keywords ExprStr
 #' @param pattern String or Expr of a string, a valid regex pattern.
@@ -444,7 +444,7 @@ ExprStr_contains = function(pattern, literal = FALSE, strict = TRUE) {
 }
 
 #' Check if string ends with a regex
-#' @name ExprStr_ends_with
+#'
 #' @description Check if string values end with a substring.
 #' @keywords ExprStr
 #' @param sub Suffix substring or Expr.
@@ -463,7 +463,7 @@ ExprStr_ends_with = function(sub) {
 
 
 #' Check if string starts with a regex
-#' @name ExprStr_starts_with
+#'
 #' @description Check if string values starts with a substring.
 #' @keywords ExprStr
 #' @param sub Prefix substring or Expr.
@@ -481,7 +481,7 @@ ExprStr_starts_with = function(sub) {
 }
 
 #' Parse string values as JSON.
-#' @name ExprStr_json_decode
+#'
 #' @keywords ExprStr
 #' @param dtype The dtype to cast the extracted value to. If `NULL`, the dtype
 #' will be inferred from the JSON value.
@@ -503,7 +503,7 @@ ExprStr_json_decode = function(dtype, infer_schema_length = 100) {
 }
 
 #' Extract the first match of JSON string with the provided JSONPath expression
-#' @name ExprStr_json_path_match
+#'
 #' @keywords ExprStr
 #' @param json_path A valid JSON path query string.
 #' @details
@@ -525,7 +525,7 @@ ExprStr_json_path_match = function(json_path) {
 
 
 #' Decode a value using the provided encoding
-#' @name ExprStr_decode
+#'
 #' @keywords ExprStr
 #' @param encoding Either 'hex' or 'base64'.
 #' @param ... Not used currently.
@@ -554,7 +554,7 @@ ExprStr_decode = function(encoding, ..., strict = TRUE) {
 }
 
 #' Encode a value using the provided encoding
-#' @name ExprStr_encode
+#'
 #' @keywords ExprStr
 #' @param encoding Either 'hex' or 'base64'.
 #' @return Utf8 array with values encoded using provided encoding
@@ -580,7 +580,7 @@ ExprStr_encode = function(encoding) {
 
 
 #' Extract the target capture group from provided patterns
-#' @name ExprStr_extract
+#'
 #' @keywords ExprStr
 #' @param pattern A valid regex pattern
 #' @param group_index Index of the targeted capture group. Group 0 means the whole
@@ -607,7 +607,7 @@ ExprStr_extract = function(pattern, group_index) {
 
 
 #' Extract all matches for the given regex pattern
-#' @name ExprStr_extract_all
+#'
 #' @description Extracts all matches for the given regex pattern. Extracts each
 #' successive non-overlapping regex match in an individual string as an array.
 #' @keywords ExprStr
@@ -627,7 +627,7 @@ ExprStr_extract_all = function(pattern) {
 }
 
 #' Count all successive non-overlapping regex matches
-#' @name ExprStr_count_matches
+#'
 #' @keywords ExprStr
 #' @param pattern A valid regex pattern
 #' @param literal Treat pattern as a literal string.
@@ -654,7 +654,7 @@ ExprStr_count_matches = function(pattern, literal = FALSE) {
 
 
 #' Split the string by a substring
-#' @name ExprStr_split
+#'
 #' @keywords ExprStr
 #' @param by String or Expr of a string, a valid regex pattern that will be
 #' used to split the string.
@@ -682,7 +682,7 @@ ExprStr_split = function(by, inclusive = FALSE) {
 
 # TODO write 2nd example after expr_struct has been implemented
 #' Split the string by a substring using `n` splits
-#' @name ExprStr_split_exact
+#'
 #' @description This results in a struct of `n+1` fields. If it cannot make `n`
 #' splits, the remaining field elements will be null.
 #' @keywords ExprStr
@@ -704,7 +704,7 @@ ExprStr_split_exact = function(by, n, inclusive = FALSE) {
 
 
 #' Split the string by a substring, restricted to returning at most `n` items
-#' @name ExprStr_splitn
+#'
 #' @description
 #' If the number of possible splits is less than `n-1`, the remaining field
 #' elements will be null. If the number of possible splits is `n-1` or greater,
@@ -727,7 +727,7 @@ ExprStr_splitn = function(by, n) {
 
 
 #' Replace first matching regex/literal substring with a new string value
-#' @name ExprStr_replace
+#'
 #' @keywords ExprStr
 #' @param pattern Regex pattern, can be an Expr.
 #' @param value Replacement, can be an Expr.
@@ -750,7 +750,7 @@ ExprStr_replace = function(pattern, value, literal = FALSE) {
 
 
 #' Replace all matching regex/literal substrings with a new string value
-#' @name ExprStr_replace_all
+#'
 #' @keywords ExprStr
 #' @param pattern Regex pattern, can be an Expr.
 #' @param value Replacement, can be an Expr.
@@ -772,7 +772,7 @@ ExprStr_replace_all = function(pattern, value, literal = FALSE) {
 
 
 #' Create subslices of the string values of a Utf8 Series
-#' @name ExprStr_slice
+#'
 #' @keywords ExprStr
 #' @param offset Start index. Negative indexing is supported.
 #' @param length Length of the slice. If `NULL` (default), the slice is taken to
@@ -791,7 +791,7 @@ ExprStr_slice = function(offset, length = NULL) {
 }
 
 #' Returns a column with a separate row for every string character
-#' @name ExprStr_explode
+#'
 #' @keywords ExprStr
 #' @return Expr: Series of dtype Utf8.
 #' @examples
@@ -803,7 +803,7 @@ ExprStr_explode = function() {
 }
 
 #' Parse integers with base radix from strings
-#' @name ExprStr_parse_int
+#'
 #' @description Parse integers with base 2 by default.
 #' @keywords ExprStr
 #' @param radix Positive integer which is the base of the string we are parsing.

--- a/R/expr__struct.R
+++ b/R/expr__struct.R
@@ -1,5 +1,5 @@
 #' field
-#' @name ExprStruct_field
+#'
 #' @aliases expr_struct_field
 #' @description Retrieve a ``Struct`` field as a new Series.
 #' By default base 2.
@@ -26,7 +26,7 @@ ExprStruct_field = function(name) {
 
 
 #' rename fields
-#' @name ExprStruct_rename_fields
+#'
 #' @aliases expr_struct_rename_fields
 #' @description Rename the fields of the struct.
 #' By default base 2.

--- a/R/utils.R
+++ b/R/utils.R
@@ -458,7 +458,7 @@ restruct_list = function(l) {
 #' # e$my_sub_ns$add2() #use the sub namespace
 #' # e$my_sub_ns$mul2()
 #'
-macro_new_subnamespace = function(class_pattern, subclass_env = NULL, remove_f = TRUE) {
+macro_new_subnamespace = function(class_pattern, subclass_env = NULL) {
   # get all methods within class
   class_methods = ls(parent.frame(), pattern = class_pattern)
   names(class_methods) = sub(class_pattern, "", class_methods)
@@ -478,10 +478,6 @@ macro_new_subnamespace = function(class_pattern, subclass_env = NULL, remove_f =
     "  env",
     "}"
   )
-
-  if (remove_f) {
-    rm(list = class_methods, envir = parent.frame())
-  }
 
   if (build_debug_print) cat("new subnamespace: ", class_pattern, "\n", string)
   eval(parse(text = string))

--- a/man/ExprBin_contains.Rd
+++ b/man/ExprBin_contains.Rd
@@ -4,6 +4,9 @@
 \alias{ExprBin_contains}
 \alias{expr_bin_contains}
 \title{contains}
+\usage{
+ExprBin_contains(lit)
+}
 \arguments{
 \item{lit}{The binary substring to look for}
 }

--- a/man/ExprBin_decode.Rd
+++ b/man/ExprBin_decode.Rd
@@ -4,6 +4,9 @@
 \alias{ExprBin_decode}
 \alias{expr_bin_decode}
 \title{decode}
+\usage{
+ExprBin_decode(encoding, strict = TRUE)
+}
 \arguments{
 \item{encoding}{binary choice either 'hex' or 'base64'}
 

--- a/man/ExprBin_encode.Rd
+++ b/man/ExprBin_encode.Rd
@@ -4,6 +4,9 @@
 \alias{ExprBin_encode}
 \alias{expr_bin_encode}
 \title{encode}
+\usage{
+ExprBin_encode(encoding)
+}
 \arguments{
 \item{encoding}{binary choice either 'hex' or 'base64'}
 }

--- a/man/ExprBin_ends_with.Rd
+++ b/man/ExprBin_ends_with.Rd
@@ -4,6 +4,9 @@
 \alias{ExprBin_ends_with}
 \alias{expr_bin_ends_with}
 \title{ends_with}
+\usage{
+ExprBin_ends_with(sub)
+}
 \value{
 Expr returning a Boolean
 }

--- a/man/ExprBin_ends_with.Rd
+++ b/man/ExprBin_ends_with.Rd
@@ -5,7 +5,10 @@
 \alias{expr_bin_ends_with}
 \title{ends_with}
 \usage{
-ExprBin_ends_with(sub)
+ExprBin_ends_with(suffix)
+}
+\arguments{
+\item{suffix}{Suffix substring.}
 }
 \value{
 Expr returning a Boolean

--- a/man/ExprBin_starts_with.Rd
+++ b/man/ExprBin_starts_with.Rd
@@ -4,6 +4,9 @@
 \alias{ExprBin_starts_with}
 \alias{expr_bin_starts_with}
 \title{starts_with}
+\usage{
+ExprBin_starts_with(sub)
+}
 \arguments{
 \item{sub}{Prefix substring.}
 }

--- a/man/ExprCat_get_categories.Rd
+++ b/man/ExprCat_get_categories.Rd
@@ -3,6 +3,9 @@
 \name{ExprCat_get_categories}
 \alias{ExprCat_get_categories}
 \title{Get the categories stored in this data type}
+\usage{
+ExprCat_get_categories()
+}
 \value{
 A polars DataFrame with the categories for each categorical Series.
 }

--- a/man/ExprCat_set_ordering.Rd
+++ b/man/ExprCat_set_ordering.Rd
@@ -4,6 +4,9 @@
 \alias{ExprCat_set_ordering}
 \alias{expr_cat_set_ordering}
 \title{Set Ordering}
+\usage{
+ExprCat_set_ordering(ordering)
+}
 \arguments{
 \item{ordering}{string either 'physical' or 'lexical'
 \itemize{

--- a/man/ExprDT_time.Rd
+++ b/man/ExprDT_time.Rd
@@ -3,6 +3,9 @@
 \name{ExprDT_time}
 \alias{ExprDT_time}
 \title{Extract time from a Datetime Series}
+\usage{
+ExprDT_time()
+}
 \value{
 A Time Expr
 }

--- a/man/ExprDT_total_days.Rd
+++ b/man/ExprDT_total_days.Rd
@@ -3,6 +3,9 @@
 \name{ExprDT_total_days}
 \alias{ExprDT_total_days}
 \title{Days}
+\usage{
+ExprDT_total_days()
+}
 \value{
 Expr of i64
 }

--- a/man/ExprDT_total_hours.Rd
+++ b/man/ExprDT_total_hours.Rd
@@ -3,6 +3,9 @@
 \name{ExprDT_total_hours}
 \alias{ExprDT_total_hours}
 \title{Hours}
+\usage{
+ExprDT_total_hours()
+}
 \value{
 Expr of i64
 }

--- a/man/ExprDT_total_microseconds.Rd
+++ b/man/ExprDT_total_microseconds.Rd
@@ -3,6 +3,9 @@
 \name{ExprDT_total_microseconds}
 \alias{ExprDT_total_microseconds}
 \title{microseconds}
+\usage{
+ExprDT_total_microseconds()
+}
 \value{
 Expr of i64
 }

--- a/man/ExprDT_total_milliseconds.Rd
+++ b/man/ExprDT_total_milliseconds.Rd
@@ -3,6 +3,9 @@
 \name{ExprDT_total_milliseconds}
 \alias{ExprDT_total_milliseconds}
 \title{milliseconds}
+\usage{
+ExprDT_total_milliseconds()
+}
 \value{
 Expr of i64
 }

--- a/man/ExprDT_total_minutes.Rd
+++ b/man/ExprDT_total_minutes.Rd
@@ -3,6 +3,9 @@
 \name{ExprDT_total_minutes}
 \alias{ExprDT_total_minutes}
 \title{Minutes}
+\usage{
+ExprDT_total_minutes()
+}
 \value{
 Expr of i64
 }

--- a/man/ExprDT_total_nanoseconds.Rd
+++ b/man/ExprDT_total_nanoseconds.Rd
@@ -3,6 +3,9 @@
 \name{ExprDT_total_nanoseconds}
 \alias{ExprDT_total_nanoseconds}
 \title{nanoseconds}
+\usage{
+ExprDT_total_nanoseconds()
+}
 \value{
 Expr of i64
 }

--- a/man/ExprDT_total_seconds.Rd
+++ b/man/ExprDT_total_seconds.Rd
@@ -3,6 +3,9 @@
 \name{ExprDT_total_seconds}
 \alias{ExprDT_total_seconds}
 \title{Seconds}
+\usage{
+ExprDT_total_seconds()
+}
 \value{
 Expr of i64
 }

--- a/man/ExprList_arg_max.Rd
+++ b/man/ExprList_arg_max.Rd
@@ -7,6 +7,9 @@
 \format{
 function
 }
+\usage{
+ExprList_arg_max()
+}
 \value{
 Expr
 }

--- a/man/ExprList_arg_min.Rd
+++ b/man/ExprList_arg_min.Rd
@@ -7,6 +7,9 @@
 \format{
 function
 }
+\usage{
+ExprList_arg_min()
+}
 \value{
 Expr
 }

--- a/man/ExprList_concat.Rd
+++ b/man/ExprList_concat.Rd
@@ -7,6 +7,9 @@
 \format{
 function
 }
+\usage{
+ExprList_concat(other)
+}
 \arguments{
 \item{other}{Rlist, Expr or column of same type as self.}
 }

--- a/man/ExprList_contains.Rd
+++ b/man/ExprList_contains.Rd
@@ -7,6 +7,9 @@
 \format{
 function
 }
+\usage{
+ExprList_contains(other)
+}
 \arguments{
 \item{item}{any into Expr/literal}
 }

--- a/man/ExprList_contains.Rd
+++ b/man/ExprList_contains.Rd
@@ -8,7 +8,7 @@
 function
 }
 \usage{
-ExprList_contains(other)
+ExprList_contains(item)
 }
 \arguments{
 \item{item}{any into Expr/literal}

--- a/man/ExprList_diff.Rd
+++ b/man/ExprList_diff.Rd
@@ -7,6 +7,9 @@
 \format{
 function
 }
+\usage{
+ExprList_diff(n = 1, null_behavior = c("ignore", "drop"))
+}
 \arguments{
 \item{n}{Number of slots to shift}
 

--- a/man/ExprList_eval.Rd
+++ b/man/ExprList_eval.Rd
@@ -7,15 +7,18 @@
 \format{
 function
 }
+\usage{
+ExprList_eval(expr, parallel = FALSE)
+}
 \arguments{
-\item{Expr}{Expression to run. Note that you can select an element with \code{pl$first()}, or
-\code{pl$col()}}
-
 \item{parallel}{bool
 Run all expression parallel. Don't activate this blindly.
 Parallelism is worth it if there is enough work to do per thread.
 This likely should not be use in the groupby context, because we already
 parallel execution per group}
+
+\item{Expr}{Expression to run. Note that you can select an element with \code{pl$first()}, or
+\code{pl$col()}}
 }
 \value{
 Expr

--- a/man/ExprList_eval.Rd
+++ b/man/ExprList_eval.Rd
@@ -11,14 +11,13 @@ function
 ExprList_eval(expr, parallel = FALSE)
 }
 \arguments{
-\item{parallel}{bool
-Run all expression parallel. Don't activate this blindly.
-Parallelism is worth it if there is enough work to do per thread.
-This likely should not be use in the groupby context, because we already
-parallel execution per group}
+\item{expr}{Expression to run. Note that you can select an element with
+\code{pl$first()}, or \code{pl$col()}}
 
-\item{Expr}{Expression to run. Note that you can select an element with \code{pl$first()}, or
-\code{pl$col()}}
+\item{parallel}{Run all expression parallel. Don't activate this blindly.
+Parallelism is worth it if there is enough work to do per thread. This likely
+should not be use in the groupby context, because we already do parallel
+execution per group.}
 }
 \value{
 Expr

--- a/man/ExprList_first.Rd
+++ b/man/ExprList_first.Rd
@@ -7,6 +7,9 @@
 \format{
 function
 }
+\usage{
+ExprList_first(index)
+}
 \value{
 Expr
 }

--- a/man/ExprList_first.Rd
+++ b/man/ExprList_first.Rd
@@ -8,7 +8,7 @@
 function
 }
 \usage{
-ExprList_first(index)
+ExprList_first()
 }
 \value{
 Expr

--- a/man/ExprList_gather.Rd
+++ b/man/ExprList_gather.Rd
@@ -7,6 +7,9 @@
 \format{
 function
 }
+\usage{
+ExprList_gather(index, null_on_oob = FALSE)
+}
 \arguments{
 \item{index}{R list of integers for each sub-element or Expr or Series of type \code{List[usize]}}
 

--- a/man/ExprList_get.Rd
+++ b/man/ExprList_get.Rd
@@ -9,12 +9,14 @@
 function
 }
 \usage{
+ExprList_get(index)
+
 \method{[}{RPolarsExprListNameSpace}(x, index)
 }
 \arguments{
-\item{x}{RPolarsExprListNameSpace}
-
 \item{index}{value to get}
+
+\item{x}{RPolarsExprListNameSpace}
 }
 \value{
 Expr

--- a/man/ExprList_head.Rd
+++ b/man/ExprList_head.Rd
@@ -7,6 +7,9 @@
 \format{
 function
 }
+\usage{
+ExprList_head(n = 5L)
+}
 \arguments{
 \item{n}{Numeric or Expr, number of values to return for each sublist.}
 }

--- a/man/ExprList_join.Rd
+++ b/man/ExprList_join.Rd
@@ -7,6 +7,9 @@
 \format{
 function
 }
+\usage{
+ExprList_join(separator)
+}
 \arguments{
 \item{separator}{String to separate the items with. Can be an Expr.}
 }

--- a/man/ExprList_last.Rd
+++ b/man/ExprList_last.Rd
@@ -7,6 +7,9 @@
 \format{
 function
 }
+\usage{
+ExprList_last(index)
+}
 \value{
 Expr
 }

--- a/man/ExprList_last.Rd
+++ b/man/ExprList_last.Rd
@@ -8,7 +8,7 @@
 function
 }
 \usage{
-ExprList_last(index)
+ExprList_last()
 }
 \value{
 Expr

--- a/man/ExprList_lengths.Rd
+++ b/man/ExprList_lengths.Rd
@@ -8,6 +8,9 @@
 \format{
 function
 }
+\usage{
+ExprList_lengths()
+}
 \value{
 Expr
 }

--- a/man/ExprList_max.Rd
+++ b/man/ExprList_max.Rd
@@ -7,6 +7,9 @@
 \format{
 function
 }
+\usage{
+ExprList_max()
+}
 \value{
 Expr
 }

--- a/man/ExprList_mean.Rd
+++ b/man/ExprList_mean.Rd
@@ -7,6 +7,9 @@
 \format{
 function
 }
+\usage{
+ExprList_mean()
+}
 \value{
 Expr
 }

--- a/man/ExprList_min.Rd
+++ b/man/ExprList_min.Rd
@@ -7,6 +7,9 @@
 \format{
 function
 }
+\usage{
+ExprList_min()
+}
 \value{
 Expr
 }

--- a/man/ExprList_reverse.Rd
+++ b/man/ExprList_reverse.Rd
@@ -7,6 +7,9 @@
 \format{
 function
 }
+\usage{
+ExprList_reverse()
+}
 \value{
 Expr
 }

--- a/man/ExprList_shift.Rd
+++ b/man/ExprList_shift.Rd
@@ -7,6 +7,9 @@
 \format{
 function
 }
+\usage{
+ExprList_shift(periods = 1)
+}
 \arguments{
 \item{periods}{Value. Number of places to shift (may be negative).}
 }

--- a/man/ExprList_slice.Rd
+++ b/man/ExprList_slice.Rd
@@ -7,6 +7,9 @@
 \format{
 function
 }
+\usage{
+ExprList_slice(offset, length = NULL)
+}
 \arguments{
 \item{offset}{value or Expr.  Start index. Negative indexing is supported.}
 

--- a/man/ExprList_sort.Rd
+++ b/man/ExprList_sort.Rd
@@ -3,6 +3,9 @@
 \name{ExprList_sort}
 \alias{ExprList_sort}
 \title{Sort an Expr}
+\usage{
+ExprList_sort(descending = FALSE)
+}
 \arguments{
 \item{descending}{Sort values in descending order}
 }

--- a/man/ExprList_sum.Rd
+++ b/man/ExprList_sum.Rd
@@ -7,6 +7,9 @@
 \format{
 function
 }
+\usage{
+ExprList_sum()
+}
 \value{
 Expr
 }

--- a/man/ExprList_tail.Rd
+++ b/man/ExprList_tail.Rd
@@ -7,6 +7,9 @@
 \format{
 function
 }
+\usage{
+ExprList_tail(n = 5L)
+}
 \arguments{
 \item{n}{Numeric or Expr, number of values to return for each sublist.}
 }

--- a/man/ExprList_to_struct.Rd
+++ b/man/ExprList_to_struct.Rd
@@ -7,6 +7,13 @@
 \format{
 function
 }
+\usage{
+ExprList_to_struct(
+  n_field_strategy = c("first_non_null", "max_width"),
+  name_generator = NULL,
+  upper_bound = 0
+)
+}
 \arguments{
 \item{n_field_strategy}{Strategy to determine the number of fields of the struct.
 default = "first_non_null": set number of fields equal to the length of the

--- a/man/ExprList_unique.Rd
+++ b/man/ExprList_unique.Rd
@@ -7,6 +7,9 @@
 \format{
 function
 }
+\usage{
+ExprList_unique()
+}
 \value{
 Expr
 }

--- a/man/ExprMeta_eq.Rd
+++ b/man/ExprMeta_eq.Rd
@@ -4,6 +4,9 @@
 \alias{ExprMeta_eq}
 \alias{expr_meta_equal}
 \title{Meta Equal}
+\usage{
+ExprMeta_eq(other)
+}
 \arguments{
 \item{other}{Expr to compare with}
 }

--- a/man/ExprMeta_has_multiple_outputs.Rd
+++ b/man/ExprMeta_has_multiple_outputs.Rd
@@ -4,6 +4,9 @@
 \alias{ExprMeta_has_multiple_outputs}
 \alias{expr_has_multiple_outputs}
 \title{Has multiple outputs}
+\usage{
+ExprMeta_has_multiple_outputs()
+}
 \value{
 Bool
 }

--- a/man/ExprMeta_is_regex_projection.Rd
+++ b/man/ExprMeta_is_regex_projection.Rd
@@ -4,6 +4,9 @@
 \alias{ExprMeta_is_regex_projection}
 \alias{expr_is_regex_projection}
 \title{Is regex projection.}
+\usage{
+ExprMeta_is_regex_projection()
+}
 \value{
 Bool
 }

--- a/man/ExprMeta_neq.Rd
+++ b/man/ExprMeta_neq.Rd
@@ -4,6 +4,9 @@
 \alias{ExprMeta_neq}
 \alias{expr_meta_not_equal}
 \title{Meta Not Equal}
+\usage{
+ExprMeta_neq(other)
+}
 \arguments{
 \item{other}{Expr to compare with}
 }

--- a/man/ExprMeta_output_name.Rd
+++ b/man/ExprMeta_output_name.Rd
@@ -4,6 +4,9 @@
 \alias{ExprMeta_output_name}
 \alias{expr_meta_output_names}
 \title{Output Name}
+\usage{
+ExprMeta_output_name()
+}
 \value{
 R charvec of output names.
 }

--- a/man/ExprMeta_pop.Rd
+++ b/man/ExprMeta_pop.Rd
@@ -4,6 +4,9 @@
 \alias{ExprMeta_pop}
 \alias{expr_meta_pop}
 \title{Pop}
+\usage{
+ExprMeta_pop()
+}
 \value{
 R list of Expr(s) usually one, only multiple if top Expr took more Expr as input.
 }

--- a/man/ExprMeta_root_names.Rd
+++ b/man/ExprMeta_root_names.Rd
@@ -4,6 +4,9 @@
 \alias{ExprMeta_root_names}
 \alias{expr_meta_root_names}
 \title{Root Name}
+\usage{
+ExprMeta_root_names()
+}
 \value{
 R charvec of root names.
 }

--- a/man/ExprMeta_tree_format.Rd
+++ b/man/ExprMeta_tree_format.Rd
@@ -3,6 +3,9 @@
 \name{ExprMeta_tree_format}
 \alias{ExprMeta_tree_format}
 \title{Format an expression as a tree}
+\usage{
+ExprMeta_tree_format(return_as_string = FALSE)
+}
 \arguments{
 \item{return_as_string}{Return the tree as a character vector? If \code{FALSE}
 (default), the tree is printed in the console.}

--- a/man/ExprMeta_undo_aliases.Rd
+++ b/man/ExprMeta_undo_aliases.Rd
@@ -4,6 +4,9 @@
 \alias{ExprMeta_undo_aliases}
 \alias{expr_meta_undo_aliases}
 \title{Undo aliases}
+\usage{
+ExprMeta_undo_aliases()
+}
 \value{
 Expr with aliases undone
 }

--- a/man/ExprName_keep.Rd
+++ b/man/ExprName_keep.Rd
@@ -3,6 +3,9 @@
 \name{ExprName_keep}
 \alias{ExprName_keep}
 \title{Keep the original root name of the expression.}
+\usage{
+ExprName_keep()
+}
 \value{
 Expr
 }

--- a/man/ExprName_map.Rd
+++ b/man/ExprName_map.Rd
@@ -3,6 +3,9 @@
 \name{ExprName_map}
 \alias{ExprName_map}
 \title{Map alias of expression with an R function}
+\usage{
+ExprName_map(fun)
+}
 \arguments{
 \item{fun}{an R function which takes a string as input and return a string}
 }

--- a/man/ExprName_prefix.Rd
+++ b/man/ExprName_prefix.Rd
@@ -3,6 +3,9 @@
 \name{ExprName_prefix}
 \alias{ExprName_prefix}
 \title{Add a prefix to a column name}
+\usage{
+ExprName_prefix(prefix)
+}
 \arguments{
 \item{prefix}{Prefix to be added to column name(s)}
 }

--- a/man/ExprName_suffix.Rd
+++ b/man/ExprName_suffix.Rd
@@ -3,6 +3,9 @@
 \name{ExprName_suffix}
 \alias{ExprName_suffix}
 \title{Add a suffix to a column name}
+\usage{
+ExprName_suffix(suffix)
+}
 \arguments{
 \item{suffix}{Suffix to be added to column name(s)}
 }

--- a/man/ExprName_to_lowercase.Rd
+++ b/man/ExprName_to_lowercase.Rd
@@ -3,6 +3,9 @@
 \name{ExprName_to_lowercase}
 \alias{ExprName_to_lowercase}
 \title{Make the root column name lowercase}
+\usage{
+ExprName_to_lowercase()
+}
 \value{
 Expr
 }

--- a/man/ExprName_to_uppercase.Rd
+++ b/man/ExprName_to_uppercase.Rd
@@ -3,6 +3,9 @@
 \name{ExprName_to_uppercase}
 \alias{ExprName_to_uppercase}
 \title{Make the root column name uppercase}
+\usage{
+ExprName_to_uppercase()
+}
 \value{
 Expr
 }

--- a/man/ExprStr_concat.Rd
+++ b/man/ExprStr_concat.Rd
@@ -3,6 +3,9 @@
 \name{ExprStr_concat}
 \alias{ExprStr_concat}
 \title{Vertically concatenate values of a Series}
+\usage{
+ExprStr_concat(delimiter = "-", ignore_nulls = TRUE)
+}
 \arguments{
 \item{delimiter}{The delimiter to insert between consecutive string values.}
 

--- a/man/ExprStr_contains.Rd
+++ b/man/ExprStr_contains.Rd
@@ -3,6 +3,9 @@
 \name{ExprStr_contains}
 \alias{ExprStr_contains}
 \title{Check if string contains a regex}
+\usage{
+ExprStr_contains(pattern, literal = FALSE, strict = TRUE)
+}
 \arguments{
 \item{pattern}{String or Expr of a string, a valid regex pattern.}
 

--- a/man/ExprStr_count_matches.Rd
+++ b/man/ExprStr_count_matches.Rd
@@ -3,6 +3,9 @@
 \name{ExprStr_count_matches}
 \alias{ExprStr_count_matches}
 \title{Count all successive non-overlapping regex matches}
+\usage{
+ExprStr_count_matches(pattern, literal = FALSE)
+}
 \arguments{
 \item{pattern}{A valid regex pattern}
 

--- a/man/ExprStr_decode.Rd
+++ b/man/ExprStr_decode.Rd
@@ -3,6 +3,9 @@
 \name{ExprStr_decode}
 \alias{ExprStr_decode}
 \title{Decode a value using the provided encoding}
+\usage{
+ExprStr_decode(encoding, ..., strict = TRUE)
+}
 \arguments{
 \item{encoding}{Either 'hex' or 'base64'.}
 

--- a/man/ExprStr_encode.Rd
+++ b/man/ExprStr_encode.Rd
@@ -3,6 +3,9 @@
 \name{ExprStr_encode}
 \alias{ExprStr_encode}
 \title{Encode a value using the provided encoding}
+\usage{
+ExprStr_encode(encoding)
+}
 \arguments{
 \item{encoding}{Either 'hex' or 'base64'.}
 }

--- a/man/ExprStr_ends_with.Rd
+++ b/man/ExprStr_ends_with.Rd
@@ -3,6 +3,9 @@
 \name{ExprStr_ends_with}
 \alias{ExprStr_ends_with}
 \title{Check if string ends with a regex}
+\usage{
+ExprStr_ends_with(sub)
+}
 \arguments{
 \item{sub}{Suffix substring or Expr.}
 }

--- a/man/ExprStr_explode.Rd
+++ b/man/ExprStr_explode.Rd
@@ -3,6 +3,9 @@
 \name{ExprStr_explode}
 \alias{ExprStr_explode}
 \title{Returns a column with a separate row for every string character}
+\usage{
+ExprStr_explode()
+}
 \value{
 Expr: Series of dtype Utf8.
 }

--- a/man/ExprStr_extract.Rd
+++ b/man/ExprStr_extract.Rd
@@ -3,6 +3,9 @@
 \name{ExprStr_extract}
 \alias{ExprStr_extract}
 \title{Extract the target capture group from provided patterns}
+\usage{
+ExprStr_extract(pattern, group_index)
+}
 \arguments{
 \item{pattern}{A valid regex pattern}
 

--- a/man/ExprStr_extract_all.Rd
+++ b/man/ExprStr_extract_all.Rd
@@ -3,6 +3,9 @@
 \name{ExprStr_extract_all}
 \alias{ExprStr_extract_all}
 \title{Extract all matches for the given regex pattern}
+\usage{
+ExprStr_extract_all(pattern)
+}
 \arguments{
 \item{pattern}{A valid regex pattern}
 }

--- a/man/ExprStr_json_decode.Rd
+++ b/man/ExprStr_json_decode.Rd
@@ -3,6 +3,9 @@
 \name{ExprStr_json_decode}
 \alias{ExprStr_json_decode}
 \title{Parse string values as JSON.}
+\usage{
+ExprStr_json_decode(dtype, infer_schema_length = 100)
+}
 \arguments{
 \item{dtype}{The dtype to cast the extracted value to. If \code{NULL}, the dtype
 will be inferred from the JSON value.}

--- a/man/ExprStr_json_path_match.Rd
+++ b/man/ExprStr_json_path_match.Rd
@@ -4,7 +4,7 @@
 \alias{ExprStr_json_path_match}
 \title{Extract the first match of JSON string with the provided JSONPath expression}
 \usage{
-ExprStr_json_path_match(pat)
+ExprStr_json_path_match(json_path)
 }
 \arguments{
 \item{json_path}{A valid JSON path query string.}

--- a/man/ExprStr_json_path_match.Rd
+++ b/man/ExprStr_json_path_match.Rd
@@ -3,6 +3,9 @@
 \name{ExprStr_json_path_match}
 \alias{ExprStr_json_path_match}
 \title{Extract the first match of JSON string with the provided JSONPath expression}
+\usage{
+ExprStr_json_path_match(pat)
+}
 \arguments{
 \item{json_path}{A valid JSON path query string.}
 }

--- a/man/ExprStr_len_bytes.Rd
+++ b/man/ExprStr_len_bytes.Rd
@@ -3,6 +3,9 @@
 \name{ExprStr_len_bytes}
 \alias{ExprStr_len_bytes}
 \title{Get the number of bytes in strings}
+\usage{
+ExprStr_len_bytes()
+}
 \value{
 Expr of u32
 }

--- a/man/ExprStr_len_chars.Rd
+++ b/man/ExprStr_len_chars.Rd
@@ -3,6 +3,9 @@
 \name{ExprStr_len_chars}
 \alias{ExprStr_len_chars}
 \title{Get the number of characters in strings}
+\usage{
+ExprStr_len_chars()
+}
 \value{
 Expr of u32
 }

--- a/man/ExprStr_pad_end.Rd
+++ b/man/ExprStr_pad_end.Rd
@@ -3,6 +3,9 @@
 \name{ExprStr_pad_end}
 \alias{ExprStr_pad_end}
 \title{Left justify strings}
+\usage{
+ExprStr_pad_end(width, fillchar = " ")
+}
 \arguments{
 \item{width}{Justify left to this length.}
 

--- a/man/ExprStr_pad_start.Rd
+++ b/man/ExprStr_pad_start.Rd
@@ -3,6 +3,9 @@
 \name{ExprStr_pad_start}
 \alias{ExprStr_pad_start}
 \title{Right justify strings}
+\usage{
+ExprStr_pad_start(width, fillchar = " ")
+}
 \arguments{
 \item{width}{Justify right to this length.}
 

--- a/man/ExprStr_parse_int.Rd
+++ b/man/ExprStr_parse_int.Rd
@@ -3,6 +3,9 @@
 \name{ExprStr_parse_int}
 \alias{ExprStr_parse_int}
 \title{Parse integers with base radix from strings}
+\usage{
+ExprStr_parse_int(radix = 2, strict = TRUE)
+}
 \arguments{
 \item{radix}{Positive integer which is the base of the string we are parsing.
 Default is 2.}

--- a/man/ExprStr_replace.Rd
+++ b/man/ExprStr_replace.Rd
@@ -3,6 +3,9 @@
 \name{ExprStr_replace}
 \alias{ExprStr_replace}
 \title{Replace first matching regex/literal substring with a new string value}
+\usage{
+ExprStr_replace(pattern, value, literal = FALSE)
+}
 \arguments{
 \item{pattern}{Regex pattern, can be an Expr.}
 

--- a/man/ExprStr_replace_all.Rd
+++ b/man/ExprStr_replace_all.Rd
@@ -3,6 +3,9 @@
 \name{ExprStr_replace_all}
 \alias{ExprStr_replace_all}
 \title{Replace all matching regex/literal substrings with a new string value}
+\usage{
+ExprStr_replace_all(pattern, value, literal = FALSE)
+}
 \arguments{
 \item{pattern}{Regex pattern, can be an Expr.}
 

--- a/man/ExprStr_slice.Rd
+++ b/man/ExprStr_slice.Rd
@@ -3,6 +3,9 @@
 \name{ExprStr_slice}
 \alias{ExprStr_slice}
 \title{Create subslices of the string values of a Utf8 Series}
+\usage{
+ExprStr_slice(offset, length = NULL)
+}
 \arguments{
 \item{offset}{Start index. Negative indexing is supported.}
 

--- a/man/ExprStr_split.Rd
+++ b/man/ExprStr_split.Rd
@@ -3,6 +3,9 @@
 \name{ExprStr_split}
 \alias{ExprStr_split}
 \title{Split the string by a substring}
+\usage{
+ExprStr_split(by, inclusive = FALSE)
+}
 \arguments{
 \item{by}{String or Expr of a string, a valid regex pattern that will be
 used to split the string.}

--- a/man/ExprStr_split_exact.Rd
+++ b/man/ExprStr_split_exact.Rd
@@ -3,6 +3,9 @@
 \name{ExprStr_split_exact}
 \alias{ExprStr_split_exact}
 \title{Split the string by a substring using \code{n} splits}
+\usage{
+ExprStr_split_exact(by, n, inclusive = FALSE)
+}
 \arguments{
 \item{by}{Substring to split by.}
 

--- a/man/ExprStr_splitn.Rd
+++ b/man/ExprStr_splitn.Rd
@@ -3,6 +3,9 @@
 \name{ExprStr_splitn}
 \alias{ExprStr_splitn}
 \title{Split the string by a substring, restricted to returning at most \code{n} items}
+\usage{
+ExprStr_splitn(by, n)
+}
 \arguments{
 \item{by}{Substring to split by.}
 

--- a/man/ExprStr_starts_with.Rd
+++ b/man/ExprStr_starts_with.Rd
@@ -3,6 +3,9 @@
 \name{ExprStr_starts_with}
 \alias{ExprStr_starts_with}
 \title{Check if string starts with a regex}
+\usage{
+ExprStr_starts_with(sub)
+}
 \arguments{
 \item{sub}{Prefix substring or Expr.}
 }

--- a/man/ExprStr_strip_chars.Rd
+++ b/man/ExprStr_strip_chars.Rd
@@ -4,6 +4,9 @@
 \alias{ExprStr_strip_chars}
 \alias{expr_str_strip_chars}
 \title{Strip leading and trailing characters}
+\usage{
+ExprStr_strip_chars(matches = NULL)
+}
 \arguments{
 \item{matches}{The set of characters to be removed. All combinations of this
 set of characters will be stripped. If \code{NULL} (default), all whitespace is

--- a/man/ExprStr_strip_chars_end.Rd
+++ b/man/ExprStr_strip_chars_end.Rd
@@ -4,6 +4,9 @@
 \alias{ExprStr_strip_chars_end}
 \alias{expr_str_strip_chars_end}
 \title{Strip trailing characters}
+\usage{
+ExprStr_strip_chars_end(matches = NULL)
+}
 \arguments{
 \item{matches}{The set of characters to be removed. All combinations of this
 set of characters will be stripped. If \code{NULL} (default), all whitespace is

--- a/man/ExprStr_strip_chars_start.Rd
+++ b/man/ExprStr_strip_chars_start.Rd
@@ -4,6 +4,9 @@
 \alias{ExprStr_strip_chars_start}
 \alias{expr_str_strip_chars_start}
 \title{Strip leading characters}
+\usage{
+ExprStr_strip_chars_start(matches = NULL)
+}
 \arguments{
 \item{matches}{The set of characters to be removed. All combinations of this
 set of characters will be stripped. If \code{NULL} (default), all whitespace is

--- a/man/ExprStr_strptime.Rd
+++ b/man/ExprStr_strptime.Rd
@@ -3,6 +3,16 @@
 \name{ExprStr_strptime}
 \alias{ExprStr_strptime}
 \title{Convert a Utf8 column into a Date/Datetime/Time column.}
+\usage{
+ExprStr_strptime(
+  datatype,
+  format,
+  strict = TRUE,
+  exact = TRUE,
+  cache = TRUE,
+  ambiguous = "raise"
+)
+}
 \arguments{
 \item{datatype}{The data type to convert into. Can be either Date, Datetime,
 or Time.}

--- a/man/ExprStr_to_date.Rd
+++ b/man/ExprStr_to_date.Rd
@@ -3,6 +3,9 @@
 \name{ExprStr_to_date}
 \alias{ExprStr_to_date}
 \title{Convert a Utf8 column into a Date column}
+\usage{
+ExprStr_to_date(format = NULL, strict = TRUE, exact = TRUE, cache = TRUE)
+}
 \arguments{
 \item{format}{Format to use for conversion. See \code{?strptime} for possible
 values. Example: "\%Y-\%m-\%d". If \code{NULL} (default), the format is

--- a/man/ExprStr_to_datetime.Rd
+++ b/man/ExprStr_to_datetime.Rd
@@ -3,6 +3,17 @@
 \name{ExprStr_to_datetime}
 \alias{ExprStr_to_datetime}
 \title{Convert a Utf8 column into a Datetime column}
+\usage{
+ExprStr_to_datetime(
+  format = NULL,
+  time_unit = NULL,
+  time_zone = NULL,
+  strict = TRUE,
+  exact = TRUE,
+  cache = TRUE,
+  ambiguous = "raise"
+)
+}
 \arguments{
 \item{format}{Format to use for conversion. See \code{?strptime} for possible
 values. Example: "\%Y-\%m-\%d \%H:\%M:\%S". If \code{NULL} (default), the format is

--- a/man/ExprStr_to_lowercase.Rd
+++ b/man/ExprStr_to_lowercase.Rd
@@ -3,6 +3,9 @@
 \name{ExprStr_to_lowercase}
 \alias{ExprStr_to_lowercase}
 \title{Convert a string to lowercase}
+\usage{
+ExprStr_to_lowercase()
+}
 \value{
 Expr of Utf8 lowercase chars
 }

--- a/man/ExprStr_to_time.Rd
+++ b/man/ExprStr_to_time.Rd
@@ -3,6 +3,9 @@
 \name{ExprStr_to_time}
 \alias{ExprStr_to_time}
 \title{Convert a Utf8 column into a Time column}
+\usage{
+ExprStr_to_time(format = NULL, strict = TRUE, cache = TRUE)
+}
 \arguments{
 \item{format}{Format to use for conversion. See \code{?strptime} for possible
 values. Example: "\%H:\%M:\%S". If \code{NULL} (default), the format is

--- a/man/ExprStr_to_titlecase.Rd
+++ b/man/ExprStr_to_titlecase.Rd
@@ -3,6 +3,9 @@
 \name{ExprStr_to_titlecase}
 \alias{ExprStr_to_titlecase}
 \title{Convert a string to titlecase}
+\usage{
+ExprStr_to_titlecase()
+}
 \value{
 Expr of Utf8 titlecase chars
 }

--- a/man/ExprStr_to_uppercase.Rd
+++ b/man/ExprStr_to_uppercase.Rd
@@ -3,6 +3,9 @@
 \name{ExprStr_to_uppercase}
 \alias{ExprStr_to_uppercase}
 \title{Convert a string to uppercase}
+\usage{
+ExprStr_to_uppercase()
+}
 \value{
 Expr of Utf8 uppercase chars
 }

--- a/man/ExprStr_zfill.Rd
+++ b/man/ExprStr_zfill.Rd
@@ -4,6 +4,9 @@
 \alias{ExprStr_zfill}
 \alias{expr_str_zfill}
 \title{Fills the string with zeroes.}
+\usage{
+ExprStr_zfill(alignment)
+}
 \arguments{
 \item{alignment}{Fill the value up to this length.}
 }

--- a/man/ExprStruct_field.Rd
+++ b/man/ExprStruct_field.Rd
@@ -4,6 +4,9 @@
 \alias{ExprStruct_field}
 \alias{expr_struct_field}
 \title{field}
+\usage{
+ExprStruct_field(name)
+}
 \arguments{
 \item{name}{string, the Name of the struct field to retrieve.}
 }

--- a/man/ExprStruct_rename_fields.Rd
+++ b/man/ExprStruct_rename_fields.Rd
@@ -4,6 +4,9 @@
 \alias{ExprStruct_rename_fields}
 \alias{expr_struct_rename_fields}
 \title{rename fields}
+\usage{
+ExprStruct_rename_fields(names)
+}
 \arguments{
 \item{names}{char vec or list of strings given in the same order as the struct's fields.
 Providing fewer names will drop the latter fields. Providing too many names is ignored.}

--- a/man/S3_knit_print.Rd
+++ b/man/S3_knit_print.Rd
@@ -4,7 +4,7 @@
 \alias{knit_print.RPolarsDataFrame}
 \title{knit print polars DataFrame}
 \usage{
-\method{knit_print}{RPolarsDataFrame}(x, ...)
+knit_print.RPolarsDataFrame(x, ...)
 }
 \arguments{
 \item{x}{a polars DataFrame to knit_print}

--- a/man/S3_knit_print.Rd
+++ b/man/S3_knit_print.Rd
@@ -4,7 +4,7 @@
 \alias{knit_print.RPolarsDataFrame}
 \title{knit print polars DataFrame}
 \usage{
-knit_print.RPolarsDataFrame(x, ...)
+\method{knit_print}{RPolarsDataFrame}(x, ...)
 }
 \arguments{
 \item{x}{a polars DataFrame to knit_print}

--- a/man/nanoarrow.Rd
+++ b/man/nanoarrow.Rd
@@ -16,13 +16,13 @@
 \alias{as_record_batch_reader.RPolarsDataFrame}
 \title{polars to nanoarrow and arrow}
 \usage{
-as_nanoarrow_array_stream.RPolarsDataFrame(x, ..., schema = NULL)
+\method{as_nanoarrow_array_stream}{RPolarsDataFrame}(x, ..., schema = NULL)
 
-infer_nanoarrow_schema.RPolarsDataFrame(x, ...)
+\method{infer_nanoarrow_schema}{RPolarsDataFrame}(x, ...)
 
-as_arrow_table.RPolarsDataFrame(x, ...)
+\method{as_arrow_table}{RPolarsDataFrame}(x, ...)
 
-as_record_batch_reader.RPolarsDataFrame(x, ..., schema = NULL)
+\method{as_record_batch_reader}{RPolarsDataFrame}(x, ..., schema = NULL)
 }
 \arguments{
 \item{x}{a polars DataFrame}

--- a/man/nanoarrow.Rd
+++ b/man/nanoarrow.Rd
@@ -16,13 +16,13 @@
 \alias{as_record_batch_reader.RPolarsDataFrame}
 \title{polars to nanoarrow and arrow}
 \usage{
-\method{as_nanoarrow_array_stream}{RPolarsDataFrame}(x, ..., schema = NULL)
+as_nanoarrow_array_stream.RPolarsDataFrame(x, ..., schema = NULL)
 
-\method{infer_nanoarrow_schema}{RPolarsDataFrame}(x, ...)
+infer_nanoarrow_schema.RPolarsDataFrame(x, ...)
 
-\method{as_arrow_table}{RPolarsDataFrame}(x, ...)
+as_arrow_table.RPolarsDataFrame(x, ...)
 
-\method{as_record_batch_reader}{RPolarsDataFrame}(x, ..., schema = NULL)
+as_record_batch_reader.RPolarsDataFrame(x, ..., schema = NULL)
 }
 \arguments{
 \item{x}{a polars DataFrame}


### PR DESCRIPTION
None of the Expr subnamespaces (DT, list, etc.) have a "Usage" section in the docs. This is because the internal function `macro_new_subnamespace()` is run before the Rd files are generated by `roxygen`.  The problem is that `macro_new_subnamespace()` removes the functions that are defined (e.g `ExprDT_days()`) and renames them, so when `roxygen` tries to detect how to use `ExprDT_days()`, it doesn't exist anymore and therefore the usage section is empty. This is also why we need to manually add the `@name` tag.

This PR fixes this by removing the argument `remove_f` in `macro_new_subnamespace()`, which means that the original functions are no longer deleted. I don't think this has an effect on the users: the snapshots that list all methods are not modified and all the tests pass. I also removed the `@name` tags, since they're no longer necessary.

In a follow-up PR, I'll deal with renaming the `ExprDT_` into something cleaner on the website (something similar to #626).