### PR TITLE
Revert refactor of `pl$DataFrame()` with `schema` only

### DIFF
--- a/R/dataframe__frame.R
+++ b/R/dataframe__frame.R
@@ -279,8 +279,10 @@ pl_DataFrame = function(..., make_names_unique = TRUE, schema = NULL) {
   # no args create empty DataFrame
   if (length(largs) == 0L) {
     if (!is.null(schema)) {
-      out = lapply(schema, \(dtype) pl$Series(NULL)$cast(dtype)) |>
-        pl$select()
+      largs = lapply(seq_along(schema), \(x) {
+        pl$lit(numeric(0))$cast(schema[[x]])$alias(names(schema)[x])
+      })
+      out = pl$select(largs)
     } else {
       out = .pr$DataFrame$default()
     }


### PR DESCRIPTION
Refactor in #904 considerably slowed down the `DataFrame` creation with `schema` only:

``` r
library(polars)

schema <- list()
for (i in 1:1000) {
  schema[[paste0("var_", i)]] <- pl$Float64
}

bench::mark(
  pre_904 = {
    largs <- lapply(seq_along(schema), \(x) {
      pl$lit(numeric(0))$cast(schema[[x]])$alias(names(schema)[x])
    })
    pl$select(largs)
  }, 
  post_904 = {
    lapply(schema, \(dtype) pl$Series(NULL)$cast(dtype)) |>
      pl$select()
  }
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 pre_904    992.55ms 992.55ms     1.01     10.5MB     17.1
#> 2 post_904      2.99s    2.99s     0.335    14.7MB     10.4
```
