### PR TITLE
fix: `$sort()` no longer panicks when `descending = NULL`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -117,5 +117,5 @@ Collate:
     'zzz.R'
 Config/rextendr/version: 0.3.1
 VignetteBuilder: knitr
-Config/polars/LibVersion: 0.36.1
+Config/polars/LibVersion: 0.36.2
 Config/polars/RustToolchainVersion: nightly-2023-12-23

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## polars (development version)
 
+### Bug fixes
+
+-   `$sort()` no longer panicks when `descending = NULL` (#747).
+
 ## polars 0.13.0
 
 ### Breaking changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
--   `$sort()` no longer panicks when `descending = NULL` (#747).
+-   `$sort()` no longer panicks when `descending = NULL` (#748).
 
 ## polars 0.13.0
 

--- a/R/lazyframe__lazy.R
+++ b/R/lazyframe__lazy.R
@@ -1172,9 +1172,9 @@ LazyFrame_join = function(
 #' df$sort(c("cyl", "mpg"), descending = c(TRUE, FALSE))$collect()
 #' df$sort(pl$col("cyl"), pl$col("mpg"))$collect()
 LazyFrame_sort = function(
-    by, # : IntoExpr | List[IntoExpr],
-    ..., # unnamed Into expr
-    descending = FALSE, #  bool | vector[bool] = False,
+    by,
+    ...,
+    descending = FALSE,
     nulls_last = FALSE,
     maintain_order = FALSE) {
   .pr$LazyFrame$sort_by_exprs(

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r-polars"
-version = "0.36.1"
+version = "0.36.2"
 edition = "2021"
 rust-version = "1.73"
 publish = false

--- a/src/rust/src/lazy/dataframe.rs
+++ b/src/rust/src/lazy/dataframe.rs
@@ -470,6 +470,12 @@ impl RPolarsLazyFrame {
         let mut ddd = robj_to!(VecPLExprCol, dotdotdot)?;
         exprs.append(&mut ddd);
         let descending = robj_to!(Vec, bool, descending)?;
+
+        if descending.is_empty() {
+            return Err(RPolarsErr::new()
+                .plain("`descending` must be of length 1 or of the same length as `by`".into()));
+        };
+
         let nulls_last = robj_to!(bool, nulls_last)?;
         let maintain_order = robj_to!(bool, maintain_order)?;
         Ok(self

--- a/tests/testthat/test-dataframe.R
+++ b/tests/testthat/test-dataframe.R
@@ -735,6 +735,16 @@ test_that("sort", {
   b = df$sort("mpg", nulls_last = FALSE)$to_data_frame()
   expect_true(is.na(a$mpg[32]))
   expect_true(is.na(b$mpg[1]))
+
+  # error if descending is NULL
+  expect_error(
+    df$sort("mpg", descending = NULL),
+    "must be of length 1 or of the same length as `by`"
+  )
+  expect_error(
+    df$sort(c("mpg", "drat"), descending = NULL),
+    "must be of length 1 or of the same length as `by`"
+  )
 })
 
 test_that("dtype_strings", {

--- a/tests/testthat/test-lazy.R
+++ b/tests/testthat/test-lazy.R
@@ -417,6 +417,16 @@ test_that("sort", {
   b = df$sort("mpg", nulls_last = FALSE, maintain_order = TRUE)$collect()$to_data_frame()
   expect_true(is.na(a$mpg[32]))
   expect_true(is.na(b$mpg[1]))
+
+  # error if descending is NULL
+  expect_error(
+    df$sort("mpg", descending = NULL),
+    "must be of length 1 or of the same length as `by`"
+  )
+  expect_error(
+    df$sort(c("mpg", "drat"), descending = NULL),
+    "must be of length 1 or of the same length as `by`"
+  )
 })
 
 

--- a/tools/lib-sums.tsv
+++ b/tools/lib-sums.tsv
@@ -1,6 +1,0 @@
-url	sha256sum
-https://github.com/pola-rs/r-polars/releases/download/lib-v0.36.1/libr_polars-0.36.1-aarch64-apple-darwin.tar.gz	8619f6ede47c7aec2b7d733c5742e253cb2317d3d39d9d6794d5e15bf7db30c8
-https://github.com/pola-rs/r-polars/releases/download/lib-v0.36.1/libr_polars-0.36.1-aarch64-unknown-linux-gnu.tar.gz	8d76ce10df688967a7a46b028efac08e7e54a0667070ec4d87a5285d473bf573
-https://github.com/pola-rs/r-polars/releases/download/lib-v0.36.1/libr_polars-0.36.1-x86_64-apple-darwin.tar.gz	42e6a7f18a210961a02ee9b2282d5c081fcd13bb7505404e60f97816efdb1180
-https://github.com/pola-rs/r-polars/releases/download/lib-v0.36.1/libr_polars-0.36.1-x86_64-pc-windows-gnu.tar.gz	596c92f98c73ff23648153ce31cef5caee4cefd61313a0b346d8c8a057f53d9f
-https://github.com/pola-rs/r-polars/releases/download/lib-v0.36.1/libr_polars-0.36.1-x86_64-unknown-linux-gnu.tar.gz	455cc005c21f92f6bcbc8c4b1e58b26215f38076d703205d09958b9dcf33eb58


### PR DESCRIPTION
Close #733 
Close #734 (which will be hard to replicate now that #733 is fixed)