### PR TITLE
ci: ensure install R on macOS runner

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -26,6 +26,14 @@ runs:
           version: 3.x
           repo-token: ${{ inputs.token }}
 
+      - name: Install R
+        # Workaround for https://github.com/actions/runner-images/issues/9394
+        if: runner.os == 'macOS'
+        uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+          Ncpus: 2
+
       - name: Set up Rust nightly toolchain
         if: inputs.rust-nightly == 'true' || env.LIBR_POLARS_FEATURES == 'full_features'
         shell: bash

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -18,6 +18,7 @@ on:
     branches:
       - main
     paths:
+      - .github/actions/setup/action.yaml
       - .github/workflows/check.yaml
       - .Rbuildignore
       - R/**

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -24,6 +24,7 @@ on:
     branches:
       - main
     paths:
+      - .github/actions/setup/action.yaml
       - .github/workflows/docs.yaml
       - altdoc/**
       - man/**

--- a/.github/workflows/release-lib.yaml
+++ b/.github/workflows/release-lib.yaml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
     paths:
+      - .github/actions/setup/action.yaml
       - .github/workflows/release-lib.yaml
       - src/rust/**
       - src/Makevars*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
     paths:
+      - .github/actions/setup/action.yaml
       - .github/workflows/release.yaml
       - src/Makevars*
   workflow_dispatch:


### PR DESCRIPTION
Workflow started failing because R was not installed on the new macOS runner (actions/runner-images#9394).
I don't know if this is a temporary or permanent problem, but this PR will correct for the possibility of a temporary problem.