### PR TITLE
Small improvements in docs of `pl$mean_horizontal()`

### DIFF
--- a/R/functions__lazy.R
+++ b/R/functions__lazy.R
@@ -960,11 +960,8 @@ pl_sum_horizontal = function(...) {
 #' )
 #'
 #' df$with_columns(
-#'   pl$mean_horizontal("a", "b")$alias("mean")
-#' )
-#'
-#' df$with_columns(
-#'   pl$mean_horizontal("a", "b", 5)$alias("mean")
+#'   pl$mean_horizontal("a", "b")$alias("mean"),
+#'   pl$mean_horizontal("a", "b", 5)$alias("mean_with_lit")
 #' )
 pl_mean_horizontal = function(...) {
   mean_horizontal(list2(...)) |>

--- a/R/functions__lazy.R
+++ b/R/functions__lazy.R
@@ -949,19 +949,22 @@ pl_sum_horizontal = function(...) {
 
 #' Compute the mean rowwise
 #'
-#' @param ... Columns to concatenate into a single string column. Accepts
-#' expressions. Strings are parsed as column names, other non-expression inputs
-#' are parsed as literals.
+#' @inheritParams pl_sum_horizontal
+#'
 #' @return Expr
 #'
 #' @examples
 #' df = pl$DataFrame(
-#'   a = c(1, 8, 3),
-#'   b = c(4, 5, NA_real_),
-#'   c = c("x", "y", "z")
+#'   a = c(1, 8, 3, 6, 7),
+#'   b = c(4, 5, NA_real_, Inf, NaN)
 #' )
+#'
 #' df$with_columns(
 #'   pl$mean_horizontal("a", "b")$alias("mean")
+#' )
+#'
+#' df$with_columns(
+#'   pl$mean_horizontal("a", "b", 5)$alias("mean")
 #' )
 pl_mean_horizontal = function(...) {
   mean_horizontal(list2(...)) |>

--- a/man/pl_mean_horizontal.Rd
+++ b/man/pl_mean_horizontal.Rd
@@ -24,10 +24,7 @@ df = pl$DataFrame(
 )
 
 df$with_columns(
-  pl$mean_horizontal("a", "b")$alias("mean")
-)
-
-df$with_columns(
-  pl$mean_horizontal("a", "b", 5)$alias("mean")
+  pl$mean_horizontal("a", "b")$alias("mean"),
+  pl$mean_horizontal("a", "b", 5)$alias("mean_with_lit")
 )
 }

--- a/man/pl_mean_horizontal.Rd
+++ b/man/pl_mean_horizontal.Rd
@@ -19,11 +19,15 @@ Compute the mean rowwise
 }
 \examples{
 df = pl$DataFrame(
-  a = c(1, 8, 3),
-  b = c(4, 5, NA_real_),
-  c = c("x", "y", "z")
+  a = c(1, 8, 3, 6, 7),
+  b = c(4, 5, NA_real_, Inf, NaN)
 )
+
 df$with_columns(
   pl$mean_horizontal("a", "b")$alias("mean")
+)
+
+df$with_columns(
+  pl$mean_horizontal("a", "b", 5)$alias("mean")
 )
 }


### PR DESCRIPTION
Following #959 

* Use `@inheritParams`
* Small changes in the examples:
  * Remove useless string column
  * Add some rows with `NaN` or `Inf` 
  * Add an example with a literal value