### PR TITLE
ci: add `macos-14` (arm64 macOS) to GitHub Actions matrixes

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -48,14 +48,14 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: macos-latest, r: "release" }
+          - { os: macos-14, r: "release" }
           - { os: windows-latest, r: "devel", rtools-version: "43" }
           - { os: windows-latest, r: "release", rtools-version: "" }
           - { os: ubuntu-latest, r: "devel", http-user-agent: "release" }
           - { os: ubuntu-latest, r: "release" }
           - { os: ubuntu-latest, r: "oldrel-1" }
         include:
-          - config: { os: macos-latest, r: "release", full-features: true }
+          - config: { os: macos-14, r: "release", full-features: true }
           - config: { os: windows-latest, r: "release", full-features: true }
           - config: { os: ubuntu-latest, r: "release", full-features: true }
 
@@ -139,7 +139,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-latest
+          - macos-12
+          - macos-14
           - windows-latest
           - ubuntu-latest
         r:
@@ -147,9 +148,13 @@ jobs:
           - release
           - devel
         exclude:
-          - os: macos-latest
+          - os: macos-12
             r: devel
-          - os: macos-latest
+          - os: macos-12
+            r: oldrel-1
+          - os: macos-14
+            r: devel
+          - os: macos-14
             r: oldrel-1
 
     env:

--- a/.github/workflows/release-lib.yaml
+++ b/.github/workflows/release-lib.yaml
@@ -38,9 +38,9 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - os: ubuntu-20.04
             target: aarch64-unknown-linux-gnu
-          - os: macos-latest
+          - os: macos-14
             target: x86_64-apple-darwin
-          - os: macos-latest
+          - os: macos-14
             target: aarch64-apple-darwin
           - os: windows-latest
             target: x86_64-pc-windows-gnu
@@ -104,7 +104,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-latest
+          - macos-12
+          - macos-14
           - windows-latest
           - ubuntu-latest
         r:
@@ -112,9 +113,13 @@ jobs:
           - release
           - devel
         exclude:
-          - os: macos-latest
+          - os: macos-12
             r: devel
-          - os: macos-latest
+          - os: macos-12
+            r: oldrel-1
+          - os: macos-14
+            r: devel
+          - os: macos-14
             r: oldrel-1
 
     permissions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,9 +40,10 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macos-latest,   r: 'release'}
-          - {os: windows-latest, r: 'release'}
-          - {os: ubuntu-latest,   r: 'release'}
+          - { os: macos-12, r: "release" }
+          - { os: macos-14, r: "release" }
+          - { os: windows-latest, r: "release" }
+          - { os: ubuntu-latest, r: "release" }
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Incorporate the newly available arm64 macOS runner into the CI.

It has been announced that `macos-latest` will be switched from `macos-12` (amd64) to `macos-14` (arm64) in a few months, so it has been changed to explicitly specify `macos-12` or `macos-14`.