### PR TITLE
fix: styler file fails on Windows

### DIFF
--- a/dev/styler_utils.R
+++ b/dev/styler_utils.R
@@ -144,7 +144,7 @@ style_files = function(
           if (verbose) {
             print("using psock cluster")
           }
-          parallel::makePSOCKcluster(spec = ncpu)
+          parallel::makePSOCKcluster(ncpu)
         }
       )
     })


### PR DESCRIPTION
The first arg of `makePSOCKcluster` is `names`, not `spec`