### PR TITLE
fix: the default value of `$str$strptime()`'s format

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-- The default value of the `format` of `$str$strptime()` is now correctly set (#892).
+-   The default value of the `format` of `$str$strptime()` is now correctly set (#892).
 
 ## Polars R Package 0.15.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## Polars R Package (development version)
 
+### Bug fixes
+
+- The default value of the `format` of `$str$strptime()` is now correctly set (#892).
+
 ## Polars R Package 0.15.0
 
 ### Breaking changes due to Rust-polars update

--- a/R/datatype.R
+++ b/R/datatype.R
@@ -41,6 +41,7 @@ wrap_proto_schema = function(x) {
 #' @title DataTypes (RPolarsDataType)
 #'
 #' @name pl_dtypes
+#' @aliases RPolarsDataType
 #' @description `DataType` any polars type (ported so far)
 #' @return not applicable
 #' @examples
@@ -166,6 +167,7 @@ DataType_constructors = function() {
 #' The underlying representation of this type is a 64-bit signed integer.
 #' The integer indicates the number of time units since the Unix epoch (1970-01-01 00:00:00).
 #' The number can be negative to indicate datetimes before the epoch.
+#' @aliases pl_Datetime
 #' @param time_unit Unit of time. One of `"ms"`, `"us"` (default) or `"ns"`.
 #' @param time_zone Time zone string, as defined in [OlsonNames()].
 #' Setting `timezone = "*"` will match any timezone, which can be useful to

--- a/R/expr__expr.R
+++ b/R/expr__expr.R
@@ -236,7 +236,7 @@ Expr_add = function(other) {
 #'
 #' Zero-division behaviour follows IEEE-754:
 #' - `0/0`: Invalid operation - mathematically undefined, returns `NaN`.
-#' - `n/0`: On finite operands gives an exact infinite result, eg: ±infinity.
+#' - `n/0`: On finite operands gives an exact infinite result, e.g.: ±infinity.
 #' @inherit Expr_add return
 #' @param other Numeric literal or expression value.
 #' @seealso

--- a/R/expr__string.R
+++ b/R/expr__string.R
@@ -10,7 +10,7 @@
 #' Similar to the [strptime()] function.
 #'
 #' When parsing a Datetime the column precision will be inferred from the format
-#' string, if given, eg: `"%F %T%.3f"` => [`pl$Datetime("ms")`][pl_Datetime].
+#' string, if given, e.g.: `"%F %T%.3f"` => [`pl$Datetime("ms")`][pl_Datetime].
 #' If no fractional second component is found then the default is `"us"` (microsecond).
 #' @param datatype The data type to convert into. Can be either Date, Datetime,
 #' or Time.
@@ -163,7 +163,7 @@ ExprStr_to_time = function(format = NULL, strict = TRUE, cache = TRUE) {
 #' @inheritParams ExprStr_strptime
 #' @param time_unit Unit of time for the resulting Datetime column. If `NULL` (default),
 #' the time unit is inferred from the format string if given,
-#' eg: `"%F %T%.3f"` => [`pl$Datetime("ms")`][pl_Datetime].
+#' e.g.: `"%F %T%.3f"` => [`pl$Datetime("ms")`][pl_Datetime].
 #' If no fractional second component is found, the default is `"us"` (microsecond).
 #' @param time_zone for the resulting [Datetime][pl_Datetime] column.
 #' @param exact If `TRUE` (default), require an exact format match. If `FALSE`, allow the format to match

--- a/R/expr__string.R
+++ b/R/expr__string.R
@@ -4,32 +4,53 @@
 # expr_str_make_sub_ns = macro_new_subnamespace("^ExprStr_", "RPolarsExprStrNameSpace")
 
 
+# TODO for 0.16.0: rename arguments, should not allow positional arguments except for the first two
 #' Convert a String column into a Date/Datetime/Time column.
 #'
+#' Similar to the [strptime()] function.
 #'
+#' When parsing a Datetime the column precision will be inferred from the format
+#' string, if given, eg: `"%F %T%.3f"` => [`pl$Datetime("ms")`][pl_Datetime].
+#' If no fractional second component is found then the default is `"us"` (microsecond).
 #' @param datatype The data type to convert into. Can be either Date, Datetime,
 #' or Time.
-#' @param format Format to use for conversion. See `?strptime` for possible
-#' values. Example: "%Y-%m-%d %H:%M:%S". If `NULL` (default), the format is
-#' inferred from the data. Notice that time zone `%Z` is not supported and will
-#' just ignore timezones. Numeric time zones like `%z` or `%:z`  are supported.
+#' @param format Format to use for conversion. Refer to
+#' [the chrono crate documentation](https://docs.rs/chrono/latest/chrono/format/strftime/index.html)
+#' for the full specification. Example: `"%Y-%m-%d %H:%M:%S"`.
+#' If `NULL` (default), the format is inferred from the data.
+#' Notice that time zone `%Z` is not supported and will just ignore timezones.
+#' Numeric time zones like `%z` or `%:z` are supported.
 #' @param strict If `TRUE` (default), raise an error if a single string cannot
-#' be parsed. Otherwise, produce a polars `null`.
-#' @param exact If `TRUE` (default), require an exact format match. Otherwise,
+#' be parsed. If `FALSE`, produce a polars `null`.
+#' @param exact If `TRUE` (default), require an exact format match. If `FALSE`,
 #' allow the format to match anywhere in the target string.
+#' Conversion to the Time type is always exact.
+#' Note that using `exact = FALSE` introduces a performance penalty -
+#' cleaning your data beforehand will almost certainly be more performant.
 #' @param cache Use a cache of unique, converted dates to apply the datetime
 #' conversion.
 #' @param ambiguous Determine how to deal with ambiguous datetimes:
 #' * `"raise"` (default): raise
 #' * `"earliest"`: use the earliest datetime
 #' * `"latest"`: use the latest datetime
-#' @details
-#' When parsing a Datetime the column precision will be inferred from the format
-#' string, if given, eg: “%F %T%.3f" => Datetime("ms"). If no fractional second
-#' component is found then the default is "us" (microsecond).
-#' @keywords ExprStr
-#' @return Expr of a Date, Datetime or Time Series
+#' @return [Expr][Expr_class] of Date, Datetime or Time type
+#' @seealso
+#' - [`<Expr>$str$to_date()`][ExprStr_to_date]
+#' - [`<Expr>$str$to_datetime()`][ExprStr_to_datetime]
+#' - [`<Expr>$str$to_time()`][ExprStr_to_time]
 #' @examples
+#' # Dealing with a consistent format
+#' s = pl$Series(c("2020-01-01 01:00Z", "2020-01-01 02:00Z"))
+#'
+#' s$str$strptime(pl$Datetime(), "%Y-%m-%d %H:%M%#z")
+#'
+#' # Auto infer format
+#' s$str$strptime(pl$Datetime())
+#'
+#' # Datetime with timezone is interpreted as UTC timezone
+#' pl$Series("2020-01-01T01:00:00+09:00")$str$strptime(pl$Datetime())
+#'
+#' # Dealing with different formats.
 #' s = pl$Series(
 #'   c(
 #'     "2021-04-22",
@@ -39,38 +60,41 @@
 #'   ),
 #'   "date"
 #' )
-#' #' #join multiple passes with different format
-#' s$to_frame()$with_columns(
-#'   pl$col("date")
-#'   $str$strptime(pl$Date, "%F", strict = FALSE)
-#'   $fill_null(pl$col("date")$str$strptime(pl$Date, "%F %T", strict = FALSE))
-#'   $fill_null(pl$col("date")$str$strptime(pl$Date, "%D", strict = FALSE))
-#'   $fill_null(pl$col("date")$str$strptime(pl$Date, "%c", strict = FALSE))
+#'
+#' s$to_frame()$select(
+#'   pl$coalesce(
+#'     pl$col("date")$str$strptime(pl$Date, "%F", strict = FALSE),
+#'     pl$col("date")$str$strptime(pl$Date, "%F %T", strict = FALSE),
+#'     pl$col("date")$str$strptime(pl$Date, "%D", strict = FALSE),
+#'     pl$col("date")$str$strptime(pl$Date, "%c", strict = FALSE)
+#'   )
 #' )
 #'
-#' txt_datetimes = c(
-#'   "2023-01-01 11:22:33 -0100",
-#'   "2023-01-01 11:22:33 +0300",
-#'   "invalid time"
+#' # Ignore invalid time
+#' s = pl$Series(
+#'   c(
+#'     "2023-01-01 11:22:33 -0100",
+#'     "2023-01-01 11:22:33 +0300",
+#'     "invalid time"
+#'   )
 #' )
 #'
-#' pl$lit(txt_datetimes)$str$strptime(
+#' s$str$strptime(
 #'   pl$Datetime("ns"),
-#'   format = "%Y-%m-%d %H:%M:%S %z", strict = FALSE,
-#' )$to_series()
+#'   format = "%Y-%m-%d %H:%M:%S %z",
+#'   strict = FALSE,
+#' )
 ExprStr_strptime = function(
     datatype,
-    format,
+    format = NULL,
     strict = TRUE,
     exact = TRUE,
     cache = TRUE,
     ambiguous = "raise") {
   pcase(
-
     # not a datatype
     !is_polars_dtype(datatype),
     Err_plain("arg datatype is not an RPolarsDataType"),
-
     # Datetime
     pl$same_outer_dt(datatype, pl$Datetime()),
     {
@@ -81,93 +105,78 @@ ExprStr_strptime = function(
         \(expr) .pr$Expr$dt_cast_time_unit(expr, datetime_type$tu) # cast if not an err
       )
     },
-
     # Date
     datatype == pl$Date,
     .pr$Expr$str_to_date(self, format, strict, exact, cache),
-
     # Time
     datatype == pl$Time,
     .pr$Expr$str_to_time(self, format, strict, cache),
-
     # Other
     or_else = Err_plain("datatype should be of type {Date, Datetime, Time}")
   ) |>
     unwrap("in str$strptime():")
 }
 
+# TODO for 0.16.0: should not allow positional arguments except for the first one
 #' Convert a String column into a Date column
 #'
-#' @param format Format to use for conversion. See `?strptime` for possible
-#' values. Example: "%Y-%m-%d". If `NULL` (default), the format is
-#' inferred from the data. Notice that time zone `%Z` is not supported and will
-#' just ignore timezones. Numeric time zones like `%z` or `%:z`  are supported.
-#' @param strict If `TRUE` (default), raise an error if a single string cannot
-#' be parsed. If `FALSE`, parsing failure will produce a polars `null`.
-#' @param exact If `TRUE` (default), require an exact format match. Otherwise,
-#' allow the format to match anywhere in the target string.
-#' @param cache Use a cache of unique, converted dates to apply the datetime
-#' conversion.
-#'
-#' @return Expr
-#'
-#'
+#' @inheritParams ExprStr_strptime
+#' @format Format to use for conversion. Refer to
+#' [the chrono crate documentation](https://docs.rs/chrono/latest/chrono/format/strftime/index.html)
+#' for the full specification. Example: `"%Y-%m-%d"`.
+#' If `NULL` (default), the format is inferred from the data.
+#' @return [Expr][Expr_class] of Date type
+#' @seealso
+#' - [`<Expr>$str$strptime()`][ExprStr_strptime]
 #' @examples
-#' pl$DataFrame(str_date = c("2009-01-02", "2009-01-03", "2009-1-4", "2009 05 01"))$
-#'   with_columns(date = pl$col("str_date")$str$to_date(strict = FALSE))
+#' s = pl$Series(c("2020/01/01", "2020/02/01", "2020/03/01"))
+#'
+#' s$str$to_date()
 ExprStr_to_date = function(format = NULL, strict = TRUE, exact = TRUE, cache = TRUE) {
   .pr$Expr$str_to_date(self, format, strict, exact, cache) |>
     unwrap("in $str$to_date():")
 }
 
+# TODO for 0.16.0: should not allow positional arguments except for the first one
 #' Convert a String column into a Time column
 #'
-#' @param format Format to use for conversion. See `?strptime` for possible
-#' values. Example: "%H:%M:%S". If `NULL` (default), the format is
-#' inferred from the data. Notice that time zone `%Z` is not supported and will
-#' just ignore timezones. Numeric time zones like `%z` or `%:z`  are supported.
-#' @param strict If `TRUE` (default), raise an error if a single string cannot
-#' be parsed. If `FALSE`, parsing failure will produce a polars `null`.
-#' @param cache Use a cache of unique, converted dates to apply the datetime
-#' conversion.
-#'
-#' @return Expr
-#'
-#'
+#' @inheritParams ExprStr_strptime
+#' @format Format to use for conversion. Refer to
+#' [the chrono crate documentation](https://docs.rs/chrono/latest/chrono/format/strftime/index.html)
+#' for the full specification. Example: `"%H:%M:%S"`.
+#' If `NULL` (default), the format is inferred from the data.
+#' @return [Expr][Expr_class] of Time type
+#' @seealso
+#' - [`<Expr>$str$strptime()`][ExprStr_strptime]
 #' @examples
-#' pl$DataFrame(str_time = c("01:20:01", "28:00:02", "03:00:02"))$
-#'   with_columns(time = pl$col("str_time")$str$to_time(strict = FALSE))
+#' s = pl$Series(c("01:00", "02:00", "03:00"))
+#'
+#' s$str$to_time("%H:%M")
 ExprStr_to_time = function(format = NULL, strict = TRUE, cache = TRUE) {
   .pr$Expr$str_to_time(self, format, strict, cache) |>
     unwrap("in $str$to_time():")
 }
 
+# TODO for 0.16.0: should not allow positional arguments except for the first one
 #' Convert a String column into a Datetime column
 #'
-#' @param format Format to use for conversion. See `?strptime` for possible
-#' values. Example: "%Y-%m-%d %H:%M:%S". If `NULL` (default), the format is
-#' inferred from the data. Notice that time zone `%Z` is not supported and will
-#' just ignore timezones. Numeric time zones like `%z` or `%:z`  are supported.
-#' @param time_unit String (`"ns"`, `"us"`, `"ms"`) or integer.
-#' @param time_zone String describing a timezone. If `NULL` (default), `"GMT` is
-#' used.
-#' @param strict If `TRUE` (default), raise an error if a single string cannot
-#' be parsed. If `FALSE`, parsing failure will produce a polars `null`.
-#' @param exact If `TRUE` (default), require an exact format match. Otherwise,
-#' allow the format to match anywhere in the target string.
-#' @param cache Use a cache of unique, converted dates to apply the datetime
-#' conversion.
-#' @param ambiguous Determine how to deal with ambiguous datetimes:
-#' * `"raise"` (default): raise
-#' * `"earliest"`: use the earliest datetime
-#' * `"latest"`: use the latest datetime
-#'
-#' @return Expr
-#'
-#'
+#' @inheritParams ExprStr_strptime
+#' @param time_unit Unit of time for the resulting Datetime column. If `NULL` (default),
+#' the time unit is inferred from the format string if given,
+#' eg: `"%F %T%.3f"` => [`pl$Datetime("ms")`][pl_Datetime].
+#' If no fractional second component is found, the default is `"us"` (microsecond).
+#' @param time_zone for the resulting [Datetime][pl_Datetime] column.
+#' @param exact If `TRUE` (default), require an exact format match. If `FALSE`, allow the format to match
+#' anywhere in the target string. Note that using `exact = FALSE` introduces a performance
+#' penalty - cleaning your data beforehand will almost certainly be more performant.
+#' @return [Expr][Expr_class] of [Datetime][pl_Datetime] type
+#' @seealso
+#' - [`<Expr>$str$strptime()`][ExprStr_strptime]
 #' @examples
-#' pl$DataFrame(str_date = c("2009-01-02 01:00", "2009-01-03 02:00", "2009-1-4 3:00"))$
-#'   with_columns(datetime = pl$col("str_date")$str$to_datetime(strict = FALSE))
+#' s = pl$Series(c("2020-01-01 01:00Z", "2020-01-01 02:00Z"))
+#'
+#' s$str$to_datetime("%Y-%m-%d %H:%M%#z")
+#' s$str$to_datetime(time_unit = "ms")
 ExprStr_to_datetime = function(
     format = NULL,
     time_unit = NULL,

--- a/man/DataType_Datetime.Rd
+++ b/man/DataType_Datetime.Rd
@@ -2,6 +2,7 @@
 % Please edit documentation in R/datatype.R
 \name{DataType_Datetime}
 \alias{DataType_Datetime}
+\alias{pl_Datetime}
 \title{Data type representing a calendar date and time of day.}
 \usage{
 DataType_Datetime(time_unit = "us", time_zone = NULL)

--- a/man/ExprStr_strptime.Rd
+++ b/man/ExprStr_strptime.Rd
@@ -51,7 +51,7 @@ Similar to the \code{\link[=strptime]{strptime()}} function.
 }
 \details{
 When parsing a Datetime the column precision will be inferred from the format
-string, if given, eg: \code{"\%F \%T\%.3f"} => \code{\link[=pl_Datetime]{pl$Datetime("ms")}}.
+string, if given, e.g.: \code{"\%F \%T\%.3f"} => \code{\link[=pl_Datetime]{pl$Datetime("ms")}}.
 If no fractional second component is found then the default is \code{"us"} (microsecond).
 }
 \examples{

--- a/man/ExprStr_strptime.Rd
+++ b/man/ExprStr_strptime.Rd
@@ -6,7 +6,7 @@
 \usage{
 ExprStr_strptime(
   datatype,
-  format,
+  format = NULL,
   strict = TRUE,
   exact = TRUE,
   cache = TRUE,
@@ -17,16 +17,21 @@ ExprStr_strptime(
 \item{datatype}{The data type to convert into. Can be either Date, Datetime,
 or Time.}
 
-\item{format}{Format to use for conversion. See \code{?strptime} for possible
-values. Example: "\%Y-\%m-\%d \%H:\%M:\%S". If \code{NULL} (default), the format is
-inferred from the data. Notice that time zone \verb{\%Z} is not supported and will
-just ignore timezones. Numeric time zones like \verb{\%z} or \verb{\%:z}  are supported.}
+\item{format}{Format to use for conversion. Refer to
+\href{https://docs.rs/chrono/latest/chrono/format/strftime/index.html}{the chrono crate documentation}
+for the full specification. Example: \code{"\%Y-\%m-\%d \%H:\%M:\%S"}.
+If \code{NULL} (default), the format is inferred from the data.
+Notice that time zone \verb{\%Z} is not supported and will just ignore timezones.
+Numeric time zones like \verb{\%z} or \verb{\%:z} are supported.}
 
 \item{strict}{If \code{TRUE} (default), raise an error if a single string cannot
-be parsed. Otherwise, produce a polars \code{null}.}
+be parsed. If \code{FALSE}, produce a polars \code{null}.}
 
-\item{exact}{If \code{TRUE} (default), require an exact format match. Otherwise,
-allow the format to match anywhere in the target string.}
+\item{exact}{If \code{TRUE} (default), require an exact format match. If \code{FALSE},
+allow the format to match anywhere in the target string.
+Conversion to the Time type is always exact.
+Note that using \code{exact = FALSE} introduces a performance penalty -
+cleaning your data beforehand will almost certainly be more performant.}
 
 \item{cache}{Use a cache of unique, converted dates to apply the datetime
 conversion.}
@@ -39,17 +44,29 @@ conversion.}
 }}
 }
 \value{
-Expr of a Date, Datetime or Time Series
+\link[=Expr_class]{Expr} of Date, Datetime or Time type
 }
 \description{
-Convert a String column into a Date/Datetime/Time column.
+Similar to the \code{\link[=strptime]{strptime()}} function.
 }
 \details{
 When parsing a Datetime the column precision will be inferred from the format
-string, if given, eg: “\%F \%T\%.3f" => Datetime("ms"). If no fractional second
-component is found then the default is "us" (microsecond).
+string, if given, eg: \code{"\%F \%T\%.3f"} => \code{\link[=pl_Datetime]{pl$Datetime("ms")}}.
+If no fractional second component is found then the default is \code{"us"} (microsecond).
 }
 \examples{
+# Dealing with a consistent format
+s = pl$Series(c("2020-01-01 01:00Z", "2020-01-01 02:00Z"))
+
+s$str$strptime(pl$Datetime(), "\%Y-\%m-\%d \%H:\%M\%#z")
+
+# Auto infer format
+s$str$strptime(pl$Datetime())
+
+# Datetime with timezone is interpreted as UTC timezone
+pl$Series("2020-01-01T01:00:00+09:00")$str$strptime(pl$Datetime())
+
+# Dealing with different formats.
 s = pl$Series(
   c(
     "2021-04-22",
@@ -59,24 +76,35 @@ s = pl$Series(
   ),
   "date"
 )
-#' #join multiple passes with different format
-s$to_frame()$with_columns(
-  pl$col("date")
-  $str$strptime(pl$Date, "\%F", strict = FALSE)
-  $fill_null(pl$col("date")$str$strptime(pl$Date, "\%F \%T", strict = FALSE))
-  $fill_null(pl$col("date")$str$strptime(pl$Date, "\%D", strict = FALSE))
-  $fill_null(pl$col("date")$str$strptime(pl$Date, "\%c", strict = FALSE))
+
+s$to_frame()$select(
+  pl$coalesce(
+    pl$col("date")$str$strptime(pl$Date, "\%F", strict = FALSE),
+    pl$col("date")$str$strptime(pl$Date, "\%F \%T", strict = FALSE),
+    pl$col("date")$str$strptime(pl$Date, "\%D", strict = FALSE),
+    pl$col("date")$str$strptime(pl$Date, "\%c", strict = FALSE)
+  )
 )
 
-txt_datetimes = c(
-  "2023-01-01 11:22:33 -0100",
-  "2023-01-01 11:22:33 +0300",
-  "invalid time"
+# Ignore invalid time
+s = pl$Series(
+  c(
+    "2023-01-01 11:22:33 -0100",
+    "2023-01-01 11:22:33 +0300",
+    "invalid time"
+  )
 )
 
-pl$lit(txt_datetimes)$str$strptime(
+s$str$strptime(
   pl$Datetime("ns"),
-  format = "\%Y-\%m-\%d \%H:\%M:\%S \%z", strict = FALSE,
-)$to_series()
+  format = "\%Y-\%m-\%d \%H:\%M:\%S \%z",
+  strict = FALSE,
+)
 }
-\keyword{ExprStr}
+\seealso{
+\itemize{
+\item \code{\link[=ExprStr_to_date]{<Expr>$str$to_date()}}
+\item \code{\link[=ExprStr_to_datetime]{<Expr>$str$to_datetime()}}
+\item \code{\link[=ExprStr_to_time]{<Expr>$str$to_time()}}
+}
+}

--- a/man/ExprStr_to_date.Rd
+++ b/man/ExprStr_to_date.Rd
@@ -3,31 +3,48 @@
 \name{ExprStr_to_date}
 \alias{ExprStr_to_date}
 \title{Convert a String column into a Date column}
+\format{
+Format to use for conversion. Refer to
+\href{https://docs.rs/chrono/latest/chrono/format/strftime/index.html}{the chrono crate documentation}
+for the full specification. Example: \code{"\%Y-\%m-\%d"}.
+If \code{NULL} (default), the format is inferred from the data.
+}
 \usage{
 ExprStr_to_date(format = NULL, strict = TRUE, exact = TRUE, cache = TRUE)
 }
 \arguments{
-\item{format}{Format to use for conversion. See \code{?strptime} for possible
-values. Example: "\%Y-\%m-\%d". If \code{NULL} (default), the format is
-inferred from the data. Notice that time zone \verb{\%Z} is not supported and will
-just ignore timezones. Numeric time zones like \verb{\%z} or \verb{\%:z}  are supported.}
+\item{format}{Format to use for conversion. Refer to
+\href{https://docs.rs/chrono/latest/chrono/format/strftime/index.html}{the chrono crate documentation}
+for the full specification. Example: \code{"\%Y-\%m-\%d \%H:\%M:\%S"}.
+If \code{NULL} (default), the format is inferred from the data.
+Notice that time zone \verb{\%Z} is not supported and will just ignore timezones.
+Numeric time zones like \verb{\%z} or \verb{\%:z} are supported.}
 
 \item{strict}{If \code{TRUE} (default), raise an error if a single string cannot
-be parsed. If \code{FALSE}, parsing failure will produce a polars \code{null}.}
+be parsed. If \code{FALSE}, produce a polars \code{null}.}
 
-\item{exact}{If \code{TRUE} (default), require an exact format match. Otherwise,
-allow the format to match anywhere in the target string.}
+\item{exact}{If \code{TRUE} (default), require an exact format match. If \code{FALSE},
+allow the format to match anywhere in the target string.
+Conversion to the Time type is always exact.
+Note that using \code{exact = FALSE} introduces a performance penalty -
+cleaning your data beforehand will almost certainly be more performant.}
 
 \item{cache}{Use a cache of unique, converted dates to apply the datetime
 conversion.}
 }
 \value{
-Expr
+\link[=Expr_class]{Expr} of Date type
 }
 \description{
 Convert a String column into a Date column
 }
 \examples{
-pl$DataFrame(str_date = c("2009-01-02", "2009-01-03", "2009-1-4", "2009 05 01"))$
-  with_columns(date = pl$col("str_date")$str$to_date(strict = FALSE))
+s = pl$Series(c("2020/01/01", "2020/02/01", "2020/03/01"))
+
+s$str$to_date()
+}
+\seealso{
+\itemize{
+\item \code{\link[=ExprStr_strptime]{<Expr>$str$strptime()}}
+}
 }

--- a/man/ExprStr_to_datetime.Rd
+++ b/man/ExprStr_to_datetime.Rd
@@ -24,7 +24,7 @@ Numeric time zones like \verb{\%z} or \verb{\%:z} are supported.}
 
 \item{time_unit}{Unit of time for the resulting Datetime column. If \code{NULL} (default),
 the time unit is inferred from the format string if given,
-eg: \code{"\%F \%T\%.3f"} => \code{\link[=pl_Datetime]{pl$Datetime("ms")}}.
+e.g.: \code{"\%F \%T\%.3f"} => \code{\link[=pl_Datetime]{pl$Datetime("ms")}}.
 If no fractional second component is found, the default is \code{"us"} (microsecond).}
 
 \item{time_zone}{for the resulting \link[=pl_Datetime]{Datetime} column.}

--- a/man/ExprStr_to_datetime.Rd
+++ b/man/ExprStr_to_datetime.Rd
@@ -15,21 +15,26 @@ ExprStr_to_datetime(
 )
 }
 \arguments{
-\item{format}{Format to use for conversion. See \code{?strptime} for possible
-values. Example: "\%Y-\%m-\%d \%H:\%M:\%S". If \code{NULL} (default), the format is
-inferred from the data. Notice that time zone \verb{\%Z} is not supported and will
-just ignore timezones. Numeric time zones like \verb{\%z} or \verb{\%:z}  are supported.}
+\item{format}{Format to use for conversion. Refer to
+\href{https://docs.rs/chrono/latest/chrono/format/strftime/index.html}{the chrono crate documentation}
+for the full specification. Example: \code{"\%Y-\%m-\%d \%H:\%M:\%S"}.
+If \code{NULL} (default), the format is inferred from the data.
+Notice that time zone \verb{\%Z} is not supported and will just ignore timezones.
+Numeric time zones like \verb{\%z} or \verb{\%:z} are supported.}
 
-\item{time_unit}{String (\code{"ns"}, \code{"us"}, \code{"ms"}) or integer.}
+\item{time_unit}{Unit of time for the resulting Datetime column. If \code{NULL} (default),
+the time unit is inferred from the format string if given,
+eg: \code{"\%F \%T\%.3f"} => \code{\link[=pl_Datetime]{pl$Datetime("ms")}}.
+If no fractional second component is found, the default is \code{"us"} (microsecond).}
 
-\item{time_zone}{String describing a timezone. If \code{NULL} (default), \verb{"GMT} is
-used.}
+\item{time_zone}{for the resulting \link[=pl_Datetime]{Datetime} column.}
 
 \item{strict}{If \code{TRUE} (default), raise an error if a single string cannot
-be parsed. If \code{FALSE}, parsing failure will produce a polars \code{null}.}
+be parsed. If \code{FALSE}, produce a polars \code{null}.}
 
-\item{exact}{If \code{TRUE} (default), require an exact format match. Otherwise,
-allow the format to match anywhere in the target string.}
+\item{exact}{If \code{TRUE} (default), require an exact format match. If \code{FALSE}, allow the format to match
+anywhere in the target string. Note that using \code{exact = FALSE} introduces a performance
+penalty - cleaning your data beforehand will almost certainly be more performant.}
 
 \item{cache}{Use a cache of unique, converted dates to apply the datetime
 conversion.}
@@ -42,12 +47,19 @@ conversion.}
 }}
 }
 \value{
-Expr
+\link[=Expr_class]{Expr} of \link[=pl_Datetime]{Datetime} type
 }
 \description{
 Convert a String column into a Datetime column
 }
 \examples{
-pl$DataFrame(str_date = c("2009-01-02 01:00", "2009-01-03 02:00", "2009-1-4 3:00"))$
-  with_columns(datetime = pl$col("str_date")$str$to_datetime(strict = FALSE))
+s = pl$Series(c("2020-01-01 01:00Z", "2020-01-01 02:00Z"))
+
+s$str$to_datetime("\%Y-\%m-\%d \%H:\%M\%#z")
+s$str$to_datetime(time_unit = "ms")
+}
+\seealso{
+\itemize{
+\item \code{\link[=ExprStr_strptime]{<Expr>$str$strptime()}}
+}
 }

--- a/man/ExprStr_to_time.Rd
+++ b/man/ExprStr_to_time.Rd
@@ -3,28 +3,42 @@
 \name{ExprStr_to_time}
 \alias{ExprStr_to_time}
 \title{Convert a String column into a Time column}
+\format{
+Format to use for conversion. Refer to
+\href{https://docs.rs/chrono/latest/chrono/format/strftime/index.html}{the chrono crate documentation}
+for the full specification. Example: \code{"\%H:\%M:\%S"}.
+If \code{NULL} (default), the format is inferred from the data.
+}
 \usage{
 ExprStr_to_time(format = NULL, strict = TRUE, cache = TRUE)
 }
 \arguments{
-\item{format}{Format to use for conversion. See \code{?strptime} for possible
-values. Example: "\%H:\%M:\%S". If \code{NULL} (default), the format is
-inferred from the data. Notice that time zone \verb{\%Z} is not supported and will
-just ignore timezones. Numeric time zones like \verb{\%z} or \verb{\%:z}  are supported.}
+\item{format}{Format to use for conversion. Refer to
+\href{https://docs.rs/chrono/latest/chrono/format/strftime/index.html}{the chrono crate documentation}
+for the full specification. Example: \code{"\%Y-\%m-\%d \%H:\%M:\%S"}.
+If \code{NULL} (default), the format is inferred from the data.
+Notice that time zone \verb{\%Z} is not supported and will just ignore timezones.
+Numeric time zones like \verb{\%z} or \verb{\%:z} are supported.}
 
 \item{strict}{If \code{TRUE} (default), raise an error if a single string cannot
-be parsed. If \code{FALSE}, parsing failure will produce a polars \code{null}.}
+be parsed. If \code{FALSE}, produce a polars \code{null}.}
 
 \item{cache}{Use a cache of unique, converted dates to apply the datetime
 conversion.}
 }
 \value{
-Expr
+\link[=Expr_class]{Expr} of Time type
 }
 \description{
 Convert a String column into a Time column
 }
 \examples{
-pl$DataFrame(str_time = c("01:20:01", "28:00:02", "03:00:02"))$
-  with_columns(time = pl$col("str_time")$str$to_time(strict = FALSE))
+s = pl$Series(c("01:00", "02:00", "03:00"))
+
+s$str$to_time("\%H:\%M")
+}
+\seealso{
+\itemize{
+\item \code{\link[=ExprStr_strptime]{<Expr>$str$strptime()}}
+}
 }

--- a/man/Expr_div.Rd
+++ b/man/Expr_div.Rd
@@ -19,7 +19,7 @@ Method equivalent of float division operator \code{expr / other}.
 Zero-division behaviour follows IEEE-754:
 \itemize{
 \item \code{0/0}: Invalid operation - mathematically undefined, returns \code{NaN}.
-\item \code{n/0}: On finite operands gives an exact infinite result, eg: ±infinity.
+\item \code{n/0}: On finite operands gives an exact infinite result, e.g.: ±infinity.
 }
 }
 \examples{

--- a/man/pl_dtypes.Rd
+++ b/man/pl_dtypes.Rd
@@ -2,6 +2,7 @@
 % Please edit documentation in R/datatype.R
 \name{pl_dtypes}
 \alias{pl_dtypes}
+\alias{RPolarsDataType}
 \title{DataTypes (RPolarsDataType)}
 \value{
 not applicable

--- a/tests/testthat/test-expr_string.R
+++ b/tests/testthat/test-expr_string.R
@@ -769,3 +769,29 @@ test_that("str$replace_many()", {
     "same amount of patterns as replacement"
   )
 })
+
+
+make_datetime_format_cases = function() {
+  tibble::tribble(
+    ~.test_name, ~time_str, ~datatype, ~type_expected,
+    "utc-example", "2020-01-01 01:00Z", pl$Datetime(), pl$Datetime("us", "UTC"),
+    "iso8602_1", "2020-01-01T01:00:00", pl$Datetime(), pl$Datetime("us"),
+    "iso8602_2", "2020-01-01T01:00", pl$Datetime(), pl$Datetime("us"),
+    "iso8602_3", "2020-01-01T01:00:00.000000001Z", pl$Datetime("ns"), pl$Datetime("ns", "UTC"),
+    "iso8602_4", "2020-01-01T01:00:00+09:00", pl$Datetime(), pl$Datetime("us", "UTC"),
+    "date_1", "2020-01-01", pl$Date, pl$Date,
+    "date_2", "2020/01/01", pl$Date, pl$Date,
+    "time_1", "01:00:00", pl$Time, pl$Time,
+    "time_2", "1:00:00", pl$Time, pl$Time,
+    "time_3", "13:00:00", pl$Time, pl$Time,
+  )
+}
+
+patrick::with_parameters_test_that(
+  "parse time without format specified",
+  {
+    s = pl$Series(time_str)$str$strptime(datatype)
+    expect_true(s$dtype == type_expected)
+  },
+  .cases = make_datetime_format_cases()
+)


### PR DESCRIPTION
Fix #884

The documentation said the default was `NULL`, but in fact there was no default value and an error would occur if the user did not specify one.

In addition, documentation has been improved and tests for default parsable values have been added.