### PR TITLE
refactor!: feature flags reorganizization

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,8 @@
 
 ### Other breaking changes
 
+-   The `simd` feature of the Rust library is removed in favor of
+    the new `nightly` feature (#800).
 -   The following functions were deprecated in 0.13.0 and are now removed (#783):
     -   `$list$lengths()` -> `$list$len()`
     -   `pl$from_arrow()` -> `as_polars_df()` or `as_polars_series()`
@@ -50,6 +52,10 @@
 
 -   `pl$threadpool_size()` is deprecated and will be removed in 0.15.0. Use
     `pl$thread_pool_size()` instead (#784).
+
+### Other improvements
+
+-   The `sql` feature is included in the default feature (#800).
 
 ## Polars R Package 0.13.1
 

--- a/R/expr__array.R
+++ b/R/expr__array.R
@@ -16,19 +16,16 @@ ExprArr_sum = function() .pr$Expr$arr_sum(self)
 #' Find the maximum value in an array
 #'
 #' @return Expr
-#' @details
-#' This method is only available with the "simd" feature.
-#' See [polars_info] for more details.
+#' @inherit ExprStr_to_titlecase details
 #' @aliases arr_max
-#' @examplesIf polars_info()$features$simd
+#' @examplesIf polars_info()$features$nightly
 #' df = pl$DataFrame(
 #'   values = list(c(1, 2), c(3, 4), c(5, 6)),
 #'   schema = list(values = pl$Array(pl$Float64, 2))
 #' )
 #' df$with_columns(max = pl$col("values")$arr$max())
 ExprArr_max = function() {
-  # TODO: not to check simd here
-  check_feature("simd", "in $arr$max():")
+  check_feature("nightly", "in $arr$max():")
 
   .pr$Expr$arr_max(self)
 }
@@ -38,18 +35,17 @@ ExprArr_max = function() {
 
 #' Find the minimum value in an array
 #'
-#' @inherit ExprArr_max details
+#' @inherit ExprStr_to_titlecase details
 #' @return Expr
 #' @aliases arr_min
-#' @examplesIf polars_info()$features$simd
+#' @examplesIf polars_info()$features$nightly
 #' df = pl$DataFrame(
 #'   values = list(c(1, 2), c(3, 4), c(5, 6)),
 #'   schema = list(values = pl$Array(pl$Float64, 2))
 #' )
 #' df$with_columns(min = pl$col("values")$arr$min())
 ExprArr_min = function() {
-  # TODO: not to check simd here
-  check_feature("simd", "in $arr$min():")
+  check_feature("nightly", "in $arr$min():")
 
   .pr$Expr$arr_min(self)
 }

--- a/R/expr__string.R
+++ b/R/expr__string.R
@@ -266,12 +266,12 @@ ExprStr_to_lowercase = function() {
 #' @keywords ExprStr
 #' @return Expr of String titlecase chars
 #' @details
-#' This method is only available with the "simd" feature.
-#' See [polars_info] for more details.
-#' @examplesIf polars_info()$features$simd
+#' This method is only available with the "nightly" feature.
+#' See [polars_info()] for more details.
+#' @examplesIf polars_info()$features$nightly
 #' pl$lit(c("hello there", "HI, THERE", NA))$str$to_titlecase()$to_series()
 ExprStr_to_titlecase = function() {
-  check_feature("simd", "in $to_titlecase():")
+  check_feature("nightly", "in $to_titlecase():")
 
   .pr$Expr$str_to_titlecase(self) |>
     unwrap("in $to_titlecase():")

--- a/R/polars_info.R
+++ b/R/polars_info.R
@@ -11,7 +11,7 @@
 #'
 #' polars_info()$rust_polars
 #'
-#' polars_info()$features$simd
+#' polars_info()$features$nightly
 polars_info = function() {
   # Similar to arrow::arrow_info()
   out = list(
@@ -58,7 +58,7 @@ print.polars_info = function(x, ...) {
 #' @return TRUE invisibly if the feature is enabled
 #' @examples
 #' tryCatch(
-#'   check_feature("simd", "in example"),
+#'   check_feature("nightly", "in example"),
 #'   error = \(e) cat(as.character(e))
 #' )
 #' tryCatch(

--- a/man/ExprArr_max.Rd
+++ b/man/ExprArr_max.Rd
@@ -14,11 +14,11 @@ Expr
 Find the maximum value in an array
 }
 \details{
-This method is only available with the "simd" feature.
-See \link{polars_info} for more details.
+This method is only available with the "nightly" feature.
+See \code{\link[=polars_info]{polars_info()}} for more details.
 }
 \examples{
-\dontshow{if (polars_info()$features$simd) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (polars_info()$features$nightly) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 df = pl$DataFrame(
   values = list(c(1, 2), c(3, 4), c(5, 6)),
   schema = list(values = pl$Array(pl$Float64, 2))

--- a/man/ExprArr_min.Rd
+++ b/man/ExprArr_min.Rd
@@ -14,11 +14,11 @@ Expr
 Find the minimum value in an array
 }
 \details{
-This method is only available with the "simd" feature.
-See \link{polars_info} for more details.
+This method is only available with the "nightly" feature.
+See \code{\link[=polars_info]{polars_info()}} for more details.
 }
 \examples{
-\dontshow{if (polars_info()$features$simd) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (polars_info()$features$nightly) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 df = pl$DataFrame(
   values = list(c(1, 2), c(3, 4), c(5, 6)),
   schema = list(values = pl$Array(pl$Float64, 2))

--- a/man/ExprStr_to_titlecase.Rd
+++ b/man/ExprStr_to_titlecase.Rd
@@ -13,11 +13,11 @@ Expr of String titlecase chars
 Transform to titlecase variant.
 }
 \details{
-This method is only available with the "simd" feature.
-See \link{polars_info} for more details.
+This method is only available with the "nightly" feature.
+See \code{\link[=polars_info]{polars_info()}} for more details.
 }
 \examples{
-\dontshow{if (polars_info()$features$simd) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (polars_info()$features$nightly) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 pl$lit(c("hello there", "HI, THERE", NA))$str$to_titlecase()$to_series()
 \dontshow{\}) # examplesIf}
 }

--- a/man/polars_info.Rd
+++ b/man/polars_info.Rd
@@ -22,5 +22,5 @@ polars_info()
 
 polars_info()$rust_polars
 
-polars_info()$features$simd
+polars_info()$features$nightly
 }

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -10,12 +10,11 @@ crate-type = ['staticlib']
 
 [features]
 default = ["sql"]
-full_features = ["nightly", "sql", "disable_limit_max_threads"]
+full_features = ["default", "nightly", "disable_limit_max_threads"]
 disable_limit_max_threads = []
+sql = ["polars/sql"]
 # also includes simd, requires nightly
 nightly = ["polars/nightly"]
-# requires nightly
-sql = ["polars/sql"]
 
 rpolars_debug_print = []
 

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -10,10 +10,13 @@ crate-type = ['staticlib']
 
 [features]
 default = []
-full_features = ["simd", "sql", "disable_limit_max_threads"]
+full_features = ["nightly", "sql", "disable_limit_max_threads"]
 disable_limit_max_threads = []
-simd = ["polars/simd"]
+# also includes simd, requires nightly
+nightly = ["polars/nightly"]
+# requires nightly
 sql = ["polars/sql"]
+
 rpolars_debug_print = []
 
 [workspace]

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 crate-type = ['staticlib']
 
 [features]
-default = []
+default = ["sql"]
 full_features = ["nightly", "sql", "disable_limit_max_threads"]
 disable_limit_max_threads = []
 # also includes simd, requires nightly

--- a/src/rust/src/info.rs
+++ b/src/rust/src/info.rs
@@ -5,12 +5,11 @@ use polars;
 fn cargo_rpolars_feature_info() -> List {
     list!(
         default = cfg!(feature = "default"),
-        // `full_features` is a combination of `simd` and `sql` features
-        full_features = cfg!(feature = "simd")
+        full_features = cfg!(feature = "nightly")
             & cfg!(feature = "sql")
             & cfg!(feature = "disable_limit_max_threads"),
         disable_limit_max_threads = cfg!(feature = "disable_limit_max_threads"),
-        simd = cfg!(feature = "simd"),
+        nightly = cfg!(feature = "nightly"),
         sql = cfg!(feature = "sql"),
         rpolars_debug_print = cfg!(feature = "rpolars_debug_print"),
     )

--- a/src/rust/src/lazy/dsl.rs
+++ b/src/rust/src/lazy/dsl.rs
@@ -2573,16 +2573,16 @@ impl RPolarsExpr {
     }
 }
 
-// handle varition in implementation if not simd
+// handle varition in implementation if not the nightly feature
 // could not get cfg feature flags conditions to work inside extendr macro
 // Therefore place it outside here instead
 #[allow(unused)]
 fn f_str_to_titlecase(expr: &RPolarsExpr) -> RResult<RPolarsExpr> {
-    #[cfg(feature = "simd")]
+    #[cfg(feature = "nightly")]
     return (Ok(expr.0.clone().str().to_titlecase().into()));
 
-    #[cfg(not(feature = "simd"))]
-    rerr().plain("$to_titlecase() is only available with the 'simd' feature")
+    #[cfg(not(feature = "nightly"))]
+    rerr().plain("$to_titlecase() is only available with the 'nightly' feature")
 }
 
 //allow proto expression that yet only are strings

--- a/tests/testthat/_snaps/polars_info.md
+++ b/tests/testthat/_snaps/polars_info.md
@@ -12,7 +12,7 @@
       default                   FALSE
       full_features             FALSE
       disable_limit_max_threads FALSE
-      simd                      FALSE
+      nightly                   FALSE
       sql                       FALSE
       rpolars_debug_print       FALSE
       

--- a/tests/testthat/test-expr_array.R
+++ b/tests/testthat/test-expr_array.R
@@ -18,8 +18,7 @@ test_that("arr$sum", {
 })
 
 test_that("arr$max and arr$min", {
-  # TODO: not to check simd here
-  skip_if_not(polars_info()$features$simd)
+  skip_if_not(polars_info()$features$nightly)
 
   df = pl$DataFrame(
     ints = list(1:2, c(1L, NA_integer_), c(NA_integer_, NA_integer_)),
@@ -50,9 +49,8 @@ test_that("arr$max and arr$min", {
   )
 })
 
-test_that("arr$max and arr$min error if the simd feature is false", {
-  # TODO: not to check simd here
-  skip_if(polars_info()$features$simd)
+test_that("arr$max and arr$min error if the nightly feature is false", {
+  skip_if(polars_info()$features$nightly)
 
   df = pl$DataFrame(
     ints = list(1:2, c(1L, NA_integer_), c(NA_integer_, NA_integer_)),

--- a/tests/testthat/test-expr_string.R
+++ b/tests/testthat/test-expr_string.R
@@ -184,8 +184,8 @@ test_that("to_uppercase, to_lowercase", {
   )
 })
 
-test_that("to_titlecase - enabled via the simd feature", {
-  skip_if_not(polars_info()$features$simd)
+test_that("to_titlecase - enabled via the nightly feature", {
+  skip_if_not(polars_info()$features$nightly)
   df2 = pl$DataFrame(foo = c("hi there", "HI, THERE", NA))
   expect_identical(
     df2$select(pl$col("foo")$str$to_titlecase())$to_list()$foo,
@@ -193,8 +193,8 @@ test_that("to_titlecase - enabled via the simd feature", {
   )
 })
 
-test_that("to_titlecase - enabled via the simd feature", {
-  skip_if(polars_info()$features$simd)
+test_that("to_titlecase - enabled via the nightly feature", {
+  skip_if(polars_info()$features$nightly)
   expect_error(pl$col("foo")$str$to_titlecase())
 })
 

--- a/vignettes/install.Rmd
+++ b/vignettes/install.Rmd
@@ -142,7 +142,6 @@ Currently `full_features` would work as a combination of the following features.
     See `?pl_thread_pool_size` for details.
 - Features for nightly toolchain
   - `nightly` for nightly toolchain features and SIMD.
-  - `sql` for enable `pl$SQLContext()`.
 
 Note that nightly features requires the Rust nightly toolchain `r rust_toolchain_version`.
 

--- a/vignettes/install.Rmd
+++ b/vignettes/install.Rmd
@@ -141,7 +141,7 @@ Currently `full_features` would work as a combination of the following features.
     and the maximum number of threads is used by default.
     See `?pl_thread_pool_size` for details.
 - Features for nightly toolchain
-  - `simd` for SIMD support.
+  - `nightly` for nightly toolchain features and SIMD.
   - `sql` for enable `pl$SQLContext()`.
 
 Note that nightly features requires the Rust nightly toolchain `r rust_toolchain_version`.

--- a/vignettes/install.Rmd
+++ b/vignettes/install.Rmd
@@ -136,6 +136,8 @@ For example, to enable the `full_features` feature, set the environment variable
 
 Currently `full_features` would work as a combination of the following features.
 
+- The `default` feature
+  - `sql` for enable `pl$SQLContext()`.
 - Features for CRAN compatibility
   - `disable_limit_max_threads`, this feature disables the automatic limit of the maximum number of threads to 2 for CRAN compatibility,
     and the maximum number of threads is used by default.


### PR DESCRIPTION
Close #300

Match with py-polars.

- `polars/nightly` includes `polars/simd`, and py-polars does not specify `polars/simd` directly but includes `polras/nightly` in the `nightly` feature.
- The `default` feature includes the `sql` feature (because `sql` no longer requires nightly toolchain).