### PR TITLE
Render vignettes even if `arrow` is absent

### DIFF
--- a/vignettes/polars.Rmd
+++ b/vignettes/polars.Rmd
@@ -489,7 +489,7 @@ aq$filter(
 Finally, we can read/scan multiple files in the same directory through pattern
 globbing.
 
-```{r}
+```{r, eval=requireNamespace("arrow", quietly = TRUE)}
 dir.create("airquality-ds")
 
 # Create a hive-partitioned dataset with the function from the arrow package


### PR DESCRIPTION
Related to #779. I tested this locally and the vignette knits correctly if `arrow` is not installed