### PR TITLE
refactor: add the lintr config file and some refactoring

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -31,3 +31,4 @@
 ^Taskfile\.yml$
 ^\.editorconfig$
 ^rustfmt\.toml$
+^\.lintr\.R$

--- a/.lintr.R
+++ b/.lintr.R
@@ -1,0 +1,8 @@
+linters = linters_with_defaults(
+  line_length_linter(120),
+  assignment_linter = NULL,
+  object_name_linter = NULL,
+  indentation_linter = NULL,
+  commented_code_linter = NULL
+)
+encoding = "UTF-8"

--- a/inst/misc/develop_polars.R
+++ b/inst/misc/develop_polars.R
@@ -166,7 +166,7 @@ submit_polars = function(
         lapply(tail, 1) |>
         substr(x = non_target_files, start = 1) |>
         unique() |>
-        (\(x){
+        (\(x) {
           x[order(nchar(x))][-1]
         })()
       for (i in paste0(temp_dir, "/", non_target_dirs)) dir.create(i)

--- a/tests/testthat/test-expr_expr.R
+++ b/tests/testthat/test-expr_expr.R
@@ -1066,7 +1066,7 @@ test_that("gather that", {
 })
 
 test_that("shift", {
-  R_shift = \(x, n){
+  R_shift = \(x, n) {
     idx = seq_along(x) - n
     idx[idx <= 0] = Inf
     x[idx]
@@ -1113,7 +1113,7 @@ test_that("fill_null  + forward backward _fill + fill_nan", {
   # fiil value
   expect_identical(
     pl$DataFrame(l)$select(pl$col("a")$fill_null(42L))$to_list()$a,
-    l$a |> (\(x){
+    l$a |> (\(x) {
       x[is.na(x)] = 42L
       x
     })()
@@ -1721,7 +1721,7 @@ test_that("Expr_diff", {
 test_that("Expr_pct_change", {
   l = list(a = c(10L, 11L, 12L, NA_integer_, NA_integer_, 12L))
 
-  R_shift = \(x, n){
+  R_shift = \(x, n) {
     idx = seq_along(x) - n
     idx[idx <= 0] = Inf
     x[idx]

--- a/tests/testthat/test-sink_stream.R
+++ b/tests/testthat/test-sink_stream.R
@@ -80,7 +80,7 @@ test_that("Test sinking data to parquet file", {
 
 dat = head(mtcars, n = 15)
 dat[c(1, 3, 9, 12), c(3, 4, 5)] = NA
-dat$id = 1:nrow(dat)
+dat$id = seq_len(nrow(dat))
 dat_pl = pl$LazyFrame(dat)
 temp_out = tempfile(fileext = ".csv")
 

--- a/tests/testthat/test-whenthen.R
+++ b/tests/testthat/test-whenthen.R
@@ -71,7 +71,7 @@ test_that("when-then-otherwise", {
   expect_identical(
     df_act$to_list()[[1]],
     sapply(
-      df$to_list()$cyl, \(x){
+      df$to_list()$cyl, \(x) {
         if (x <= 4) {
           return("<=4cyl")
         }

--- a/vignettes/userguide.Rmd
+++ b/vignettes/userguide.Rmd
@@ -448,7 +448,7 @@ df$sort("Type 1")$select(
 
 ````{comment}
 
-```{r}
+```
 grades = pl$DataFrame(
         "student" = c("bas", "laura", "tim", "jenny"),
         "arithmetic" = c(10, 5, 6, 8),
@@ -476,7 +476,7 @@ grades$with_columns(
 
 # Custom functions
 
-```{r}
+```
 df = pl$DataFrame(
   "keys" = c("a", "a", "b"),
   "values" = c(10, 7, 1)
@@ -521,7 +521,7 @@ print(out)
 
 # R examples
 
-```{r}
+```
 df = pl$DataFrame(
   "A" = c(1, 2, 3, 4, 5),
   "fruits" = c("banana", "banana", "apple", "apple", "banana"),

--- a/vignettes/userguide.Rmd
+++ b/vignettes/userguide.Rmd
@@ -28,7 +28,7 @@ These functions/methods are either missing, broken, or Vincent can't figure out 
 * `pl$fold`
 * `DataFrame.explode`
 * Custom R function in an agg on group_by
-  
+
 Requires new Polars version:
 
 * `df$sample()`
@@ -422,13 +422,13 @@ pl$sum("foo")$over("groups")
 # output type: -> Int32
 (pl$col("x")$sum() * pl$col("y"))$over("groups")
 
-# sum within a group and multiply with group elements 
+# sum within a group and multiply with group elements
 # and aggregate/implode the group to a list
 # output type: -> List(Int32)
 (pl$col("x")$sum() * pl$col("y"))$implode()$over("groups")
 
 # note that it will require an explicit `implode()` call
-# sum within a group and multiply with group elements 
+# sum within a group and multiply with group elements
 # and aggregate/implode the group to a list
 # the explode call unpack the list and combine inner elements to one column
 
@@ -521,7 +521,7 @@ print(out)
 
 # R examples
 
-```
+```{r}
 df = pl$DataFrame(
   "A" = c(1, 2, 3, 4, 5),
   "fruits" = c("banana", "banana", "apple", "apple", "banana"),
@@ -542,12 +542,12 @@ df$select(
 # We can use a list within select (example above) or a comma-separated list of expressions (this example)$
 df$select(
   pl$col("A"),
-  "B",      
+  "B",
   pl$lit("B")
 )
 
 # We can select columns with a regex if the regex starts with '^' and ends with '$'
-df$select(    
+df$select(
   pl$col("^A|B$")$sum()
 )
 


### PR DESCRIPTION
Close #766
Part of #214

Note that this PR does not correct all warnings because there are too many to correct.

Also, because `lint_package` takes several minutes to run, the Taskfile does not run the function.