### PR TITLE
refactor: remove the `data.table` package from Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,6 @@ Suggests:
     bit64,
     callr,
     curl,
-    data.table,
     ggplot2,
     jsonlite,
     knitr,

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -118,8 +118,6 @@ replace_private_with_pub_methods(RPolarsSQLContext, "^SQLContext_")
 # pl top level functions
 replace_private_with_pub_methods(pl, "^pl_")
 
-# tell testthat data.table is suggested
-.datatable.aware = TRUE
 
 # Package startup messages must be in .onAttach(), not in .onLoad() otherwise
 # R CMD check throws a NOTE. See also: https://r-pkgs.org/r-cmd-check.html#r-code

--- a/tests/testthat/test-dataframe.R
+++ b/tests/testthat/test-dataframe.R
@@ -922,55 +922,6 @@ test_that("melt example", {
   )
 })
 
-test_that("melt vs data.table::melt", {
-  skip_if_not_installed("data.table")
-  pdf = pl$DataFrame(
-    a = c("x", "y", "z"),
-    b = c(1, 3, 5),
-    c = c(2, 4, 6)
-  )
-
-  rdf = pdf$to_data_frame()
-  dtt = data.table::data.table(rdf)
-
-  melt_mod = \(...) {
-    data.table::melt(variable.factor = FALSE, value.factor = FALSE, ...)
-  }
-
-  expect_identical(
-    pdf$melt(id_vars = "a", value_vars = c("b", "c"))$to_list(),
-    as.list(melt_mod(dtt, id.vars = "a", value_vars = c("b", "c")))
-  )
-  expect_identical(
-    pdf$melt(id_vars = c("c", "b"), value_vars = c("a"))$to_list(),
-    as.list(melt_mod(dtt, id.vars = c("c", "b"), value_vars = c("a")))
-  )
-  expect_identical(
-    pdf$melt(id_vars = c("a", "b"), value_vars = c("c"))$to_list(),
-    as.list(melt_mod(dtt, id.vars = c("a", "b"), value_vars = c("b", "c")))
-  )
-
-
-  expect_identical(
-    pdf$melt(
-      id_vars = c("a", "b"), value_vars = c("c"), value_name = "alice", variable_name = "bob"
-    )$to_list(),
-    as.list(melt_mod(
-      dtt,
-      id.vars = c("a", "b"), value_vars = c("b", "c"), value.name = "alice", variable.name = "bob"
-    ))
-  )
-
-  # check the check, this should not be equal
-  expect_error(expect_equal(
-    pdf$melt(id_vars = c("c", "b"), value_vars = c("a"))$to_list(),
-    as.list(melt_mod(dtt, id.vars = c("a", "b"), value_vars = c("c")))
-  ))
-})
-
-
-
-
 
 test_that("pivot examples", {
   df = pl$DataFrame(

--- a/tests/testthat/test-dataframe.R
+++ b/tests/testthat/test-dataframe.R
@@ -905,24 +905,6 @@ test_that("n_chunks", {
 })
 
 
-test_that("melt example", {
-  df = pl$DataFrame(
-    a = c("x", "y", "z"),
-    b = c(1, 3, 5),
-    c = c(2, 4, 6)
-  )
-
-  expect_identical(
-    df$melt(id_vars = "a", value_vars = c("b", "c"))$to_list(),
-    list(
-      a = c("x", "y", "z", "x", "y", "z"),
-      variable = c("b", "b", "b", "c", "c", "c"),
-      value = c(1, 3, 5, 2, 4, 6)
-    )
-  )
-})
-
-
 test_that("pivot examples", {
   df = pl$DataFrame(
     foo = c("one", "one", "one", "two", "two", "two"),

--- a/tests/testthat/test-expr_expr.R
+++ b/tests/testthat/test-expr_expr.R
@@ -1663,25 +1663,18 @@ test_that("interpolate", {
 
 
 test_that("Expr_rolling_", {
-  skip_if_not_installed("data.table")
-  suppressMessages(library(data.table))
-  # check all examples
-  df = pl$DataFrame(list(a = 1:6))
-  dt = data.table(a = 1:6)
+  df = pl$DataFrame(a = 1:6)
 
-  df_expected = dt[
-    ,
-    .(
-      min = as.integer(frollapply(a, 2, min)),
-      max = as.integer(frollapply(a, 2, max)),
-      mean = frollmean(a, 2),
-      sum = as.integer(frollsum(a, 2)),
-      std = frollapply(a, 2, sd),
-      var = frollapply(a, 2, var),
-      median = frollapply(a, 2, median),
-      quantile_linear = frollapply(a, 2, quantile, probs = .33)
-    )
-  ] |> as.data.frame()
+  expected = data.frame(
+    min = c(NA_integer_, 1L:5L),
+    max = c(NA_integer_, 2L:6L),
+    mean = c(NA, 1.5, 2.5, 3.5, 4.5, 5.5),
+    sum = c(NA_integer_, 3L, 5L, 7L, 9L, 11L),
+    std = c(NA, rep(0.7071067811865476, 5)),
+    var = c(NA, rep(0.5, 5)),
+    median = c(NA, 1.5, 2.5, 3.5, 4.5, 5.5),
+    quantile_linear = c(NA, 1.33, 2.33, 3.33, 4.33, 5.33)
+  )
 
   expect_identical(
     df$select(
@@ -1696,11 +1689,11 @@ test_that("Expr_rolling_", {
         quantile = .33, window_size = 2, interpolation = "linear"
       )$alias("quantile_linear")
     )$to_data_frame(),
-    df_expected
+    expected
   )
 
   # check skewness
-  df_actual_skew = pl$DataFrame(list(a = iris$Sepal.Length))$select(pl$col("a")$rolling_skew(window_size = 4)$head(10))
+  df_actual_skew = pl$DataFrame(a = iris$Sepal.Length)$select(pl$col("a")$rolling_skew(window_size = 4)$head(10))
   expect_equal(
     df_actual_skew$to_list()[[1L]],
     c(

--- a/tests/testthat/test-expr_list.R
+++ b/tests/testthat/test-expr_list.R
@@ -249,58 +249,69 @@ test_that("arg_min arg_max", {
 
 
 test_that("diff", {
-  skip_if_not_installed("data.table")
   l = list(
     l_i32 = list(1:5, 1:3, c(4L, 2L, 1L, 7L, 42L)),
     l_f64 = list(c(1, 1, 2, 3, NA, Inf, NA, Inf), c(1), numeric())
   )
   df = pl$DataFrame(l)
 
-  r_diff = function(x, n = 1L) {
-    x - data.table::shift(x, n)
-  }
-
   l_act_diff_1 = df$select(pl$all()$list$diff())$to_list()
-  l_exp_diff_1 = lapply(l, sapply, r_diff)
+  l_exp_diff_1 = list(
+    l_i32 = list(c(NA, rep(1L, 4)), c(NA, 1L, 1L), c(NA, -2L, -1L, 6L, 35L)),
+    l_f64 = list(c(NA, 0, 1, 1, NA, NA, NA, NA), NA_real_, numeric())
+  )
   expect_identical(l_act_diff_1, l_exp_diff_1)
 
   l_act_diff_2 = df$select(pl$all()$list$diff(n = 2))$to_list()
-  l_exp_diff_2 = lapply(l, sapply, r_diff, n = 2)
+  l_exp_diff_2 = list(
+    l_i32 = list(c(NA, NA, rep(2L, 3)), c(NA, NA, 2L), c(NA, NA, -3L, 5L, 41L)),
+    l_f64 = list(c(NA, NA, 1, 2, NA, Inf, NA, NaN), NA_real_, numeric())
+  )
   expect_identical(l_act_diff_2, l_exp_diff_2)
 
   l_act_diff_0 = df$select(pl$all()$list$diff(n = 0))$to_list()
-  l_exp_diff_0 = lapply(l, sapply, r_diff, n = 0)
+  l_exp_diff_0 = list(
+    l_i32 = list(rep(0L, 5), rep(0L, 3), rep(0L, 5)),
+    l_f64 = list(c(rep(0, 4), NA, NaN, NA, NaN), 0, numeric())
+  )
   expect_identical(l_act_diff_0, l_exp_diff_0)
 })
 
 
 
 test_that("shift", {
-  skip_if_not_installed("data.table")
   l = list(
     l_i32 = list(1:5, 1:3, c(4L, 2L, 1L, 7L, 42L)),
     l_f64 = list(c(1, 1, 2, 3, NA, Inf, NA, Inf), c(1), numeric())
   )
   df = pl$DataFrame(l)
 
-  r_shift = function(x, n = 1L) {
-    data.table::shift(x, n) # <3 data.table
-  }
-
   l_act_diff_1 = df$select(pl$all()$list$shift())$to_list()
-  l_exp_diff_1 = lapply(l, sapply, r_shift)
+  l_exp_diff_1 = list(
+    l_i32 = list(c(NA, 1L:4L), c(NA, 1L, 2L), c(NA, 4L, 2L, 1L, 7L)),
+    l_f64 = list(c(NA, 1, 1, 2, 3, NA, Inf, NA), NA_real_, numeric())
+  )
   expect_identical(l_act_diff_1, l_exp_diff_1)
 
   l_act_diff_2 = df$select(pl$all()$list$shift(2))$to_list()
-  l_exp_diff_2 = lapply(l, sapply, r_shift, 2)
+  l_exp_diff_2 = list(
+    l_i32 = list(c(NA, NA, 1L:3L), c(NA, NA, 1L), c(NA, NA, 4L, 2L, 1L)),
+    l_f64 = list(c(NA, NA, 1, 1, 2, 3, NA, Inf), NA_real_, numeric())
+  )
   expect_identical(l_act_diff_2, l_exp_diff_2)
 
   l_act_diff_0 = df$select(pl$all()$list$shift(0))$to_list()
-  l_exp_diff_0 = lapply(l, sapply, r_shift, 0)
+  l_exp_diff_0 = list(
+    l_i32 = list(1L:5L, 1L:3L, c(4L, 2L, 1L, 7L, 42L)),
+    l_f64 = list(c(1, 1, 2, 3, NA, Inf, NA, Inf), 1, numeric())
+  )
   expect_identical(l_act_diff_0, l_exp_diff_0)
 
   l_act_diff_m1 = df$select(pl$all()$list$shift(-1))$to_list()
-  l_exp_diff_m1 = lapply(l, sapply, r_shift, -1)
+  l_exp_diff_m1 = list(
+    l_i32 = list(c(2L:5L, NA), c(2L, 3L, NA), c(2L, 1L, 7L, 42L, NA)),
+    l_f64 = list(c(1, 2, 3, NA, Inf, NA, Inf, NA), NA_real_, numeric())
+  )
   expect_identical(l_act_diff_m1, l_exp_diff_m1)
 })
 

--- a/tests/testthat/test-lazy.R
+++ b/tests/testthat/test-lazy.R
@@ -557,50 +557,6 @@ test_that("melt example", {
   )
 })
 
-test_that("melt vs data.table::melt", {
-  skip_if_not_installed("data.table")
-  plf = pl$DataFrame(
-    a = c("x", "y", "z"),
-    b = c(1, 3, 5),
-    c = c(2, 4, 6)
-  )$lazy()
-
-  rdf = plf$collect()$to_data_frame()
-  dtt = data.table::data.table(rdf)
-
-  melt_mod = \(...) {
-    data.table::melt(variable.factor = FALSE, value.factor = FALSE, ...)
-  }
-
-  expect_identical(
-    plf$melt(id_vars = "a", value_vars = c("b", "c"))$collect()$to_list(),
-    as.list(melt_mod(dtt, id.vars = "a", value_vars = c("b", "c")))
-  )
-  expect_identical(
-    plf$melt(id_vars = c("c", "b"), value_vars = c("a"))$collect()$to_list(),
-    as.list(melt_mod(dtt, id.vars = c("c", "b"), value_vars = c("a")))
-  )
-  expect_identical(
-    plf$melt(id_vars = c("a", "b"), value_vars = c("c"))$collect()$to_list(),
-    as.list(melt_mod(dtt, id.vars = c("a", "b"), value_vars = c("b", "c")))
-  )
-
-  expect_identical(
-    plf$melt(
-      id_vars = c("a", "b"), value_vars = c("c"), value_name = "alice", variable_name = "bob"
-    )$collect()$to_list(),
-    as.list(melt_mod(
-      dtt,
-      id.vars = c("a", "b"), value_vars = c("b", "c"), value.name = "alice", variable.name = "bob"
-    ))
-  )
-
-  # check the check, this should not be equal
-  expect_error(expect_equal(
-    plf$melt(id_vars = c("c", "b"), value_vars = c("a"))$collect()$to_list(),
-    as.list(melt_mod(dtt, id.vars = c("a", "b"), value_vars = c("c")))
-  ))
-})
 
 test_that("rename", {
   lf = pl$DataFrame(mtcars)$lazy()

--- a/tests/testthat/test-lazy.R
+++ b/tests/testthat/test-lazy.R
@@ -540,23 +540,6 @@ test_that("join_asof_simple", {
   expect_identical(get_reg(logical_json_plan_FF, force_p_pat), "\"force_parallel\": Bool(false)")
 })
 
-test_that("melt example", {
-  lf = pl$DataFrame(
-    a = c("x", "y", "z"),
-    b = c(1, 3, 5),
-    c = c(2, 4, 6)
-  )$lazy()
-
-  expect_identical(
-    lf$melt(id_vars = "a", value_vars = c("b", "c"))$collect()$to_list(),
-    list(
-      a = c("x", "y", "z", "x", "y", "z"),
-      variable = c("b", "b", "b", "c", "c", "c"),
-      value = c(1, 3, 5, 2, 4, 6)
-    )
-  )
-})
-
 
 test_that("rename", {
   lf = pl$DataFrame(mtcars)$lazy()

--- a/tests/testthat/test-melt.R
+++ b/tests/testthat/test-melt.R
@@ -16,25 +16,8 @@ patrick::with_parameters_test_that("melt example",
         value = c(1, 3, 5, 2, 4, 6)
       )
     )
-
-    df_2 = pl[[create_func]](
-      a = c("x", "y", "z"),
-      b = c(1, 3, 5),
-      c = c(2, 4, 6)
-    )
-
-    expect_true(is_func(df_2))
-
     expect_identical(
-      df_2$melt(id_vars = "a", value_vars = c("b", "c")) |> as.data.frame(),
-      data.frame(
-        a = c("x", "y", "z", "x", "y", "z"),
-        variable = c("b", "b", "b", "c", "c", "c"),
-        value = c(1, 3, 5, 2, 4, 6)
-      )
-    )
-    expect_identical(
-      df_2$melt(id_vars = c("c", "b"), value_vars = "a") |> as.data.frame(),
+      df_1$melt(id_vars = c("c", "b"), value_vars = "a") |> as.data.frame(),
       data.frame(
         c = c(2, 4, 6),
         b = c(1, 3, 5),
@@ -43,7 +26,7 @@ patrick::with_parameters_test_that("melt example",
       )
     )
     expect_identical(
-      df_2$melt(id_vars = c("a", "b"), value_vars = "c") |> as.data.frame(),
+      df_1$melt(id_vars = c("a", "b"), value_vars = "c") |> as.data.frame(),
       data.frame(
         a = c("x", "y", "z"),
         b = c(1, 3, 5),
@@ -53,7 +36,7 @@ patrick::with_parameters_test_that("melt example",
     )
 
     expect_identical(
-      df_2$melt(
+      df_1$melt(
         id_vars = c("a", "b"),
         value_vars = c("c"),
         value_name = "alice",
@@ -66,8 +49,6 @@ patrick::with_parameters_test_that("melt example",
         alice = c(2, 4, 6)
       )
     )
-
-    expect_error
   },
   create_func = c("DataFrame", "LazyFrame"),
   is_func = list(is_polars_df, is_polars_lf),

--- a/tests/testthat/test-melt.R
+++ b/tests/testthat/test-melt.R
@@ -1,0 +1,75 @@
+patrick::with_parameters_test_that("melt example",
+  {
+    df_1 = pl[[create_func]](
+      a = c("x", "y", "z"),
+      b = c(1, 3, 5),
+      c = c(2, 4, 6)
+    )
+
+    expect_true(is_func(df_1))
+
+    expect_identical(
+      df_1$melt(id_vars = "a", value_vars = c("b", "c")) |> as.data.frame(),
+      data.frame(
+        a = c("x", "y", "z", "x", "y", "z"),
+        variable = c("b", "b", "b", "c", "c", "c"),
+        value = c(1, 3, 5, 2, 4, 6)
+      )
+    )
+
+    df_2 = pl[[create_func]](
+      a = c("x", "y", "z"),
+      b = c(1, 3, 5),
+      c = c(2, 4, 6)
+    )
+
+    expect_true(is_func(df_2))
+
+    expect_identical(
+      df_2$melt(id_vars = "a", value_vars = c("b", "c")) |> as.data.frame(),
+      data.frame(
+        a = c("x", "y", "z", "x", "y", "z"),
+        variable = c("b", "b", "b", "c", "c", "c"),
+        value = c(1, 3, 5, 2, 4, 6)
+      )
+    )
+    expect_identical(
+      df_2$melt(id_vars = c("c", "b"), value_vars = "a") |> as.data.frame(),
+      data.frame(
+        c = c(2, 4, 6),
+        b = c(1, 3, 5),
+        variable = rep("a", 3),
+        value = c("x", "y", "z")
+      )
+    )
+    expect_identical(
+      df_2$melt(id_vars = c("a", "b"), value_vars = "c") |> as.data.frame(),
+      data.frame(
+        a = c("x", "y", "z"),
+        b = c(1, 3, 5),
+        variable = rep("c", 3),
+        value = c(2, 4, 6)
+      )
+    )
+
+    expect_identical(
+      df_2$melt(
+        id_vars = c("a", "b"),
+        value_vars = c("c"),
+        value_name = "alice",
+        variable_name = "bob"
+      ) |> as.data.frame(),
+      data.frame(
+        a = c("x", "y", "z"),
+        b = c(1, 3, 5),
+        bob = rep("c", 3),
+        alice = c(2, 4, 6)
+      )
+    )
+
+    expect_error
+  },
+  create_func = c("DataFrame", "LazyFrame"),
+  is_func = list(is_polars_df, is_polars_lf),
+  .test_name = create_func
+)


### PR DESCRIPTION
In fact, it is used only within the tests and there is little need to use it.