### PR TITLE
chore: refactor some rust code

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -1776,7 +1776,7 @@ dependencies = [
 
 [[package]]
 name = "r-polars"
-version = "0.36.1"
+version = "0.36.2"
 dependencies = [
  "either",
  "extendr-api",

--- a/src/rust/src/lazy/dataframe.rs
+++ b/src/rust/src/lazy/dataframe.rs
@@ -240,7 +240,7 @@ impl RPolarsLazyFrame {
         let out = ldf
             .quantile(
                 robj_to!(PLExpr, quantile)?,
-                robj_to!(new_quantile_interpolation_option, interpolation)?,
+                robj_to!(quantile_interpolation_option, interpolation)?,
             )
             .map_err(polars_to_rpolars_err)?;
         Ok(out.into())

--- a/src/rust/src/lazy/dsl.rs
+++ b/src/rust/src/lazy/dsl.rs
@@ -423,7 +423,7 @@ impl RPolarsExpr {
             .0
             .quantile(
                 robj_to!(PLExpr, quantile)?,
-                robj_to!(new_quantile_interpolation_option, interpolation)?,
+                robj_to!(quantile_interpolation_option, interpolation)?,
             )
             .into())
     }
@@ -480,12 +480,12 @@ impl RPolarsExpr {
             .into()
     }
 
-    pub fn interpolate(&self, method: &str) -> List {
-        use crate::rdatatype::new_interpolation_method;
-        let im_result = new_interpolation_method(method)
-            .map(|im| RPolarsExpr(self.0.clone().interpolate(im)))
-            .map_err(|err| format!("in interpolate(): {}", err));
-        r_result_list(im_result)
+    pub fn interpolate(&self, method: Robj) -> RResult<RPolarsExpr> {
+        Ok(self
+            .clone()
+            .0
+            .interpolate(robj_to!(InterpolationMethod, method)?)
+            .into())
     }
 
     pub fn rolling_min(
@@ -687,7 +687,7 @@ impl RPolarsExpr {
             fn_params: None,
         };
         let quantile = robj_to!(f64, quantile)?;
-        let interpolation = robj_to!(new_quantile_interpolation_option, interpolation)?;
+        let interpolation = robj_to!(quantile_interpolation_option, interpolation)?;
 
         Ok(self
             .0

--- a/src/rust/src/utils/mod.rs
+++ b/src/rust/src/utils/mod.rs
@@ -955,8 +955,11 @@ macro_rules! robj_to_inner {
     (StartBy, $a:ident) => {
         $crate::rdatatype::robj_to_start_by($a)
     };
-    (new_quantile_interpolation_option, $a:ident) => {
-        $crate::rdatatype::new_quantile_interpolation_option($a)
+    (quantile_interpolation_option, $a:ident) => {
+        $crate::rdatatype::robj_to_quantile_interpolation_option($a)
+    };
+    (InterpolationMethod, $a:ident) => {
+        $crate::rdatatype::robj_to_interpolation_method($a)
     };
     (new_null_behavior, $a:ident) => {
         $crate::rdatatype::robj_new_null_behavior($a)


### PR DESCRIPTION
I think the `robj_to_` macros are now the way to go for converting R objects to anything, so I move some interpolation methods to use these macros