### PR TITLE
docs: skip the example if `arrow` package's dataset feature is not available

### DIFF
--- a/vignettes/polars.Rmd
+++ b/vignettes/polars.Rmd
@@ -493,7 +493,7 @@ aq$filter(
 Finally, we can read/scan multiple files in the same directory through pattern
 globbing.
 
-```{r, eval=requireNamespace("arrow", quietly = TRUE)}
+```{r, eval=(requireNamespace("arrow", quietly = TRUE) && arrow::arrow_with_dataset())}
 dir.create("airquality-ds")
 
 # Create a hive-partitioned dataset with the function from the arrow package


### PR DESCRIPTION
Recently CI on macOS started failing. Probably because the binary of the arrow package on CRAN does not have the dataset feature enabled.