### PR TITLE
ci(website): use `r-lib/actions/setup-r-dependencies` to cache R packages

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -86,9 +86,13 @@ jobs:
         # altdoc uses quarto
       - uses: quarto-dev/quarto-actions/setup@v2
 
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: dev,website
+
       - name: Get requirements
         run: |
-          task setup-r-tools
           task setup-python-tools
 
       - name: Build docs


### PR DESCRIPTION
Currently the binary for the new version of the `arrow` package is not yet available via P3M, so that is installed source from CRAN.
Switching to `r-lib/actions/setup-r-dependencies` should speed up the process.