### PR TITLE
fix: set the API document site to the primary URL of package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,8 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.0
 SystemRequirements: Cargo (rustc package manager), cmake
-URL: https://github.com/pola-rs/r-polars
+URL: https://rpolars.github.io/,
+    https://github.com/pola-rs/r-polars,
     https://rpolars.r-universe.dev/polars
 Suggests:
     arrow,

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -221,6 +221,7 @@ tasks:
   install-package:
     desc: Install the R package.
     sources:
+      - DESCRIPTION
       - "{{.R_SOURCE}}"
       - src/Makevars*
       - configure*


### PR DESCRIPTION
Related to #700

This is required for automatic linking support via `downlit`, as `downlit` expects the very first URL in the URL field to be a pkgdown site.

``` r
downlit::autolink("polars::as_polars_df()")
#> [1] "<a href='https://rpolars.github.io/man/as_polars_df.html'>polars::as_polars_df()</a>"
```

<sup>Created on 2024-01-28 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>