### PR TITLE
ci: make dependabot to check local action and devcontainer config file

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,9 +7,21 @@ updates:
     commit-message:
       prefix: "ci: "
 
+  - package-ecosystem: "github-actions"
+    directory: ".github/actions/setup/action.yaml"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "ci: "
+
   - package-ecosystem: "cargo"
     directory: "/src/rust"
     schedule:
       interval: "daily"
     commit-message:
       prefix: "chore: "
+
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: daily


### PR DESCRIPTION
I did not know that additional configuration was required to have GitHub Actions check local actions.

> Dependabot will ignore actions or reusable workflows referenced locally (for example, `./.github/actions/foo.yml)`.

https://docs.github.com/ja/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#github-actions

Also add settings for updating devcontainer.json.