### PR TITLE
ci: migrate to actions/upload-artifact@v4 and actions/download-artifact@v4

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -125,9 +125,9 @@ jobs:
 
       - name: upload artifact
         if: matrix.config.full-features
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: libs
+          name: checked-lib-${{ steps.rust-target.outputs.TARGET }}
           path: ${{ env.LIBR_POLARS_PATH }}
 
   source-with-bin-check:

--- a/.github/workflows/release-lib.yaml
+++ b/.github/workflows/release-lib.yaml
@@ -92,9 +92,9 @@ jobs:
           echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >>"$GITHUB_ENV"
 
       - name: upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: libs
+          name: libs-${{ matrix.target }}
           path: ${{ env.ARTIFACT_NAME }}
 
   test:

--- a/.github/workflows/release-lib.yaml
+++ b/.github/workflows/release-lib.yaml
@@ -128,11 +128,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v3
-        with:
-          name: libs
-          path: libs
-
       - name: prep Rust
         working-directory: src/rust
         run: |
@@ -144,6 +139,11 @@ jobs:
             echo "LIB_TARGET=$(rustc -vV | grep host | cut -d' ' -f2)" >>"$GITHUB_ENV"
           fi
           rm "$(rustup which cargo)"
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: libs-${{ env.LIB_TARGET }}
+          path: libs
 
       - name: prep lib
         run: |
@@ -186,10 +186,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: libs
           path: libs
+          pattern: libs-*
+          merge-multiple: true
 
       - name: create checksums
         working-directory: libs

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -96,7 +96,6 @@ jobs:
           mv ../polars* ./
 
       - name: Upload produced R packages
-        if: runner.os != 'Windows'
         uses: actions/upload-artifact@v4
         with:
           name: package-${{ matrix.config.os }}-${{ matrix.config.r }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
   build:
     runs-on: ${{ matrix.config.os }}
 
-    name: ${{ matrix.config.os }} (${{ matrix.config.r }}) - ${{ matrix.config.target }}
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
 
     permissions:
       contents: write
@@ -96,8 +96,10 @@ jobs:
           mv ../polars* ./
 
       - name: Upload produced R packages
-        uses: actions/upload-artifact@v3
+        if: runner.os != 'Windows'
+        uses: actions/upload-artifact@v4
         with:
+          name: package-${{ matrix.config.os }}-${{ matrix.config.r }}
           path: |
             polars_*
             polars.zip


### PR DESCRIPTION
Artifacts with the same name are no longer allowed and must use unique names.