### PR TITLE
feat(installation): support cross-compiling the R package via the `--host` option of the configure script

### DIFF
--- a/configure
+++ b/configure
@@ -41,12 +41,12 @@ check_cargo() {
 }
 
 check_bin_lib() {
-  if [ "${NOT_CRAN}" = "true" ] && [ -z "${LIBR_POLARS_BUILD}"  ]; then
+  if [ "${NOT_CRAN}" = "true" ] && [ -z "${LIBR_POLARS_BUILD}" ]; then
     LIBR_POLARS_BUILD="false"
   fi
 
   # On R-universe, we try to download the pre-built binary from GitHub releases.
-  if [ -n "${MY_UNIVERSE}" ] && [ -z "${LIBR_POLARS_BUILD}"  ]; then
+  if [ -n "${MY_UNIVERSE}" ] && [ -z "${LIBR_POLARS_BUILD}" ]; then
     echo ""
     echo "--------------------- [SETTING FOR R-UNIVERSE] ---------------------"
     echo "It seems that this is on R-universe <${MY_UNIVERSE}>."
@@ -56,7 +56,7 @@ check_bin_lib() {
     LIBR_POLARS_BUILD="false"
   fi
 
-  if [ "${LIBR_POLARS_BUILD}" = "false" ] && [ -f "tools/lib-sums.tsv" ] && [ ! -f "${LIBR_POLARS_PATH}" ] ; then
+  if [ "${LIBR_POLARS_BUILD}" = "false" ] && [ -f "tools/lib-sums.tsv" ] && [ ! -f "${LIBR_POLARS_PATH}" ]; then
     echo ""
     echo "---------------- [TRY TO DOWNLOAD PRE-BUILT BINARY] ----------------"
     "${R_HOME}/bin${R_ARCH_BIN}/Rscript" "tools/prep-lib.R" || echo "Failed to download pre-built binary."
@@ -102,15 +102,39 @@ check_bin_lib() {
 }
 
 check_darwin() {
-  if [ "$(uname)" = "Darwin" ] ; then
+  if [ "$(uname)" = "Darwin" ]; then
     ADDITIONAL_PKG_LIBS_FLAG=""
   fi
 }
 
+detect_target_option() {
+  for option in "$@"; do
+    case "${option}" in
+    --build=*)
+      specified_target="$(echo "${option}" | sed -e 's/--build=//' | sed -E 's/([0-9]+\.)*[0-9]+$//')"
+      echo ""
+      echo "------------------------------ [DETECTED TARGET] ------------------------------"
+      echo "The target was specified as <${specified_target}> via the '--build' option."
+      echo "-------------------------------------------------------------------------------"
+      echo ""
+      export TARGET="${specified_target}"
+      ;;
+    *) ;;
+    esac
+    shift
+  done
+}
+
+detect_target_option "$@"
 check_darwin
 check_bin_lib
 check_cargo
 
-sed -e "s|@RUST_TARGET@|$(rustc -vV | grep host | cut -d' ' -f2)|" -e "s|@ADDITIONAL_PKG_LIBS_FLAG@|${ADDITIONAL_PKG_LIBS_FLAG}|" src/Makevars.in >src/Makevars
+RUST_TARGET="${TARGET:-$(rustc -vV | grep host | cut -d' ' -f2)}"
+
+sed \
+  -e "s|@RUST_TARGET@|${RUST_TARGET}|" \
+  -e "s|@ADDITIONAL_PKG_LIBS_FLAG@|${ADDITIONAL_PKG_LIBS_FLAG}|" \
+  src/Makevars.in >src/Makevars
 
 exit 0

--- a/configure
+++ b/configure
@@ -110,11 +110,11 @@ check_darwin() {
 detect_target_option() {
   for option in "$@"; do
     case "${option}" in
-    --build=*)
-      specified_target="$(echo "${option}" | sed -e 's/--build=//' | sed -E 's/([0-9]+\.)*[0-9]+$//')"
+    --host=*)
+      specified_target="$(echo "${option}" | sed -e 's/--host=//' | sed -E 's/([0-9]+\.)*[0-9]+$//')"
       echo ""
       echo "------------------------------ [DETECTED TARGET] ------------------------------"
-      echo "The target was specified as <${specified_target}> via the '--build' option."
+      echo "The target was specified as <${specified_target}> via the '--host' option."
       echo "-------------------------------------------------------------------------------"
       echo ""
       export TARGET="${specified_target}"

--- a/tools/prep-lib.R
+++ b/tools/prep-lib.R
@@ -64,7 +64,11 @@ current_os = which_os()
 vendor_sys_abi = which_vendor_sys_abi(current_os)
 current_arch = which_arch()
 
-target_triple = paste0(current_arch, "-", vendor_sys_abi)
+target_triple = ifelse(
+  Sys.getenv("TARGET") != "",
+  Sys.getenv("TARGET"),
+  paste0(current_arch, "-", vendor_sys_abi)
+)
 
 lib_data = utils::read.table("tools/lib-sums.tsv", header = TRUE, stringsAsFactors = FALSE)
 

--- a/vignettes/install.Rmd
+++ b/vignettes/install.Rmd
@@ -34,7 +34,7 @@ Sys.setenv(NOT_CRAN = "true") # Enable installation with pre-built Rust library 
 install.packages("polars", repos = "https://rpolars.r-universe.dev")
 ```
 
-- On amd64 architecture Windows and macOS, binary R packages will be installed.
+- On supported platforms, binary R package will be installed.
 - On the other platforms, the pre-built Rust library binary will be downloaded while building the R source package.
 - If the pre-built Rust library binary is not available, the Rust library will be built from source (provided that Rust is installed).
 


### PR DESCRIPTION
Same as eitsupi/prqlr#247

R-universe started distributing R binary packages for arm64 macOS yesterday (r-universe-org/help#340).

![image](https://github.com/pola-rs/r-polars/assets/50911393/b85ced8a-088d-4405-a133-43f6a58d1607)

This PR should enable both of the following two R package cross-compilation methods to work.

1. Compile from Rust source (confirmed with eitsupi/prqlr#247)
2. Download and use Rust binary libraries from the internet (Checked on my R-universe https://github.com/eitsupi/eitsupi.r-universe.dev/commit/2b5163fe86eac278eee3a1fe7a343b7c9bd37518)