### PR TITLE
refactor: rewrite `as_polars_df.data.frame`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
     each column. The output of `$flags` for `Series` was also improved and now
     contains `FAST_EXPLODE` for `Series` of type `list` and `array` (#809).
 -   Add string methods `to_lowercase()` and `to_uppercase()` for `Series` (#810).
+-   `as_polars_df()` for `data.frame` is completely rewritten and new arguments
+    `schema` and `schema_overrides` are added (#817).
 
 ## Polars R Package 0.14.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
     each column. The output of `$flags` for `Series` was also improved and now
     contains `FAST_EXPLODE` for `Series` of type `list` and `array` (#809).
 -   Add string methods `to_lowercase()` and `to_uppercase()` for `Series` (#810).
--   `as_polars_df()` for `data.frame` is completely rewritten and new arguments
+-   `as_polars_df()` for `data.frame` is more memory-efficient and new arguments
     `schema` and `schema_overrides` are added (#817).
 
 ## Polars R Package 0.14.0

--- a/R/as_polars.R
+++ b/R/as_polars.R
@@ -197,7 +197,7 @@ as_polars_df.ArrowTabular = function(
     rechunk = TRUE,
     schema = NULL,
     schema_overrides = NULL) {
-  arrow_to_rdf(
+  arrow_to_rpldf(
     x,
     rechunk = rechunk,
     schema = schema,

--- a/R/as_polars.R
+++ b/R/as_polars.R
@@ -1,9 +1,7 @@
 #' To polars DataFrame
 #'
 #' [as_polars_df()] is a generic function that converts an R object to a
-#' polars DataFrame. It is basically a wrapper for [pl$DataFrame()][pl_DataFrame],
-#' but has special implementations for Apache Arrow-based objects such as
-#' polars [LazyFrame][LazyFrame_class] and [arrow::Table].
+#' [polars DataFrame][DataFrame_class].
 #'
 #' For [LazyFrame][LazyFrame_class] objects, this function is a shortcut for
 #' [$collect()][LazyFrame_collect] or [$fetch()][LazyFrame_fetch], depending on

--- a/R/as_polars.R
+++ b/R/as_polars.R
@@ -74,25 +74,26 @@ as_polars_df.data.frame = function(
     make_names_unique = TRUE,
     schema = NULL,
     schema_overrides = NULL) {
+  uw = \(res) unwrap(res, "in as_polars_df():")
+
   if (anyDuplicated(names(x)) > 0) {
     col_names_orig = names(x)
     if (make_names_unique) {
       names(x) = make.unique(col_names_orig, sep = "_")
     } else {
-      stop(
+      Err_plain(
         paste(
           "conflicting column names not allowed:",
           paste(unique(col_names_orig[duplicated(col_names_orig)]), collapse = ", ")
         )
-      )
+      ) |>
+        uw()
     }
   }
 
   if (is.null(rownames)) {
     df_to_rpldf(x, schema = schema, schema_overrides = schema_overrides)
   } else {
-    uw = \(res) unwrap(res, "in as_polars_df():")
-
     if (length(rownames) != 1L || !is.character(rownames) || is.na(rownames)) {
       Err_plain("`rownames` must be a single string, or `NULL`") |>
         uw()

--- a/R/construction.R
+++ b/R/construction.R
@@ -11,7 +11,7 @@
 #' @param schema_overrides named list of DataTypes. Cast some columns to the DataType.
 #' @noRd
 #' @return RPolarsDataFrame
-arrow_to_rdf = function(at, schema = NULL, schema_overrides = NULL, rechunk = TRUE) {
+arrow_to_rpldf = function(at, schema = NULL, schema_overrides = NULL, rechunk = TRUE) {
   # new column names by schema, #todo get names if schema not NULL
   n_cols = at$num_columns
 

--- a/R/construction.R
+++ b/R/construction.R
@@ -21,7 +21,10 @@ arrow_to_rpldf = function(at, schema = NULL, schema_overrides = NULL, rechunk = 
   )
   col_names = names(new_schema)
 
-  if (length(col_names) != n_cols) stop("schema length does not match column length")
+  if (length(col_names) != n_cols) {
+    Err_plain("schema length does not match column length") |>
+      unwrap()
+  }
 
   data_cols = list()
   # dictionaries cannot be built in different batches (categorical does not allow
@@ -215,7 +218,10 @@ df_to_rpldf = function(x, ..., schema = NULL, schema_overrides = NULL) {
   )
   col_names = names(new_schema)
 
-  if (length(col_names) != n_cols) stop("schema length does not match column length")
+  if (length(col_names) != n_cols) {
+    Err_plain("schema length does not match column length") |>
+      unwrap()
+  }
 
   data_cols = list()
 

--- a/man/as_polars_df.Rd
+++ b/man/as_polars_df.Rd
@@ -129,9 +129,7 @@ a \link[=DataFrame_class]{DataFrame}
 }
 \description{
 \code{\link[=as_polars_df]{as_polars_df()}} is a generic function that converts an R object to a
-polars DataFrame. It is basically a wrapper for \link[=pl_DataFrame]{pl$DataFrame()},
-but has special implementations for Apache Arrow-based objects such as
-polars \link[=LazyFrame_class]{LazyFrame} and \link[arrow:Table-class]{arrow::Table}.
+\link[=DataFrame_class]{polars DataFrame}.
 }
 \details{
 For \link[=LazyFrame_class]{LazyFrame} objects, this function is a shortcut for

--- a/man/as_polars_df.Rd
+++ b/man/as_polars_df.Rd
@@ -19,7 +19,14 @@ as_polars_df(x, ...)
 
 \method{as_polars_df}{default}(x, ...)
 
-\method{as_polars_df}{data.frame}(x, ..., rownames = NULL, make_names_unique = TRUE)
+\method{as_polars_df}{data.frame}(
+  x,
+  ...,
+  rownames = NULL,
+  make_names_unique = TRUE,
+  schema = NULL,
+  schema_overrides = NULL
+)
 
 \method{as_polars_df}{RPolarsDataFrame}(x, ...)
 
@@ -70,6 +77,13 @@ If \code{x} already has a column with that name, an error is thrown.
 with unique names. If \code{FALSE} and there are duplicated column names, an
 error is thrown.}
 
+\item{schema}{named list of DataTypes, or character vector of column names.
+Should be the same length as the number of columns of \code{x}.
+If schema names or types do not match \code{x}, the columns will be renamed/recast.
+If \code{NULL} (default), convert columns as is.}
+
+\item{schema_overrides}{named list of DataTypes. Cast some columns to the DataType.}
+
 \item{n_rows}{Number of rows to fetch. Defaults to \code{Inf}, meaning all rows.}
 
 \item{type_coercion}{Boolean. Coerce types such that operations succeed and
@@ -109,13 +123,6 @@ into the resulting DataFrame. Useful in interactive mode to not lock R session.}
 
 \item{rechunk}{A logical flag (default \code{TRUE}).
 Make sure that all data of each column is in contiguous memory.}
-
-\item{schema}{named list of DataTypes, or character vector of column names.
-Should be the same length as the number of columns of \code{x}.
-If schema names or types do not match \code{x}, the columns will be renamed/recast.
-If \code{NULL} (default), convert columns as is.}
-
-\item{schema_overrides}{named list of DataTypes. Cast some columns to the DataType.}
 }
 \value{
 a \link[=DataFrame_class]{DataFrame}

--- a/tests/testthat/test-as_polars.R
+++ b/tests/testthat/test-as_polars.R
@@ -99,6 +99,29 @@ test_that("as_polars_df throws error when make_names_unique = FALSE and there ar
 })
 
 
+test_that("schema option and schema_overrides for as_polars_df.data.frame", {
+  df = data.frame(a = 1:3, b = 4:6)
+  pl_df_1 = as_polars_df(df, schema = list(a = pl$String, b = pl$Int32))
+  pl_df_2 = as_polars_df(df, schema = c("x", "y"))
+  pl_df_3 = as_polars_df(df, schema_overrides = list(a = pl$String))
+
+  expect_equal(
+    pl_df_1$to_data_frame(),
+    data.frame(a = as.character(1:3), b = 4L:6L)
+  )
+  expect_equal(
+    pl_df_2$to_data_frame(),
+    data.frame(x = 1:3, y = 4:6)
+  )
+  expect_equal(
+    pl_df_3$to_data_frame(),
+    data.frame(a = as.character(1:3), b = 4:6)
+  )
+
+  expect_error(as_polars_df(mtcars, schema = "cyl"), "schema length does not match")
+})
+
+
 if (requireNamespace("arrow", quietly = TRUE) && requireNamespace("nanoarrow", quietly = TRUE)) {
   make_as_polars_series_cases = function() {
     tibble::tribble(

--- a/tests/testthat/test-as_polars.R
+++ b/tests/testthat/test-as_polars.R
@@ -142,7 +142,6 @@ if (requireNamespace("arrow", quietly = TRUE) && requireNamespace("nanoarrow", q
   patrick::with_parameters_test_that(
     "as_polars_series S3 methods",
     {
-
       pl_series = as_polars_series(x)
       expect_s3_class(pl_series, "RPolarsSeries")
 


### PR DESCRIPTION
Close #816
It used to call `pl$DataFrame` internally, but has been completely rewritten to not call it.

Speeds seem to be comparable, but memory usage may have been reduced.
(The `bench` package does not measure memory usage on the Rust side, but given that the output RPolarsDataFrame is the same, memory usage on the Rust side should not be much different.)

``` r
big_df = do.call(rbind, lapply(1:10, \(x) nycflights13::flights))

library(polars)
library(nanoarrow)

bench::mark(
  pl_DataFrame = {
    pl$DataFrame(big_df)
  },
  as_polars_df = {
    as_polars_df(big_df)
  },
  from_nanoarrow = {
    as_polars_df(as_nanoarrow_array_stream(big_df))
  },
  check = FALSE,
  min_iterations = 10L
)
#> # A tibble: 3 × 6
#>   expression          min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 pl_DataFrame   826.41ms 839.49ms     1.16     1.91MB    0.289
#> 2 as_polars_df   738.85ms 864.31ms     1.16   204.05KB    0.129
#> 3 from_nanoarrow    1.15s    1.27s     0.790   77.48MB    0.339
```

<sup>Created on 2024-02-17 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>