### PR TITLE
docs: clarify argument `maintain_order`

### DIFF
--- a/R/dataframe__frame.R
+++ b/R/dataframe__frame.R
@@ -393,10 +393,9 @@ DataFrame_drop_nulls = function(subset = NULL) {
 #' * "first": Keep first unique row.
 #' * "last": Keep last unique row.
 #' * "none": Don’t keep duplicate rows.
-#' @param maintain_order Keep the same order as the original `DataFrame`. Setting
+#' @param maintain_order Keep the same order as the original data. Setting
 #'  this to `TRUE` makes it more expensive to compute and blocks the possibility
-#'  to run on the streaming engine. The default value can be changed with
-#' `options(polars.maintain_order = TRUE)`.
+#'  to run on the streaming engine.
 #'
 #' @return DataFrame
 #' @examples
@@ -616,8 +615,8 @@ DataFrame_to_series = function(idx = 0) {
 }
 
 #' Sort a DataFrame
-#' @inheritParams DataFrame_unique
 #' @inherit LazyFrame_sort details description params
+#' @inheritParams DataFrame_unique
 #' @return DataFrame
 #' @keywords  DataFrame
 #' @examples
@@ -843,7 +842,7 @@ DataFrame_filter = function(...) {
 }
 
 #' Group a DataFrame
-#' @inheritParams DataFrame_unique
+#' @inheritParams LazyFrame_group_by
 #' @inherit LazyFrame_group_by description params
 #' @keywords DataFrame
 #' @return GroupBy (a DataFrame with special groupby methods like `$agg()`)
@@ -1404,7 +1403,8 @@ DataFrame_melt = function(
 #'   - string indicating the expressions to aggregate with, such as 'first',
 #'     'sum', 'max', 'min', 'mean', 'median', 'last', 'count'),
 #'   - an Expr e.g. `pl$element()$sum()`
-#' @inheritParams DataFrame_unique
+#' @param maintain_order Sort the grouped keys so that the output order is
+#' predictable.
 #' @param sort_columns Sort the transposed columns by name. Default is by order
 #' of discovery.
 #' @param separator Used as separator/delimiter in generated column names.

--- a/R/lazyframe__lazy.R
+++ b/R/lazyframe__lazy.R
@@ -1043,15 +1043,15 @@ LazyFrame_unique = function(
 
 #' Group a LazyFrame
 #' @description This doesn't modify the data but only stores information about
-#' the group structure. This structure can then be used by several functions
-#' (`$agg()`, `$filter()`, etc.).
+#'   the group structure. This structure can then be used by several functions
+#'   (`$agg()`, `$filter()`, etc.).
 #' @keywords LazyFrame
 #' @param ... Any Expr(s) or string(s) naming a column.
-#' @param maintain_order Keep the same group order as the original `LazyFrame`.
-#' Within each group, the order of rows is always preserved, regardless of this
-#' argument. Setting this to `TRUE` makes it more expensive to compute and
-#' blocks the possibility to run on the streaming engine. The default value can
-#' be changed with `options(polars.maintain_order = TRUE)`.
+#' @param maintain_order Keep the same group order as the original data. Within
+#'   each group, the order of rows is always preserved, regardless of this
+#'   argument. Setting this to `TRUE` makes it more expensive to compute and
+#'   blocks the possibility to run on the streaming engine. The default value
+#'   can be changed with `options(polars.maintain_order = TRUE)`.
 #' @return LazyGroupBy (a LazyFrame with special groupby methods like `$agg()`)
 #' @examples
 #' pl$LazyFrame(
@@ -1172,8 +1172,9 @@ LazyFrame_join = function(
 #' either of length 1 or a logical vector of the same length as the number of
 #' Expr(s) specified in `by` and `...`.
 #' @param nulls_last Boolean. Place `NULL`s at the end? Default is `FALSE`.
-#' @inheritParams LazyFrame_group_by
-#' @inheritParams DataFrame_unique
+#' @param maintain_order Whether the order should be maintained if elements are
+#' equal. If `TRUE`, streaming is not possible and performance might be worse
+#' since this requires a stable search.
 #' @return LazyFrame
 #' @keywords  LazyFrame
 #' @examples

--- a/R/lazyframe__lazy.R
+++ b/R/lazyframe__lazy.R
@@ -1043,15 +1043,15 @@ LazyFrame_unique = function(
 
 #' Group a LazyFrame
 #' @description This doesn't modify the data but only stores information about
-#'   the group structure. This structure can then be used by several functions
-#'   (`$agg()`, `$filter()`, etc.).
+#' the group structure. This structure can then be used by several functions
+#' (`$agg()`, `$filter()`, etc.).
 #' @keywords LazyFrame
 #' @param ... Any Expr(s) or string(s) naming a column.
 #' @param maintain_order Keep the same group order as in the original data.
-#'   Within each group, the order of rows is always preserved, regardless of
-#'   this argument. Setting this to `TRUE` makes it more expensive to compute
-#'   and blocks the possibility to run on the streaming engine. The default
-#'   value can be changed with `options(polars.maintain_order = TRUE)`.
+#' Within each group, the order of rows is always preserved, regardless of
+#' this argument. Setting this to `TRUE` makes it more expensive to compute
+#' and blocks the possibility to run on the streaming engine. The default
+#' value can be changed with `options(polars.maintain_order = TRUE)`.
 #' @return LazyGroupBy (a LazyFrame with special groupby methods like `$agg()`)
 #' @examples
 #' pl$LazyFrame(

--- a/R/lazyframe__lazy.R
+++ b/R/lazyframe__lazy.R
@@ -500,6 +500,8 @@ LazyFrame_collect_in_background = function() {
 #' smaller chunks may reduce memory pressure and improve writing speeds.
 #' @param data_pagesize_limit `NULL` or Integer. If `NULL` (default), the limit
 #' will be ~1MB.
+#' @param maintain_order Maintain the order in which data is processed. Setting
+#' this to `FALSE` will be slightly faster.
 #' @inheritParams LazyFrame_group_by
 #' @inheritParams DataFrame_unique
 #' @inheritParams LazyFrame_collect
@@ -577,6 +579,7 @@ LazyFrame_sink_parquet = function(
 #' @param compression `NULL` or string, the compression method. One of `NULL`,
 #' "lz4" or "zstd". Choose "zstd" for good compression performance. Choose "lz4"
 #' for fast compression/decompression.
+#' @inheritParams LazyFrame_sink_parquet
 #' @inheritParams LazyFrame_collect
 #' @inheritParams LazyFrame_group_by
 #' @inheritParams DataFrame_unique
@@ -644,6 +647,7 @@ LazyFrame_sink_ipc = function(
 #' larger than RAM as it would crash the R session if it was collected into R.
 #'
 #' @inheritParams DataFrame_write_csv
+#' @inheritParams LazyFrame_sink_parquet
 #' @inheritParams LazyFrame_collect
 #' @inheritParams LazyFrame_group_by
 #' @inheritParams DataFrame_unique
@@ -733,6 +737,7 @@ LazyFrame_sink_csv = function(
 #' larger than RAM as it would crash the R session if it was collected into R.
 #'
 #' @inheritParams DataFrame_write_csv
+#' @inheritParams LazyFrame_sink_parquet
 #' @inheritParams LazyFrame_collect
 #' @inheritParams LazyFrame_group_by
 #' @inheritParams DataFrame_unique
@@ -1042,10 +1047,11 @@ LazyFrame_unique = function(
 #' (`$agg()`, `$filter()`, etc.).
 #' @keywords LazyFrame
 #' @param ... Any Expr(s) or string(s) naming a column.
-#' @param maintain_order Keep the same order as the original `LazyFrame`. Setting
-#'  this to `TRUE` makes it more expensive to compute and blocks the possibility
-#'  to run on the streaming engine. The default value can be changed with
-#' `options(polars.maintain_order = TRUE)`.
+#' @param maintain_order Keep the same group order as the original `LazyFrame`.
+#' Within each group, the order of rows is always preserved, regardless of this
+#' argument. Setting this to `TRUE` makes it more expensive to compute and
+#' blocks the possibility to run on the streaming engine. The default value can
+#' be changed with `options(polars.maintain_order = TRUE)`.
 #' @return LazyGroupBy (a LazyFrame with special groupby methods like `$agg()`)
 #' @examples
 #' pl$LazyFrame(

--- a/R/lazyframe__lazy.R
+++ b/R/lazyframe__lazy.R
@@ -1047,11 +1047,11 @@ LazyFrame_unique = function(
 #'   (`$agg()`, `$filter()`, etc.).
 #' @keywords LazyFrame
 #' @param ... Any Expr(s) or string(s) naming a column.
-#' @param maintain_order Keep the same group order as the original data. Within
-#'   each group, the order of rows is always preserved, regardless of this
-#'   argument. Setting this to `TRUE` makes it more expensive to compute and
-#'   blocks the possibility to run on the streaming engine. The default value
-#'   can be changed with `options(polars.maintain_order = TRUE)`.
+#' @param maintain_order Keep the same group order as in the original data.
+#'   Within each group, the order of rows is always preserved, regardless of
+#'   this argument. Setting this to `TRUE` makes it more expensive to compute
+#'   and blocks the possibility to run on the streaming engine. The default
+#'   value can be changed with `options(polars.maintain_order = TRUE)`.
 #' @return LazyGroupBy (a LazyFrame with special groupby methods like `$agg()`)
 #' @examples
 #' pl$LazyFrame(

--- a/R/polars_options.R
+++ b/R/polars_options.R
@@ -26,8 +26,7 @@
 #'   This option should be set before the package is loaded.
 #' * `maintain_order` (`FALSE`): Default for the `maintain_order` argument in
 #'   [`<LazyFrame>$group_by()`][LazyFrame_group_by] and
-#'   [`<DataFrame>$group_by()`][DataFrame_group_by]
-#'   (present in `$group_by()` or `$unique()` for example).
+#'   [`<DataFrame>$group_by()`][DataFrame_group_by].
 #' * `no_messages` (`FALSE`): Hide messages.
 #' * `rpool_cap`: The maximum number of R sessions that can be used to process
 #'   R code in the background. See the section "About pool options" below.

--- a/R/polars_options.R
+++ b/R/polars_options.R
@@ -24,7 +24,9 @@
 #' * `limit_max_threads` ([`!polars_info()$features$disable_limit_max_threads`][polars_info]):
 #'   See [`?pl_thread_pool_size`][pl_thread_pool_size] for details.
 #'   This option should be set before the package is loaded.
-#' * `maintain_order` (`FALSE`): Default for all `maintain_order` options
+#' * `maintain_order` (`FALSE`): Default for the `maintain_order` argument in
+#'   [`<LazyFrame>$group_by()`][LazyFrame_group_by] and
+#'   [`<DataFrame>$group_by()`][DataFrame_group_by]
 #'   (present in `$group_by()` or `$unique()` for example).
 #' * `no_messages` (`FALSE`): Hide messages.
 #' * `rpool_cap`: The maximum number of R sessions that can be used to process

--- a/man/DataFrame_group_by.Rd
+++ b/man/DataFrame_group_by.Rd
@@ -9,10 +9,11 @@ DataFrame_group_by(..., maintain_order = polars_options()$maintain_order)
 \arguments{
 \item{...}{Any Expr(s) or string(s) naming a column.}
 
-\item{maintain_order}{Keep the same order as the original \code{DataFrame}. Setting
-this to \code{TRUE} makes it more expensive to compute and blocks the possibility
-to run on the streaming engine. The default value can be changed with
-\code{options(polars.maintain_order = TRUE)}.}
+\item{maintain_order}{Keep the same group order as the original data. Within
+each group, the order of rows is always preserved, regardless of this
+argument. Setting this to \code{TRUE} makes it more expensive to compute and
+blocks the possibility to run on the streaming engine. The default value
+can be changed with \code{options(polars.maintain_order = TRUE)}.}
 }
 \value{
 GroupBy (a DataFrame with special groupby methods like \verb{$agg()})

--- a/man/DataFrame_group_by.Rd
+++ b/man/DataFrame_group_by.Rd
@@ -9,11 +9,11 @@ DataFrame_group_by(..., maintain_order = polars_options()$maintain_order)
 \arguments{
 \item{...}{Any Expr(s) or string(s) naming a column.}
 
-\item{maintain_order}{Keep the same group order as the original data. Within
-each group, the order of rows is always preserved, regardless of this
-argument. Setting this to \code{TRUE} makes it more expensive to compute and
-blocks the possibility to run on the streaming engine. The default value
-can be changed with \code{options(polars.maintain_order = TRUE)}.}
+\item{maintain_order}{Keep the same group order as in the original data.
+Within each group, the order of rows is always preserved, regardless of
+this argument. Setting this to \code{TRUE} makes it more expensive to compute
+and blocks the possibility to run on the streaming engine. The default
+value can be changed with \code{options(polars.maintain_order = TRUE)}.}
 }
 \value{
 GroupBy (a DataFrame with special groupby methods like \verb{$agg()})

--- a/man/DataFrame_pivot.Rd
+++ b/man/DataFrame_pivot.Rd
@@ -30,10 +30,8 @@ of the output DataFrame.}
 \item an Expr e.g. \code{pl$element()$sum()}
 }}
 
-\item{maintain_order}{Keep the same order as the original \code{DataFrame}. Setting
-this to \code{TRUE} makes it more expensive to compute and blocks the possibility
-to run on the streaming engine. The default value can be changed with
-\code{options(polars.maintain_order = TRUE)}.}
+\item{maintain_order}{Sort the grouped keys so that the output order is
+predictable.}
 
 \item{sort_columns}{Sort the transposed columns by name. Default is by order
 of discovery.}

--- a/man/DataFrame_sort.Rd
+++ b/man/DataFrame_sort.Rd
@@ -24,10 +24,9 @@ Expr(s) specified in \code{by} and \code{...}.}
 
 \item{nulls_last}{Boolean. Place \code{NULL}s at the end? Default is \code{FALSE}.}
 
-\item{maintain_order}{Keep the same order as the original \code{DataFrame}. Setting
-this to \code{TRUE} makes it more expensive to compute and blocks the possibility
-to run on the streaming engine. The default value can be changed with
-\code{options(polars.maintain_order = TRUE)}.}
+\item{maintain_order}{Whether the order should be maintained if elements are
+equal. If \code{TRUE}, streaming is not possible and performance might be worse
+since this requires a stable search.}
 }
 \value{
 DataFrame

--- a/man/DataFrame_unique.Rd
+++ b/man/DataFrame_unique.Rd
@@ -21,10 +21,9 @@ identify duplicates. If \code{NULL} (default), use all columns.}
 \item "none": Don’t keep duplicate rows.
 }}
 
-\item{maintain_order}{Keep the same order as the original \code{DataFrame}. Setting
+\item{maintain_order}{Keep the same order as the original data. Setting
 this to \code{TRUE} makes it more expensive to compute and blocks the possibility
-to run on the streaming engine. The default value can be changed with
-\code{options(polars.maintain_order = TRUE)}.}
+to run on the streaming engine.}
 }
 \value{
 DataFrame

--- a/man/IO_sink_csv.Rd
+++ b/man/IO_sink_csv.Rd
@@ -76,10 +76,8 @@ then quotes will be used even if they aren`t strictly necessary.
 invalid CSV data (e.g. by not quoting strings containing the separator).
 }}
 
-\item{maintain_order}{Keep the same order as the original \code{LazyFrame}. Setting
-this to \code{TRUE} makes it more expensive to compute and blocks the possibility
-to run on the streaming engine. The default value can be changed with
-\code{options(polars.maintain_order = TRUE)}.}
+\item{maintain_order}{Maintain the order in which data is processed. Setting
+this to \code{FALSE} will be slightly faster.}
 
 \item{type_coercion}{Boolean. Coerce types such that operations succeed and
 run on minimal required memory.}

--- a/man/IO_sink_ipc.Rd
+++ b/man/IO_sink_ipc.Rd
@@ -24,10 +24,8 @@ LazyFrame_sink_ipc(
 "lz4" or "zstd". Choose "zstd" for good compression performance. Choose "lz4"
 for fast compression/decompression.}
 
-\item{maintain_order}{Keep the same order as the original \code{LazyFrame}. Setting
-this to \code{TRUE} makes it more expensive to compute and blocks the possibility
-to run on the streaming engine. The default value can be changed with
-\code{options(polars.maintain_order = TRUE)}.}
+\item{maintain_order}{Maintain the order in which data is processed. Setting
+this to \code{FALSE} will be slightly faster.}
 
 \item{type_coercion}{Boolean. Coerce types such that operations succeed and
 run on minimal required memory.}

--- a/man/IO_sink_ndjson.Rd
+++ b/man/IO_sink_ndjson.Rd
@@ -19,10 +19,8 @@ LazyFrame_sink_ndjson(
 \arguments{
 \item{path}{File path to which the result should be written.}
 
-\item{maintain_order}{Keep the same order as the original \code{LazyFrame}. Setting
-this to \code{TRUE} makes it more expensive to compute and blocks the possibility
-to run on the streaming engine. The default value can be changed with
-\code{options(polars.maintain_order = TRUE)}.}
+\item{maintain_order}{Maintain the order in which data is processed. Setting
+this to \code{FALSE} will be slightly faster.}
 
 \item{type_coercion}{Boolean. Coerce types such that operations succeed and
 run on minimal required memory.}

--- a/man/IO_sink_parquet.Rd
+++ b/man/IO_sink_parquet.Rd
@@ -55,10 +55,8 @@ smaller chunks may reduce memory pressure and improve writing speeds.}
 \item{data_pagesize_limit}{\code{NULL} or Integer. If \code{NULL} (default), the limit
 will be ~1MB.}
 
-\item{maintain_order}{Keep the same order as the original \code{LazyFrame}. Setting
-this to \code{TRUE} makes it more expensive to compute and blocks the possibility
-to run on the streaming engine. The default value can be changed with
-\code{options(polars.maintain_order = TRUE)}.}
+\item{maintain_order}{Maintain the order in which data is processed. Setting
+this to \code{FALSE} will be slightly faster.}
 
 \item{type_coercion}{Boolean. Coerce types such that operations succeed and
 run on minimal required memory.}

--- a/man/LazyFrame_group_by.Rd
+++ b/man/LazyFrame_group_by.Rd
@@ -9,11 +9,11 @@ LazyFrame_group_by(..., maintain_order = polars_options()$maintain_order)
 \arguments{
 \item{...}{Any Expr(s) or string(s) naming a column.}
 
-\item{maintain_order}{Keep the same group order as the original data. Within
-each group, the order of rows is always preserved, regardless of this
-argument. Setting this to \code{TRUE} makes it more expensive to compute and
-blocks the possibility to run on the streaming engine. The default value
-can be changed with \code{options(polars.maintain_order = TRUE)}.}
+\item{maintain_order}{Keep the same group order as in the original data.
+Within each group, the order of rows is always preserved, regardless of
+this argument. Setting this to \code{TRUE} makes it more expensive to compute
+and blocks the possibility to run on the streaming engine. The default
+value can be changed with \code{options(polars.maintain_order = TRUE)}.}
 }
 \value{
 LazyGroupBy (a LazyFrame with special groupby methods like \verb{$agg()})

--- a/man/LazyFrame_group_by.Rd
+++ b/man/LazyFrame_group_by.Rd
@@ -9,11 +9,11 @@ LazyFrame_group_by(..., maintain_order = polars_options()$maintain_order)
 \arguments{
 \item{...}{Any Expr(s) or string(s) naming a column.}
 
-\item{maintain_order}{Keep the same group order as the original \code{LazyFrame}.
-Within each group, the order of rows is always preserved, regardless of this
+\item{maintain_order}{Keep the same group order as the original data. Within
+each group, the order of rows is always preserved, regardless of this
 argument. Setting this to \code{TRUE} makes it more expensive to compute and
-blocks the possibility to run on the streaming engine. The default value can
-be changed with \code{options(polars.maintain_order = TRUE)}.}
+blocks the possibility to run on the streaming engine. The default value
+can be changed with \code{options(polars.maintain_order = TRUE)}.}
 }
 \value{
 LazyGroupBy (a LazyFrame with special groupby methods like \verb{$agg()})

--- a/man/LazyFrame_group_by.Rd
+++ b/man/LazyFrame_group_by.Rd
@@ -9,10 +9,11 @@ LazyFrame_group_by(..., maintain_order = polars_options()$maintain_order)
 \arguments{
 \item{...}{Any Expr(s) or string(s) naming a column.}
 
-\item{maintain_order}{Keep the same order as the original \code{LazyFrame}. Setting
-this to \code{TRUE} makes it more expensive to compute and blocks the possibility
-to run on the streaming engine. The default value can be changed with
-\code{options(polars.maintain_order = TRUE)}.}
+\item{maintain_order}{Keep the same group order as the original \code{LazyFrame}.
+Within each group, the order of rows is always preserved, regardless of this
+argument. Setting this to \code{TRUE} makes it more expensive to compute and
+blocks the possibility to run on the streaming engine. The default value can
+be changed with \code{options(polars.maintain_order = TRUE)}.}
 }
 \value{
 LazyGroupBy (a LazyFrame with special groupby methods like \verb{$agg()})

--- a/man/LazyFrame_sort.Rd
+++ b/man/LazyFrame_sort.Rd
@@ -24,10 +24,11 @@ Expr(s) specified in \code{by} and \code{...}.}
 
 \item{nulls_last}{Boolean. Place \code{NULL}s at the end? Default is \code{FALSE}.}
 
-\item{maintain_order}{Keep the same order as the original \code{LazyFrame}. Setting
-this to \code{TRUE} makes it more expensive to compute and blocks the possibility
-to run on the streaming engine. The default value can be changed with
-\code{options(polars.maintain_order = TRUE)}.}
+\item{maintain_order}{Keep the same group order as the original \code{LazyFrame}.
+Within each group, the order of rows is always preserved, regardless of this
+argument. Setting this to \code{TRUE} makes it more expensive to compute and
+blocks the possibility to run on the streaming engine. The default value can
+be changed with \code{options(polars.maintain_order = TRUE)}.}
 }
 \value{
 LazyFrame

--- a/man/LazyFrame_sort.Rd
+++ b/man/LazyFrame_sort.Rd
@@ -24,11 +24,9 @@ Expr(s) specified in \code{by} and \code{...}.}
 
 \item{nulls_last}{Boolean. Place \code{NULL}s at the end? Default is \code{FALSE}.}
 
-\item{maintain_order}{Keep the same group order as the original \code{LazyFrame}.
-Within each group, the order of rows is always preserved, regardless of this
-argument. Setting this to \code{TRUE} makes it more expensive to compute and
-blocks the possibility to run on the streaming engine. The default value can
-be changed with \code{options(polars.maintain_order = TRUE)}.}
+\item{maintain_order}{Whether the order should be maintained if elements are
+equal. If \code{TRUE}, streaming is not possible and performance might be worse
+since this requires a stable search.}
 }
 \value{
 LazyFrame

--- a/man/LazyFrame_unique.Rd
+++ b/man/LazyFrame_unique.Rd
@@ -21,10 +21,9 @@ identify duplicates. If \code{NULL} (default), use all columns.}
 \item "none": Don’t keep duplicate rows.
 }}
 
-\item{maintain_order}{Keep the same order as the original \code{DataFrame}. Setting
+\item{maintain_order}{Keep the same order as the original data. Setting
 this to \code{TRUE} makes it more expensive to compute and blocks the possibility
-to run on the streaming engine. The default value can be changed with
-\code{options(polars.maintain_order = TRUE)}.}
+to run on the streaming engine.}
 }
 \value{
 LazyFrame

--- a/man/polars_options.Rd
+++ b/man/polars_options.Rd
@@ -43,7 +43,9 @@ the package \code{bit64} to be attached).
 \item \code{limit_max_threads} (\code{\link[=polars_info]{!polars_info()$features$disable_limit_max_threads}}):
 See \code{\link[=pl_thread_pool_size]{?pl_thread_pool_size}} for details.
 This option should be set before the package is loaded.
-\item \code{maintain_order} (\code{FALSE}): Default for all \code{maintain_order} options
+\item \code{maintain_order} (\code{FALSE}): Default for the \code{maintain_order} argument in
+\code{\link[=LazyFrame_group_by]{<LazyFrame>$group_by()}} and
+\code{\link[=DataFrame_group_by]{<DataFrame>$group_by()}}
 (present in \verb{$group_by()} or \verb{$unique()} for example).
 \item \code{no_messages} (\code{FALSE}): Hide messages.
 \item \code{rpool_cap}: The maximum number of R sessions that can be used to process

--- a/man/polars_options.Rd
+++ b/man/polars_options.Rd
@@ -45,8 +45,7 @@ See \code{\link[=pl_thread_pool_size]{?pl_thread_pool_size}} for details.
 This option should be set before the package is loaded.
 \item \code{maintain_order} (\code{FALSE}): Default for the \code{maintain_order} argument in
 \code{\link[=LazyFrame_group_by]{<LazyFrame>$group_by()}} and
-\code{\link[=DataFrame_group_by]{<DataFrame>$group_by()}}
-(present in \verb{$group_by()} or \verb{$unique()} for example).
+\code{\link[=DataFrame_group_by]{<DataFrame>$group_by()}}.
 \item \code{no_messages} (\code{FALSE}): Hide messages.
 \item \code{rpool_cap}: The maximum number of R sessions that can be used to process
 R code in the background. See the section "About pool options" below.


### PR DESCRIPTION
* For `group_by`, clarify that `maintain_order` only influences the order of groups, not the order of rows in each group
* Use a different definition for each type of function. `maintain_order` doesn't mean the same thing for `sink_*()` and for `unique()` for example
* Clarify that `polars_options()$maintain_order` only affects the value of `maintain_order` in `group_by` functions. We can discuss if this should be extended to all `maintain_order` args, but that's how it has been in the code so far.

Easier to review by looking at the content of the Rd files.