### PR TITLE
fix!: change the default delimiter of `$str$concat` from `"-"` to `""` and `ignore_nulls` should be a named argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,10 @@
         that are either column names or regular expressions (#852).
     -   There is no argument for `pl$len()`. If you want to measure the length of
         specific columns, you should use `pl$count(...)` (#852).
+    -   `<Expr>$str$concat()` method's `delimiter` argument's default value is
+        changed from `"-"` to `""` (#853).
+    -   `<Expr>$str$concat()` method's `ignore_nulls` argument should be a
+        named argument (#853).
 
 ### New features
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,7 +17,7 @@
         specific columns, you should use `pl$count(...)` (#852).
     -   `<Expr>$str$concat()` method's `delimiter` argument's default value is
         changed from `"-"` to `""` (#853).
-    -   `<Expr>$str$concat()` method's `ignore_nulls` argument should be a
+    -   `<Expr>$str$concat()` method's `ignore_nulls` argument must be a
         named argument (#853).
 
 ### New features

--- a/R/expr__list.R
+++ b/R/expr__list.R
@@ -431,17 +431,27 @@ ExprList_to_struct = function(
 #'   a = list(c(1, 8, 3), c(3, 2), c(NA, NA, 1)),
 #'   b = list(c("R", "is", "amazing"), c("foo", "bar"), "text")
 #' )
-#' df$with_columns(
-#'   # standardize each value inside a list, using only the values in this list
+#'
+#' df
+#'
+#' # standardize each value inside a list, using only the values in this list
+#' df$select(
 #'   a_stand = pl$col("a")$list$eval(
 #'     (pl$element() - pl$element()$mean()) / pl$element()$std()
-#'   ),
+#'   )
+#' )
 #'
-#'   # count characters for each element in list. Since column "b" is list[str],
-#'   # we can apply all `$str` functions on elements in the list:
+#' # count characters for each element in list. Since column "b" is list[str],
+#' # we can apply all `$str` functions on elements in the list:
+#' df$select(
 #'   b_len_chars = pl$col("b")$list$eval(
 #'     pl$element()$str$len_chars()
 #'   )
+#' )
+#'
+#' # concat strings in each list
+#' df$select(
+#'   pl$col("b")$list$eval(pl$element()$str$concat(" "))$list$first()
 #' )
 ExprList_eval = function(expr, parallel = FALSE) {
   .pr$Expr$list_eval(self, expr, parallel)

--- a/R/expr__string.R
+++ b/R/expr__string.R
@@ -221,7 +221,6 @@ ExprStr_len_chars = function() {
 #' @param ... Ignored.
 #' @param ignore_nulls Ignore null values (default). If `FALSE`, null values will be
 #' propagated: if the column contains any null values, the output is null.
-#' @keywords ExprStr
 #' @return Expr of String concatenated
 #' @examples
 #' # concatenate a Series of strings to a single string

--- a/R/expr__string.R
+++ b/R/expr__string.R
@@ -229,14 +229,6 @@ ExprStr_len_chars = function() {
 #' df$select(pl$col("foo")$str$concat("-"))
 #'
 #' df$select(pl$col("foo")$str$concat("-", ignore_nulls = FALSE))
-#'
-#' # Series list of strings to Series of concatenated strings
-#' df = pl$DataFrame(bar = list(c("a", "b", "c"), c("d", "f", NA)))
-#' df
-#'
-#' df$select(
-#'   pl$col("bar")$list$eval(pl$element()$str$concat("-"))$list$first()
-#' )
 ExprStr_concat = function(
     delimiter = "",
     ...,

--- a/R/expr__string.R
+++ b/R/expr__string.R
@@ -215,25 +215,33 @@ ExprStr_len_chars = function() {
   .pr$Expr$str_len_chars(self)
 }
 
-#' Vertically concatenate values of a Series
+#' Vertically concatenate the string values in the column to a single string value.
 #'
-#' @description Vertically concatenate the values in the Series to a single
-#' string value.
 #' @param delimiter The delimiter to insert between consecutive string values.
-#' @param ignore_nulls Ignore null values. If `FALSE`, null values will be
+#' @param ... Ignored.
+#' @param ignore_nulls Ignore null values (default). If `FALSE`, null values will be
 #' propagated: if the column contains any null values, the output is null.
 #' @keywords ExprStr
 #' @return Expr of String concatenated
 #' @examples
 #' # concatenate a Series of strings to a single string
-#' df = pl$DataFrame(foo = c("1", NA, 2))
+#' df = pl$DataFrame(foo = c(1, NA, 2))
+#'
 #' df$select(pl$col("foo")$str$concat("-"))
+#'
 #' df$select(pl$col("foo")$str$concat("-", ignore_nulls = FALSE))
 #'
 #' # Series list of strings to Series of concatenated strings
-#' df = pl$DataFrame(list(bar = list(c("a", "b", "c"), c("1", "2", NA))))
-#' df$select(pl$col("bar")$list$eval(pl$col("")$str$concat("-"))$list$first())
-ExprStr_concat = function(delimiter = "-", ignore_nulls = TRUE) {
+#' df = pl$DataFrame(bar = list(c("a", "b", "c"), c("d", "f", NA)))
+#' df
+#'
+#' df$select(
+#'   pl$col("bar")$list$eval(pl$element()$str$concat("-"))$list$first()
+#' )
+ExprStr_concat = function(
+    delimiter = "",
+    ...,
+    ignore_nulls = TRUE) {
   .pr$Expr$str_concat(self, delimiter, ignore_nulls) |>
     unwrap("in $concat():")
 }

--- a/man/ExprList_eval.Rd
+++ b/man/ExprList_eval.Rd
@@ -27,16 +27,26 @@ df = pl$DataFrame(
   a = list(c(1, 8, 3), c(3, 2), c(NA, NA, 1)),
   b = list(c("R", "is", "amazing"), c("foo", "bar"), "text")
 )
-df$with_columns(
-  # standardize each value inside a list, using only the values in this list
+
+df
+
+# standardize each value inside a list, using only the values in this list
+df$select(
   a_stand = pl$col("a")$list$eval(
     (pl$element() - pl$element()$mean()) / pl$element()$std()
-  ),
+  )
+)
 
-  # count characters for each element in list. Since column "b" is list[str],
-  # we can apply all `$str` functions on elements in the list:
+# count characters for each element in list. Since column "b" is list[str],
+# we can apply all `$str` functions on elements in the list:
+df$select(
   b_len_chars = pl$col("b")$list$eval(
     pl$element()$str$len_chars()
   )
+)
+
+# concat strings in each list
+df$select(
+  pl$col("b")$list$eval(pl$element()$str$concat(" "))$list$first()
 )
 }

--- a/man/ExprStr_concat.Rd
+++ b/man/ExprStr_concat.Rd
@@ -2,31 +2,38 @@
 % Please edit documentation in R/expr__string.R
 \name{ExprStr_concat}
 \alias{ExprStr_concat}
-\title{Vertically concatenate values of a Series}
+\title{Vertically concatenate the string values in the column to a single string value.}
 \usage{
-ExprStr_concat(delimiter = "-", ignore_nulls = TRUE)
+ExprStr_concat(delimiter = "", ..., ignore_nulls = TRUE)
 }
 \arguments{
 \item{delimiter}{The delimiter to insert between consecutive string values.}
 
-\item{ignore_nulls}{Ignore null values. If \code{FALSE}, null values will be
+\item{...}{Ignored.}
+
+\item{ignore_nulls}{Ignore null values (default). If \code{FALSE}, null values will be
 propagated: if the column contains any null values, the output is null.}
 }
 \value{
 Expr of String concatenated
 }
 \description{
-Vertically concatenate the values in the Series to a single
-string value.
+Vertically concatenate the string values in the column to a single string value.
 }
 \examples{
 # concatenate a Series of strings to a single string
-df = pl$DataFrame(foo = c("1", NA, 2))
+df = pl$DataFrame(foo = c(1, NA, 2))
+
 df$select(pl$col("foo")$str$concat("-"))
+
 df$select(pl$col("foo")$str$concat("-", ignore_nulls = FALSE))
 
 # Series list of strings to Series of concatenated strings
-df = pl$DataFrame(list(bar = list(c("a", "b", "c"), c("1", "2", NA))))
-df$select(pl$col("bar")$list$eval(pl$col("")$str$concat("-"))$list$first())
+df = pl$DataFrame(bar = list(c("a", "b", "c"), c("d", "f", NA)))
+df
+
+df$select(
+  pl$col("bar")$list$eval(pl$element()$str$concat("-"))$list$first()
+)
 }
 \keyword{ExprStr}

--- a/man/ExprStr_concat.Rd
+++ b/man/ExprStr_concat.Rd
@@ -27,13 +27,4 @@ df = pl$DataFrame(foo = c(1, NA, 2))
 df$select(pl$col("foo")$str$concat("-"))
 
 df$select(pl$col("foo")$str$concat("-", ignore_nulls = FALSE))
-
-# Series list of strings to Series of concatenated strings
-df = pl$DataFrame(bar = list(c("a", "b", "c"), c("d", "f", NA)))
-df
-
-df$select(
-  pl$col("bar")$list$eval(pl$element()$str$concat("-"))$list$first()
-)
 }
-\keyword{ExprStr}

--- a/tests/testthat/test-expr_string.R
+++ b/tests/testthat/test-expr_string.R
@@ -154,17 +154,25 @@ test_that("str$len_bytes str$len_chars", {
 
 test_that("str$concat", {
   # concatenate a Series of strings to a single string
-  df = pl$DataFrame(foo = c("1", "a", 2))
+  df = pl$DataFrame(foo = c("1", "a", NA))
   expect_identical(
-    df$select(pl$col("foo")$str$concat())$to_list(),
-    lapply(df$to_list(), paste, collapse = "-")
+    df$select(pl$col("foo")$str$concat())$to_list()[[1]],
+    "1a"
+  )
+  expect_identical(
+    df$select(pl$col("foo")$str$concat("-"))$to_list()[[1]],
+    "1-a"
+  )
+  expect_identical(
+    df$select(pl$col("foo")$str$concat(ignore_nulls = FALSE))$to_list()[[1]],
+    NA_character_
   )
 
   # Series list of strings to Series of concatenated strings
   df = pl$DataFrame(list(bar = list(c("a", "b", "c"), c("1", "2", "æ"))))
   expect_identical(
-    df$select(pl$col("bar")$list$eval(pl$col("")$str$concat())$list$first())$to_list()$bar,
-    sapply(df$to_list()[[1]], paste, collapse = "-")
+    df$select(pl$col("bar")$list$eval(pl$element()$str$concat())$list$first())$to_list()$bar,
+    sapply(df$to_list()[[1]], paste, collapse = "")
   )
 })
 


### PR DESCRIPTION
Ref pola-rs/polars#13690