### PR TITLE
ci: fix typo of the path in the ci trigger

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -17,7 +17,7 @@ on:
       - man/**
       - R/**
       - src/**
-      - vignetts/**
+      - vignettes/**
       - DESCRIPTION
       - README.md
   pull_request:
@@ -29,7 +29,7 @@ on:
       - man/**
       - R/**
       - src/**
-      - vignetts/**
+      - vignettes/**
       - DESCRIPTION
       - README.md
   workflow_dispatch:


### PR DESCRIPTION
I noticed that #669 was not triggering the docs workflow due to a typo in this file.