### PR TITLE
ci: fix migration to actions/download-artifact@v4

### DIFF
--- a/.github/workflows/release-lib.yaml
+++ b/.github/workflows/release-lib.yaml
@@ -174,10 +174,23 @@ jobs:
           devtools::install_local(force = TRUE)
           testthat::test_dir("tests")
 
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - test
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: libs
+          pattern: libs-*
+
   release:
     needs:
       - build
       - test
+      - merge
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
@@ -190,8 +203,6 @@ jobs:
         with:
           name: libs
           path: libs
-          pattern: libs-*
-          merge-multiple: true
 
       - name: create checksums
         working-directory: libs


### PR DESCRIPTION
Sorry, the release job failed because the fixes were not sufficient.
See https://github.com/actions/download-artifact/blob/348754975ef0295bfa2c111cba996120cfdf8a5d/docs/MIGRATION.md