### PR TITLE
docs(vignette): update the introduction vignette to use the new functions

### DIFF
--- a/vignettes/polars.Rmd
+++ b/vignettes/polars.Rmd
@@ -471,8 +471,11 @@ on disk. Let's see an example.
 ```{r}
 as_polars_df(airquality)$write_parquet("airquality.parquet")
 
-# aq = read_parquet("airquality.parquet) # eager version (okay)
-aq = pl$scan_parquet("airquality.parquet") # lazy version (better)
+# eager version (okay)
+aq_collected = pl$read_parquet("airquality.parquet")
+
+# lazy version (better)
+aq = pl$scan_parquet("airquality.parquet")
 
 aq$filter(
   pl$col("Month") <= 6

--- a/vignettes/polars.Rmd
+++ b/vignettes/polars.Rmd
@@ -15,7 +15,6 @@ knitr::opts_chunk$set(
 options(rmarkdown.html_vignette.check_title = FALSE)
 ```
 
-
 ## What is Polars?
 
 Polars is [a lightning fast](https://duckdblabs.github.io/db-benchmark/) Data Frame
@@ -100,7 +99,7 @@ collision with classes provided by other packages, the class name of all objects
 created by `polars` starts with "RPolars". For example, a `polars` `DataFrame`
 has the class "RPolarsDataFrame".
 
-To convert R vectors and data frames to Polars `Series` and `DataFrames`, we
+To create Polars `Series` and `DataFrames` objects, we
 load the library and use constructor functions with the `pl$` prefix. This
 prefix is very important, as most of the `polars` functions are made available
 via `pl$`:
@@ -108,13 +107,23 @@ via `pl$`:
 ```{r}
 library(polars)
 
-ser = pl$Series((1:5) * 5)
+pl$Series((1:5) * 5)
+
+pl$DataFrame(a = 1:5, b = letters[1:5])
+```
+
+Or, to convert existing R objects to Polars objects, we can use the
+`as_polars_series()` and `as_polars_df()` generic functions.
+
+```{r}
+ser = as_polars_series((1:5) * 5)
 ser
 
-dat = pl$DataFrame(mtcars)
+dat = as_polars_df(mtcars)
 dat
 ```
 
+`pl$DataFrame()` is similar to `data.frame()`, and `as_polars_df()` is similar to `as.data.frame()`.
 
 Both Polars and R are column-orientated. So you can think of `DataFrames`
 (data.frames) as being made up of a collection of `Series` (vectors). In fact,
@@ -154,12 +163,11 @@ head(dat, n = 2)
 
 Although some simple R functions work out of the box on **polars** objects, the
 full power of Polars is realized via _methods_. Polars methods are accessed
-using the `$` syntax. For example, to convert Polars `Series` and `DataFrames`
-back to standard R objects, we use the `$to_vector()` and `$to_data_frame()`
-methods:
+using the `$` syntax. For example, to sort a `Series` object, we use the
+`$sort()` method:
 
 ```{r}
-ser$to_vector()
+ser$sort()
 ```
 
 There are numerous methods designed to accomplish various tasks:
@@ -210,7 +218,8 @@ dat$tail(10)$max()
 Finally, we convert the result to a standard R data frame:
 
 ```{r}
-dat$tail(10)$max()$to_data_frame()
+dat$tail(10)$max() |>
+  as.data.frame()
 ```
 
 Below, we will introduce several other methods, including `$select`, `$filter`,
@@ -314,7 +323,7 @@ to long ("melt"). Let's switch to the `Indometh` dataset to demonstrate some
 basic examples. Note that the data are currently in long format.
 
 ```{r}
-indo = pl$DataFrame(Indometh)
+indo = as_polars_df(Indometh)
 ```
 
 To go from long to wide, we use the `pivot` method.
@@ -360,8 +369,8 @@ datasets from the **nycflights13** package.
 
 ```{r}
 data("flights", "planes", package = "nycflights13")
-flights = pl$DataFrame(flights)
-planes = pl$DataFrame(planes)
+flights = as_polars_df(flights)
+planes = as_polars_df(planes)
 
 flights$join(
   planes,
@@ -393,6 +402,12 @@ existing object in memory, we can invoke the `lazy()` constructor.
 ```{r}
 ldat = dat$lazy()
 ldat
+```
+
+Or, use the `as_polars_lf()` generic function.
+
+```{r}
+as_polars_lf(dat)
 ```
 
 Now consider what happens when we run our subsetting query from earlier on this
@@ -437,26 +452,24 @@ subset_query$collect()
 demonstrate using the `airquality` dataset that also comes bundled with base R.
 
 ```{r}
-write.csv(airquality, "airquality.csv")
+write.csv(airquality, "airquality.csv", row.names = FALSE)
 
 pl$read_csv("airquality.csv")
 ```
 
-Again, however, the package works best if we take the lazy approach. 
+Again, however, the package works best if we take the lazy approach.
 
 ```{r}
 pl$scan_csv("airquality.csv")
 ```
 
 We could obviously append a set of query operators to the above LazyFrame and
-then collect the results. However, this workflow is even better suited to 
-Parquet files, since we can leverage their efficient storage format 
+then collect the results. However, this workflow is even better suited to
+Parquet files, since we can leverage their efficient storage format
 on disk. Let's see an example.
 
 ```{r}
-library(arrow)
-
-write_parquet(airquality, "airquality.parquet")
+as_polars_df(airquality)$write_parquet("airquality.parquet")
 
 # aq = read_parquet("airquality.parquet) # eager version (okay)
 aq = pl$scan_parquet("airquality.parquet") # lazy version (better)
@@ -475,7 +488,9 @@ globbing.
 
 ```{r}
 dir.create("airquality-ds")
-write_dataset(airquality, "airquality-ds", partitioning = "Month")
+
+# Create a hive-partitioned dataset with the function from the arrow package
+arrow::write_dataset(airquality, "airquality-ds", partitioning = "Month")
 
 # Use pattern globbing to scan all parquet files in the folder
 aq2 = pl$scan_parquet("airquality-ds/**/*.parquet")
@@ -500,13 +515,14 @@ R functions are typically slower, so we recommend using native Polars functions
 and expressions wherever possible.
 
 ```{r}
-pl$DataFrame(iris)$select(
+as_polars_df(iris)$select(
   pl$col("Sepal.Length")$map_batches(\(s) { # map with a R function
     x = s$to_vector() # convert from Polars Series to a native R vector
     x[x >= 5] = 10
     x[1:10] # if return is R vector, it will automatically be converted to Polars Series again
   })
-)$to_data_frame()
+) |>
+  as.data.frame()
 ```
 
 ## Data types
@@ -526,4 +542,3 @@ they are called in R (e.g., _Boolean_ in Polars is equivalent to `logical()` in
 R). This might occasionally require you to look up a specific type. But the good
 news is that **polars** generally does a good job of inferring types
 automatically.
-


### PR DESCRIPTION
I saw a user [on SNS](https://twitter.com/LegoAnand/status/1751190842641957042) who could not figure out how to convert RPolarsDataFrame to data.frame.
I would like to emphasize that it is easy to convert between objects by actively using S3 methods.

- Use `as_polars_*` functions instead of `pl$*` function to convert base objects to polars objects.
- Use `as.data.frame` instead of `$to_data_frame()`.
- Use `<DataFrame>$write_parquet` instead of `arrow::write_parquet`.