### PR TITLE
refactor: remove unused functions related to arrow

### DIFF
--- a/R/extendr-wrappers.R
+++ b/R/extendr-wrappers.R
@@ -38,8 +38,6 @@ as_struct <- function(exprs) .Call(wrap__as_struct, exprs)
 
 struct_ <- function(exprs, eager, schema) .Call(wrap__struct_, exprs, eager, schema)
 
-rb_list_to_df <- function(r_batches, names) .Call(wrap__rb_list_to_df, r_batches, names)
-
 dtype_str_repr <- function(dtype) .Call(wrap__dtype_str_repr, dtype)
 
 new_arrow_stream <- function() .Call(wrap__new_arrow_stream)

--- a/src/rust/src/arrow_interop/mod.rs
+++ b/src/rust/src/arrow_interop/mod.rs
@@ -1,1 +1,63 @@
 pub mod to_rust;
+
+use extendr_api::prelude::*;
+use std::result::Result;
+
+#[derive(Debug)]
+pub enum RArrowArrayClass {
+    ArrowArray,
+    NanoArrowArray,
+}
+
+impl<'a> FromRobj<'a> for RArrowArrayClass {
+    fn from_robj(robj: &Robj) -> std::result::Result<Self, &'static str> {
+        if robj.inherits("nanoarrow_array") {
+            Ok(RArrowArrayClass::NanoArrowArray)
+        } else if robj.inherits("Array") {
+            Ok(RArrowArrayClass::ArrowArray)
+        } else {
+            Err("Robj does not inherit from Array or nanoarrow_array")
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ArrowRPackage;
+#[derive(Debug)]
+pub struct NanoArrowRPackage;
+
+impl RArrowArrayClass {
+    pub fn get_package(&self) -> Box<dyn RPackage> {
+        match self {
+            RArrowArrayClass::ArrowArray => Box::new(ArrowRPackage),
+            RArrowArrayClass::NanoArrowArray => Box::new(NanoArrowRPackage),
+        }
+    }
+}
+
+pub trait RPackage {
+    fn get_export_array_func(&self) -> Result<Robj, Error>;
+}
+
+impl RPackage for ArrowRPackage {
+    fn get_export_array_func(&self) -> Result<Robj, Error> {
+        R!(r#"
+        function(array, exportable_array, exportable_schema) {
+            array$export_to_c(exportable_array, exportable_schema)
+        }"#)
+    }
+}
+
+impl RPackage for NanoArrowRPackage {
+    fn get_export_array_func(&self) -> Result<Robj, Error> {
+        R!(r#"
+        function(array, exportable_array, exportable_schema) {
+            nanoarrow::nanoarrow_pointer_export(
+                nanoarrow::infer_nanoarrow_schema(array),
+                exportable_schema
+            )
+            nanoarrow::nanoarrow_pointer_export(array, exportable_array)
+        }
+        "#)
+    }
+}

--- a/src/rust/src/rlib.rs
+++ b/src/rust/src/rlib.rs
@@ -170,22 +170,6 @@ unsafe fn export_df_to_arrow_stream(robj_df: Robj, robj_str: Robj) -> RResult<Ro
 }
 
 #[extendr]
-fn rb_list_to_df(r_batches: List, names: Vec<String>) -> Result<RPolarsDataFrame, String> {
-    let mut iter = r_batches.into_iter().map(|(_, robj)| {
-        let robj = call!(r"\(x) x$columns", robj)?;
-        let l = robj.as_list().ok_or_else(|| "not a list!?".to_string())?;
-        crate::arrow_interop::to_rust::rb_to_rust_df(l, &names)
-    });
-    let mut df_acc = iter
-        .next()
-        .unwrap_or_else(|| Ok(pl::DataFrame::default()))?;
-    for df in iter {
-        df_acc.vstack_mut(&df?).map_err(|err| err.to_string())?;
-    }
-    Ok(RPolarsDataFrame(df_acc))
-}
-
-#[extendr]
 pub fn dtype_str_repr(dtype: Robj) -> RResult<String> {
     let dtype = robj_to!(RPolarsDataType, dtype)?.0;
     Ok(dtype.to_string())
@@ -328,10 +312,6 @@ extendr_module! {
     fn r_date_range_lazy;
     fn as_struct;
     fn struct_;
-    //fn field_to_rust2;
-    //fn series_from_arrow;
-    //fn rb_to_df;
-    fn rb_list_to_df;
 
     fn dtype_str_repr;
 


### PR DESCRIPTION
Part of #732

- Remove unused internal R function `rb_list_to_df`
- Move some codes from `to_rust.rs` to `mod.rs` for future use.
- Remove some unused Rust functions and comments.