### PR TITLE
empty .lintr take precedence over ~/.lintr

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -31,3 +31,4 @@
 ^Taskfile\.yml$
 ^\.editorconfig$
 ^rustfmt\.toml$
+^\.lintr$


### PR DESCRIPTION
For users who have .lintr in their home dir. r-polars code may show many unwanted lints. This PR is to fix it.

CRAN package rextendr  has .lintr in its project root so I think it is ok to add it in r-polars too.
