### PR TITLE
docs: remove `@usage NULL` for datetime methods

### DIFF
--- a/R/expr__datetime.R
+++ b/R/expr__datetime.R
@@ -47,7 +47,7 @@ ExprDT_truncate = function(every, offset = NULL) {
 #'
 #'
 #' @param every string encoding duration see details.
-#' @param ofset optional string encoding duration see details.
+#' @param offset optional string encoding duration see details.
 #'
 #' @details The ``every`` and ``offset`` argument are created with the
 #' the following string language:
@@ -431,6 +431,8 @@ ExprDT_minute = function() {
 #' Returns the integer second number from 0 to 59, or a floating
 #' point number from 0 < 60 if ``fractional=True`` that includes
 #' any milli/micro/nanosecond component.
+#'
+#' @param fractional Whether to include the fractional component of the second.
 #'
 #' @return Expr of second as UInt32
 #' @keywords ExprDT

--- a/R/expr__datetime.R
+++ b/R/expr__datetime.R
@@ -21,8 +21,6 @@
 #'   - 3d12h4m25s # 3 days, 12 hours, 4 minutes, and 25 seconds
 #' @return   Date/Datetime expr
 #' @keywords ExprDT
-#' @format function
-#' @usage NULL
 #' @aliases (Expr)$dt$truncate
 #' @examples
 #' t1 = as.POSIXct("3040-01-01", tz = "GMT")
@@ -71,8 +69,6 @@ ExprDT_truncate = function(every, offset = NULL) {
 #'
 #' @return   Date/Datetime expr
 #' @keywords ExprDT
-#' @format function
-#' @usage NULL
 #' @aliases (Expr)$dt$round
 #' @examples
 #' t1 = as.POSIXct("3040-01-01", tz = "GMT")
@@ -114,8 +110,6 @@ ExprDT_round = function(every, offset = NULL) {
 #'
 #' @return   Date/Datetime expr
 #' @keywords ExprDT
-#' @format function
-#' @usage NULL
 #' @aliases (Expr)$dt$combine
 #' @examples
 #' # Using pl$PTime
@@ -148,8 +142,6 @@ ExprDT_combine = function(tm, tu = "us") {
 #'
 #' @return   Date/Datetime expr
 #' @keywords ExprDT
-#' @format function
-#' @usage NULL
 #' @aliases (Expr)$dt$strftime
 #' @examples
 #' pl$lit(as.POSIXct("2021-01-02 12:13:14", tz = "GMT"))$dt$strftime("this is the year: %Y")$to_r()
@@ -167,8 +159,6 @@ ExprDT_strftime = function(format) {
 #'
 #' @return Expr of Year as Int32
 #' @keywords ExprDT
-#' @format function
-#' @usage NULL
 #' @aliases (Expr)$dt$year
 #' @examples
 #' df = pl$DataFrame(
@@ -199,8 +189,6 @@ ExprDT_year = function() {
 #'
 #' @return Expr of iso_year as Int32
 #' @keywords ExprDT
-#' @format function
-#' @usage NULL
 #' @aliases (Expr)$dt$iso_year
 #' @examples
 #' df = pl$DataFrame(
@@ -229,8 +217,6 @@ ExprDT_iso_year = function() {
 #'
 #' @return Expr of quarter as UInt32
 #' @keywords ExprDT
-#' @format function
-#' @usage NULL
 #' @aliases (Expr)$dt$quarter
 #' @examples
 #' df = pl$DataFrame(
@@ -258,8 +244,6 @@ ExprDT_quarter = function() {
 #'
 #' @return Expr of month as UInt32
 #' @keywords ExprDT
-#' @format function
-#' @usage NULL
 #' @aliases (Expr)$dtmonth
 #' @examples
 #' df = pl$DataFrame(
@@ -288,8 +272,6 @@ ExprDT_month = function() {
 #'
 #' @return Expr of week as UInt32
 #' @keywords ExprDT
-#' @format function
-#' @usage NULL
 #' @aliases (Expr)$dt$week
 #' @examples
 #' df = pl$DataFrame(
@@ -316,8 +298,6 @@ ExprDT_week = function() {
 #'
 #' @return Expr of weekday as UInt32
 #' @keywords ExprDT
-#' @format function
-#' @usage NULL
 #' @aliases (Expr)$dt$weekday
 #' @examples
 #' df = pl$DataFrame(
@@ -346,8 +326,6 @@ ExprDT_weekday = function() {
 #'
 #' @return Expr of day as UInt32
 #' @keywords ExprDT
-#' @format function
-#' @usage NULL
 #' @aliases (Expr)$dt$day
 #' @examples
 #' df = pl$DataFrame(
@@ -375,8 +353,6 @@ ExprDT_day = function() {
 #'
 #' @return Expr of ordinal_day as UInt32
 #' @keywords ExprDT
-#' @format function
-#' @usage NULL
 #' @aliases (Expr)$dt$ordinal_day
 #' @examples
 #' df = pl$DataFrame(
@@ -404,8 +380,6 @@ ExprDT_ordinal_day = function() {
 #'
 #' @return Expr of hour as UInt32
 #' @keywords ExprDT
-#' @format function
-#' @usage NULL
 #' @aliases (Expr)$dt$hour
 #' @examples
 #' df = pl$DataFrame(
@@ -432,8 +406,6 @@ ExprDT_hour = function() {
 #'
 #' @return Expr of minute as UInt32
 #' @keywords ExprDT
-#' @format function
-#' @usage NULL
 #' @aliases (Expr)$dt$minute
 #' @examples
 #' df = pl$DataFrame(
@@ -462,8 +434,6 @@ ExprDT_minute = function() {
 #'
 #' @return Expr of second as UInt32
 #' @keywords ExprDT
-#' @format function
-#' @usage NULL
 #' @aliases (Expr)$dt$second
 #' @examples
 #' pl$DataFrame(date = pl$date_range(
@@ -492,8 +462,6 @@ ExprDT_second = function(fractional = FALSE) {
 #'
 #' @return Expr of millisecond as Int64
 #' @keywords ExprDT
-#' @format function
-#' @usage NULL
 #' @aliases (Expr)$dt$millisecond
 #' @examples
 #' pl$DataFrame(date = pl$date_range(
@@ -517,8 +485,6 @@ ExprDT_millisecond = function() {
 #'
 #' @return Expr of microsecond as Int64
 #' @keywords ExprDT
-#' @format function
-#' @usage NULL
 #' @aliases (Expr)$dt$microsecond
 #' @examples
 #' pl$DataFrame(
@@ -549,8 +515,6 @@ ExprDT_microsecond = function() {
 #'
 #' @return Expr of second as Int64
 #' @keywords ExprDT
-#' @format function
-#' @usage NULL
 #' @aliases (Expr)$dt$nanosecond
 #' @examples
 #' pl$DataFrame(date = pl$date_range(
@@ -578,8 +542,6 @@ ExprDT_nanosecond = function() {
 #' R as flaot64/double.
 #' @return Expr of epoch as UInt32
 #' @keywords ExprDT
-#' @format function
-#' @usage NULL
 #' @aliases (Expr)$dt$epoch
 #' @examples
 #' pl$date_range(as.Date("2022-1-1"), eager = FALSE)$dt$epoch("ns")$to_series()
@@ -612,8 +574,6 @@ ExprDT_epoch = function(tu = c("us", "ns", "ms", "s", "d")) {
 #' @param tu string option either 'ns', 'us', or 'ms'
 #' @return Expr of i64
 #' @keywords ExprDT
-#' @format function
-#' @usage NULL
 #' @aliases (Expr)$dt$timestamp
 #' @examples
 #' df = pl$DataFrame(
@@ -644,8 +604,6 @@ ExprDT_timestamp = function(tu = c("ns", "us", "ms")) {
 #' @param tu string option either 'ns', 'us', or 'ms'
 #' @return Expr of i64
 #' @keywords ExprDT
-#' @format function
-#' @usage NULL
 #' @aliases (Expr)$dt$with_time_unit
 #' @examples
 #' df = pl$DataFrame(
@@ -677,8 +635,6 @@ ExprDT_with_time_unit = function(tu = c("ns", "us", "ms")) {
 #' @param tu string option either 'ns', 'us', or 'ms'
 #' @return Expr of i64
 #' @keywords ExprDT
-#' @format function
-#' @usage NULL
 #' @aliases (Expr)$dt$cast_time_unit
 #' @examples
 #' df = pl$DataFrame(
@@ -708,8 +664,6 @@ ExprDT_cast_time_unit = function(tu = c("ns", "us", "ms")) {
 #' @return Expr of i64
 #' @keywords ExprDT
 #' @details corresponds to in R manually modifying the tzone attribute of POSIXt objects
-#' @format function
-#' @usage NULL
 #' @aliases (Expr)$dt$convert_time_zone
 #' @examples
 #' df = pl$DataFrame(
@@ -748,8 +702,6 @@ ExprDT_convert_time_zone = function(tz) {
 #' * `"latest"`: use the latest datetime
 #' @return Expr of i64
 #' @keywords ExprDT
-#' @format function
-#' @usage NULL
 #' @aliases (Expr)$dt$replace_time_zone
 #' @examples
 #' df_1 = pl$DataFrame(x = as.POSIXct("2009-08-07 00:00:01", tz = "America/New_York"))
@@ -955,8 +907,6 @@ ExprDT_total_nanoseconds = function() {
 #'
 #' @return   Date/Datetime expr
 #' @keywords ExprDT
-#' @format function
-#' @usage NULL
 #' @aliases (Expr)$dt$offset_by
 #' @examples
 #' df = pl$DataFrame(

--- a/man/ExprDT_cast_time_unit.Rd
+++ b/man/ExprDT_cast_time_unit.Rd
@@ -4,8 +4,8 @@
 \alias{ExprDT_cast_time_unit}
 \alias{(Expr)$dt$cast_time_unit}
 \title{cast_time_unit}
-\format{
-function
+\usage{
+ExprDT_cast_time_unit(tu = c("ns", "us", "ms"))
 }
 \arguments{
 \item{tu}{string option either 'ns', 'us', or 'ms'}

--- a/man/ExprDT_combine.Rd
+++ b/man/ExprDT_combine.Rd
@@ -4,8 +4,8 @@
 \alias{ExprDT_combine}
 \alias{(Expr)$dt$combine}
 \title{Combine Data and Time}
-\format{
-function
+\usage{
+ExprDT_combine(tm, tu = "us")
 }
 \arguments{
 \item{tm}{Expr or numeric or PTime, the number of epoch since or before(if negative) the Date

--- a/man/ExprDT_convert_time_zone.Rd
+++ b/man/ExprDT_convert_time_zone.Rd
@@ -4,8 +4,8 @@
 \alias{ExprDT_convert_time_zone}
 \alias{(Expr)$dt$convert_time_zone}
 \title{With Time Zone}
-\format{
-function
+\usage{
+ExprDT_convert_time_zone(tz)
 }
 \arguments{
 \item{tz}{String time zone from base::OlsonNames()}

--- a/man/ExprDT_day.Rd
+++ b/man/ExprDT_day.Rd
@@ -4,8 +4,8 @@
 \alias{ExprDT_day}
 \alias{(Expr)$dt$day}
 \title{Day}
-\format{
-function
+\usage{
+ExprDT_day()
 }
 \value{
 Expr of day as UInt32

--- a/man/ExprDT_epoch.Rd
+++ b/man/ExprDT_epoch.Rd
@@ -4,8 +4,8 @@
 \alias{ExprDT_epoch}
 \alias{(Expr)$dt$epoch}
 \title{Epoch}
-\format{
-function
+\usage{
+ExprDT_epoch(tu = c("us", "ns", "ms", "s", "d"))
 }
 \arguments{
 \item{tu}{string option either 'ns', 'us', 'ms', 's' or  'd'}

--- a/man/ExprDT_hour.Rd
+++ b/man/ExprDT_hour.Rd
@@ -4,8 +4,8 @@
 \alias{ExprDT_hour}
 \alias{(Expr)$dt$hour}
 \title{Hour}
-\format{
-function
+\usage{
+ExprDT_hour()
 }
 \value{
 Expr of hour as UInt32

--- a/man/ExprDT_iso_year.Rd
+++ b/man/ExprDT_iso_year.Rd
@@ -4,8 +4,8 @@
 \alias{ExprDT_iso_year}
 \alias{(Expr)$dt$iso_year}
 \title{Iso-Year}
-\format{
-function
+\usage{
+ExprDT_iso_year()
 }
 \value{
 Expr of iso_year as Int32

--- a/man/ExprDT_microsecond.Rd
+++ b/man/ExprDT_microsecond.Rd
@@ -4,8 +4,8 @@
 \alias{ExprDT_microsecond}
 \alias{(Expr)$dt$microsecond}
 \title{Microsecond}
-\format{
-function
+\usage{
+ExprDT_microsecond()
 }
 \value{
 Expr of microsecond as Int64

--- a/man/ExprDT_millisecond.Rd
+++ b/man/ExprDT_millisecond.Rd
@@ -4,8 +4,8 @@
 \alias{ExprDT_millisecond}
 \alias{(Expr)$dt$millisecond}
 \title{Millisecond}
-\format{
-function
+\usage{
+ExprDT_millisecond()
 }
 \value{
 Expr of millisecond as Int64

--- a/man/ExprDT_minute.Rd
+++ b/man/ExprDT_minute.Rd
@@ -4,8 +4,8 @@
 \alias{ExprDT_minute}
 \alias{(Expr)$dt$minute}
 \title{Minute}
-\format{
-function
+\usage{
+ExprDT_minute()
 }
 \value{
 Expr of minute as UInt32

--- a/man/ExprDT_month.Rd
+++ b/man/ExprDT_month.Rd
@@ -4,8 +4,8 @@
 \alias{ExprDT_month}
 \alias{(Expr)$dtmonth}
 \title{Month}
-\format{
-function
+\usage{
+ExprDT_month()
 }
 \value{
 Expr of month as UInt32

--- a/man/ExprDT_nanosecond.Rd
+++ b/man/ExprDT_nanosecond.Rd
@@ -4,8 +4,8 @@
 \alias{ExprDT_nanosecond}
 \alias{(Expr)$dt$nanosecond}
 \title{Nanosecond}
-\format{
-function
+\usage{
+ExprDT_nanosecond()
 }
 \value{
 Expr of second as Int64

--- a/man/ExprDT_offset_by.Rd
+++ b/man/ExprDT_offset_by.Rd
@@ -4,8 +4,8 @@
 \alias{ExprDT_offset_by}
 \alias{(Expr)$dt$offset_by}
 \title{Offset By}
-\format{
-function
+\usage{
+ExprDT_offset_by(by)
 }
 \arguments{
 \item{by}{optional string encoding duration see details.}

--- a/man/ExprDT_ordinal_day.Rd
+++ b/man/ExprDT_ordinal_day.Rd
@@ -4,8 +4,8 @@
 \alias{ExprDT_ordinal_day}
 \alias{(Expr)$dt$ordinal_day}
 \title{Ordinal Day}
-\format{
-function
+\usage{
+ExprDT_ordinal_day()
 }
 \value{
 Expr of ordinal_day as UInt32

--- a/man/ExprDT_quarter.Rd
+++ b/man/ExprDT_quarter.Rd
@@ -4,8 +4,8 @@
 \alias{ExprDT_quarter}
 \alias{(Expr)$dt$quarter}
 \title{Quarter}
-\format{
-function
+\usage{
+ExprDT_quarter()
 }
 \value{
 Expr of quarter as UInt32

--- a/man/ExprDT_replace_time_zone.Rd
+++ b/man/ExprDT_replace_time_zone.Rd
@@ -4,8 +4,8 @@
 \alias{ExprDT_replace_time_zone}
 \alias{(Expr)$dt$replace_time_zone}
 \title{replace_time_zone}
-\format{
-function
+\usage{
+ExprDT_replace_time_zone(tz, ambiguous = "raise")
 }
 \arguments{
 \item{tz}{NULL or string time zone from \code{\link[base:timezones]{base::OlsonNames()}}}

--- a/man/ExprDT_round.Rd
+++ b/man/ExprDT_round.Rd
@@ -4,8 +4,8 @@
 \alias{ExprDT_round}
 \alias{(Expr)$dt$round}
 \title{Round datetime}
-\format{
-function
+\usage{
+ExprDT_round(every, offset = NULL)
 }
 \arguments{
 \item{every}{string encoding duration see details.}

--- a/man/ExprDT_round.Rd
+++ b/man/ExprDT_round.Rd
@@ -10,7 +10,7 @@ ExprDT_round(every, offset = NULL)
 \arguments{
 \item{every}{string encoding duration see details.}
 
-\item{ofset}{optional string encoding duration see details.}
+\item{offset}{optional string encoding duration see details.}
 }
 \value{
 Date/Datetime expr

--- a/man/ExprDT_second.Rd
+++ b/man/ExprDT_second.Rd
@@ -4,8 +4,8 @@
 \alias{ExprDT_second}
 \alias{(Expr)$dt$second}
 \title{Second}
-\format{
-function
+\usage{
+ExprDT_second(fractional = FALSE)
 }
 \value{
 Expr of second as UInt32

--- a/man/ExprDT_second.Rd
+++ b/man/ExprDT_second.Rd
@@ -7,6 +7,9 @@
 \usage{
 ExprDT_second(fractional = FALSE)
 }
+\arguments{
+\item{fractional}{Whether to include the fractional component of the second.}
+}
 \value{
 Expr of second as UInt32
 }

--- a/man/ExprDT_strftime.Rd
+++ b/man/ExprDT_strftime.Rd
@@ -4,8 +4,8 @@
 \alias{ExprDT_strftime}
 \alias{(Expr)$dt$strftime}
 \title{strftime}
-\format{
-function
+\usage{
+ExprDT_strftime(format)
 }
 \arguments{
 \item{format}{string format very much like in R passed to chrono}

--- a/man/ExprDT_timestamp.Rd
+++ b/man/ExprDT_timestamp.Rd
@@ -4,8 +4,8 @@
 \alias{ExprDT_timestamp}
 \alias{(Expr)$dt$timestamp}
 \title{timestamp}
-\format{
-function
+\usage{
+ExprDT_timestamp(tu = c("ns", "us", "ms"))
 }
 \arguments{
 \item{tu}{string option either 'ns', 'us', or 'ms'}

--- a/man/ExprDT_truncate.Rd
+++ b/man/ExprDT_truncate.Rd
@@ -4,8 +4,8 @@
 \alias{ExprDT_truncate}
 \alias{(Expr)$dt$truncate}
 \title{Truncate datetime}
-\format{
-function
+\usage{
+ExprDT_truncate(every, offset = NULL)
 }
 \arguments{
 \item{every}{string encoding duration see details.}

--- a/man/ExprDT_week.Rd
+++ b/man/ExprDT_week.Rd
@@ -4,8 +4,8 @@
 \alias{ExprDT_week}
 \alias{(Expr)$dt$week}
 \title{Week}
-\format{
-function
+\usage{
+ExprDT_week()
 }
 \value{
 Expr of week as UInt32

--- a/man/ExprDT_weekday.Rd
+++ b/man/ExprDT_weekday.Rd
@@ -4,8 +4,8 @@
 \alias{ExprDT_weekday}
 \alias{(Expr)$dt$weekday}
 \title{Weekday}
-\format{
-function
+\usage{
+ExprDT_weekday()
 }
 \value{
 Expr of weekday as UInt32

--- a/man/ExprDT_with_time_unit.Rd
+++ b/man/ExprDT_with_time_unit.Rd
@@ -4,8 +4,8 @@
 \alias{ExprDT_with_time_unit}
 \alias{(Expr)$dt$with_time_unit}
 \title{with_time_unit}
-\format{
-function
+\usage{
+ExprDT_with_time_unit(tu = c("ns", "us", "ms"))
 }
 \arguments{
 \item{tu}{string option either 'ns', 'us', or 'ms'}

--- a/man/ExprDT_year.Rd
+++ b/man/ExprDT_year.Rd
@@ -4,8 +4,8 @@
 \alias{ExprDT_year}
 \alias{(Expr)$dt$year}
 \title{Year}
-\format{
-function
+\usage{
+ExprDT_year()
 }
 \value{
 Expr of Year as Int32


### PR DESCRIPTION
Something forgotten in previous PRs. These were the last `@usage NULL` to remove