### PR TITLE
docs(website): show DynamicGroupBy in a different section

### DIFF
--- a/altdoc/altdoc_preprocessing.R
+++ b/altdoc/altdoc_preprocessing.R
@@ -36,8 +36,8 @@ out = list()
 # order determines order in sidebar
 classes = c(
   "pl", "Series", "DataFrame", "LazyFrame", "GroupBy",
-  "LazyGroupBy", "RollingGroupBy", "ExprList", "ExprBin", "ExprCat", "ExprDT",
-  "ExprMeta", "ExprName", "ExprStr", "ExprStruct",
+  "LazyGroupBy", "RollingGroupBy", "DynamicGroupBy", "ExprList", "ExprBin",
+  "ExprCat", "ExprDT", "ExprMeta", "ExprName", "ExprStr", "ExprStruct",
   "Expr", "IO", "RField", "RThreadHandle", "SQLContext", "S3"
 )
 for (cl in classes) {


### PR DESCRIPTION
We already had a section for `RollingGroupBy`, I think it makes sense to have one for `RollingGroupBy` too.

Before:

![image](https://github.com/pola-rs/r-polars/assets/52219252/02ab0181-6c40-4ef3-bb6c-dd1e0dbe98fc)


After:

![image](https://github.com/pola-rs/r-polars/assets/52219252/80808f94-2dfb-457b-ae7c-955c6067067e)
