### PR TITLE
refactor!: temporary deprecate positional arguments of `pl$Series()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,19 +18,21 @@
     - The argument `x` is renamed `values` (#933).
     - Using positional arguments in `pl$Series()` throws a warning, since the
       argument positions will be changed in the future (#966).
+
       ```r
       # polars 0.15.1 or earlier
       # The first argument is `x`, the second argument is `name`.
       pl$Series(1:3, "foo")
-      
+
       # The code above will warn in 0.16.0
       # Use named arguments to silence the warning.
       pl$Series(values = 1:3, name = "foo")
       pl$Series(name = "foo", values = 1:3)
-      
+
       # polars 0.17.0 or later (future version)
       # The first argument is `name`, the second argument is `values`.
       pl$Series("foo", 1:3)
+      ```
   - `pl$implode(...)` is rewritten to be a syntactic sugar for `pl$col(...)$implode()` (#923).
   - Unify names of input/output function arguments (#935).
     - All arguments except the first argument must be named arguments.

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,25 +15,22 @@
 
 - Several functions have been rewritten to match the behavior of Python Polars.
   - In `pl$Series()` arguments are changed.
-    - The argument converted to the values of the Series is renamed from `x` to `values` (#933).
-    - Using positional arguments in `pl$Series()` is warned, since the
+    - The argument `x` is renamed `values` (#933).
+    - Using positional arguments in `pl$Series()` throws a warning, since the
       argument positions will be changed in the future (#966).
       ```r
       # polars 0.15.1 or earlier
       # The first argument is `x`, the second argument is `name`.
       pl$Series(1:3, "foo")
-      ```
-      ```r
-      # polars 0.17.0 or later (future version)
-      # The first argument is `values`, the second argument is `name`.
-      pl$Series("foo", 1:3)
-      ```
-      To silence the warning, please use named arguments.
-      ```r
-      # polars 0.16.0 or later
+      
+      # The code above will warn in 0.16.0
+      # Use named arguments to silence the warning.
       pl$Series(values = 1:3, name = "foo")
       pl$Series(name = "foo", values = 1:3)
-      ```
+      
+      # polars 0.17.0 or later (future version)
+      # The first argument is `name`, the second argument is `values`.
+      pl$Series("foo", 1:3)
   - `pl$implode(...)` is rewritten to be a syntactic sugar for `pl$col(...)$implode()` (#923).
   - Unify names of input/output function arguments (#935).
     - All arguments except the first argument must be named arguments.

--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,8 @@
       # The first argument is `name`, the second argument is `values`.
       pl$Series("foo", 1:3)
       ```
+      This warning can also be silenced by replacing `pl$Series(<values>, <name>)` 
+      by `as_polars_series(<values>, <name>)`.
   - `pl$implode(...)` is rewritten to be a syntactic sugar for `pl$col(...)$implode()` (#923).
   - Unify names of input/output function arguments (#935).
     - All arguments except the first argument must be named arguments.

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,7 +14,26 @@
 ### Other breaking changes
 
 - Several functions have been rewritten to match the behavior of Python Polars.
-  - In `pl$Series()`, the first argument `x` is renamed to `values` (#933).
+  - In `pl$Series()` arguments are changed.
+    - The argument converted to the values of the Series is renamed from `x` to `values` (#933).
+    - Using positional arguments in `pl$Series()` is warned, since the
+      argument positions will be changed in the future (#966).
+      ```r
+      # polars 0.15.1 or earlier
+      # The first argument is `x`, the second argument is `name`.
+      pl$Series(1:3, "foo")
+      ```
+      ```r
+      # polars 0.17.0 or later (future version)
+      # The first argument is `values`, the second argument is `name`.
+      pl$Series("foo", 1:3)
+      ```
+      To silence the warning, please use named arguments.
+      ```r
+      # polars 0.16.0 or later
+      pl$Series(values = 1:3, name = "foo")
+      pl$Series(name = "foo", values = 1:3)
+      ```
   - `pl$implode(...)` is rewritten to be a syntactic sugar for `pl$col(...)$implode()` (#923).
   - Unify names of input/output function arguments (#935).
     - All arguments except the first argument must be named arguments.

--- a/NEWS.md
+++ b/NEWS.md
@@ -34,7 +34,8 @@
       # The first argument is `name`, the second argument is `values`.
       pl$Series("foo", 1:3)
       ```
-      This warning can also be silenced by replacing `pl$Series(<values>, <name>)` 
+
+      This warning can also be silenced by replacing `pl$Series(<values>, <name>)`
       by `as_polars_series(<values>, <name>)`.
   - `pl$implode(...)` is rewritten to be a syntactic sugar for `pl$col(...)$implode()` (#923).
   - Unify names of input/output function arguments (#935).

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 - Several functions have been rewritten to match the behavior of Python Polars.
   - In `pl$Series()` arguments are changed.
     - The argument `x` is renamed `values` (#933).
+    - The argument `values` has a new default value `NULL` (#966).
     - Using positional arguments in `pl$Series()` throws a warning, since the
       argument positions will be changed in the future (#966).
 

--- a/R/PTime.R
+++ b/R/PTime.R
@@ -63,7 +63,7 @@ time_unit_conv_factor = c(
 #' pl$PTime("23:59:59")
 #'
 #'
-#' pl$Series(pl$PTime(runif(5) * 3600 * 24 * 1E0, tu = "s"))
+#' as_polars_series(pl$PTime(runif(5) * 3600 * 24 * 1E0, tu = "s"))
 #' pl$lit(pl$PTime("23:59:59"))$to_series()
 #'
 #' pl$lit(pl$PTime("23:59:59"))$to_r()

--- a/R/after-wrappers.R
+++ b/R/after-wrappers.R
@@ -315,7 +315,7 @@ pl_select = function(...) {
 #' Does not give meaningful answers for regular R objects.
 #' @param robj an R object
 #' @return String of mem address
-#' @examples pl$mem_address(pl$Series(1:3))
+#' @examples pl$mem_address(pl$Series(values = 1:3))
 pl_mem_address = function(robj) {
   mem_address(robj)
 }

--- a/R/as_polars.R
+++ b/R/as_polars.R
@@ -329,7 +329,7 @@ as_polars_series = function(x, name = NULL, ...) {
 #' @rdname as_polars_series
 #' @export
 as_polars_series.default = function(x, name = NULL, ...) {
-  pl$Series(x, name = name)
+  pl$Series(values = x, name = name)
 }
 
 

--- a/R/as_polars.R
+++ b/R/as_polars.R
@@ -117,7 +117,7 @@ as_polars_df.data.frame = function(
     old_rownames = as.character(old_rownames)
 
     pl$concat(
-      pl$Series(old_rownames, name = rownames),
+      as_polars_series(old_rownames, name = rownames),
       df_to_rpldf(x, schema = schema, schema_overrides = schema_overrides),
       how = "horizontal"
     )
@@ -408,7 +408,7 @@ as_polars_series.nanoarrow_array_stream = function(x, name = NULL, ...) {
 
   if (length(list_of_arrays) < 1L) {
     # TODO: support 0-length array stream
-    out = pl$Series(NULL, name = name)
+    out = pl$Series(name = name)
   } else {
     out = as_polars_series.nanoarrow_array(list_of_arrays[[1L]], name = name)
     lapply(

--- a/R/dataframe__frame.R
+++ b/R/dataframe__frame.R
@@ -2056,7 +2056,9 @@ DataFrame_rolling = function(index_column, period, offset = NULL, closed = "righ
 #' )
 #'
 #' # Dynamic group bys can also be combined with grouping on normal keys
-#' df = df$with_columns(groups = pl$Series(c("a", "a", "a", "b", "b", "a", "a")))
+#' df = df$with_columns(
+#'   groups = as_polars_series(c("a", "a", "a", "b", "b", "a", "a"))
+#' )
 #' df
 #'
 #' df$group_by_dynamic(

--- a/R/dataframe__frame.R
+++ b/R/dataframe__frame.R
@@ -79,7 +79,7 @@
 #' ```{r}
 #' # Due to daylight savings, clocks were turned forward 1 hour on Sunday, March 8, 2020, 2:00:00 am
 #' # so this particular date-time doesn't exist
-#' non_existent_time = pl$Series("2020-03-08 02:00:00")$str$strptime(pl$Datetime(), "%F %T")
+#' non_existent_time = as_polars_series("2020-03-08 02:00:00")$str$strptime(pl$Datetime(), "%F %T")
 #'
 #' withr::with_envvar(
 #'   new = c(TZ = "America/New_York"),

--- a/R/datatype.R
+++ b/R/datatype.R
@@ -55,7 +55,7 @@ wrap_proto_schema = function(x) {
 #'
 #' # The function changes type from Int32 to String
 #' # Specifying the output DataType: String solves the problem
-#' pl$Series(1:4)$map_elements(\(x) letters[x], datatype = pl$dtypes$String)
+#' as_polars_series(1:4)$map_elements(\(x) letters[x], datatype = pl$dtypes$String)
 #'
 NULL
 

--- a/R/expr__string.R
+++ b/R/expr__string.R
@@ -37,7 +37,7 @@
 #' - [`<Expr>$str$to_time()`][ExprStr_to_time]
 #' @examples
 #' # Dealing with a consistent format
-#' s = pl$Series(c("2020-01-01 01:00Z", "2020-01-01 02:00Z"))
+#' s = as_polars_series(c("2020-01-01 01:00Z", "2020-01-01 02:00Z"))
 #'
 #' s$str$strptime(pl$Datetime(), "%Y-%m-%d %H:%M%#z")
 #'
@@ -45,10 +45,10 @@
 #' s$str$strptime(pl$Datetime())
 #'
 #' # Datetime with timezone is interpreted as UTC timezone
-#' pl$Series("2020-01-01T01:00:00+09:00")$str$strptime(pl$Datetime())
+#' as_polars_series("2020-01-01T01:00:00+09:00")$str$strptime(pl$Datetime())
 #'
 #' # Dealing with different formats.
-#' s = pl$Series(
+#' s = as_polars_series(
 #'   c(
 #'     "2021-04-22",
 #'     "2022-01-04 00:00:00",
@@ -68,7 +68,7 @@
 #' )
 #'
 #' # Ignore invalid time
-#' s = pl$Series(
+#' s = as_polars_series(
 #'   c(
 #'     "2023-01-01 11:22:33 -0100",
 #'     "2023-01-01 11:22:33 +0300",
@@ -126,12 +126,12 @@ ExprStr_strptime = function(
 #' @seealso
 #' - [`<Expr>$str$strptime()`][ExprStr_strptime]
 #' @examples
-#' s = pl$Series(c("2020/01/01", "2020/02/01", "2020/03/01"))
+#' s = as_polars_series(c("2020/01/01", "2020/02/01", "2020/03/01"))
 #'
 #' s$str$to_date()
 #'
 #' # by default, this errors if some values cannot be converted
-#' s = pl$Series(c("2020/01/01", "2020 02 01", "2020-03-01"))
+#' s = as_polars_series(c("2020/01/01", "2020 02 01", "2020-03-01"))
 #' try(s$str$to_date())
 #' s$str$to_date(strict = FALSE)
 ExprStr_to_date = function(format = NULL, ..., strict = TRUE, exact = TRUE, cache = TRUE) {
@@ -150,7 +150,7 @@ ExprStr_to_date = function(format = NULL, ..., strict = TRUE, exact = TRUE, cach
 #' @seealso
 #' - [`<Expr>$str$strptime()`][ExprStr_strptime]
 #' @examples
-#' s = pl$Series(c("01:00", "02:00", "03:00"))
+#' s = as_polars_series(c("01:00", "02:00", "03:00"))
 #'
 #' s$str$to_time("%H:%M")
 ExprStr_to_time = function(format = NULL, ..., strict = TRUE, cache = TRUE) {
@@ -173,7 +173,7 @@ ExprStr_to_time = function(format = NULL, ..., strict = TRUE, cache = TRUE) {
 #' @seealso
 #' - [`<Expr>$str$strptime()`][ExprStr_strptime]
 #' @examples
-#' s = pl$Series(c("2020-01-01 01:00Z", "2020-01-01 02:00Z"))
+#' s = as_polars_series(c("2020-01-01 01:00Z", "2020-01-01 02:00Z"))
 #'
 #' s$str$to_datetime("%Y-%m-%d %H:%M%#z")
 #' s$str$to_datetime(time_unit = "ms")

--- a/R/extendr-wrappers.R
+++ b/R/extendr-wrappers.R
@@ -1230,7 +1230,7 @@ RPolarsLazyGroupBy$tail <- function(n) .Call(wrap__RPolarsLazyGroupBy__tail, sel
 
 RPolarsSeries <- new.env(parent = emptyenv())
 
-RPolarsSeries$new <- function(x, name) .Call(wrap__RPolarsSeries__new, x, name)
+RPolarsSeries$new <- function(name, values) .Call(wrap__RPolarsSeries__new, name, values)
 
 RPolarsSeries$clone <- function() .Call(wrap__RPolarsSeries__clone, self)
 

--- a/R/functions__eager.R
+++ b/R/functions__eager.R
@@ -461,16 +461,16 @@ pl_datetime_ranges = function(
 #' raw_list = pl$raw_list(raw(1), raw(3), charToRaw("alice"), NULL)
 #'
 #' # pass it to Series or lit
-#' pl$Series(raw_list)
+#' pl$Series(values = raw_list)
 #' pl$lit(raw_list)
 #'
 #' # convert polars bianry Series to rpolars_raw_list
-#' pl$Series(raw_list)$to_r()
+#' pl$Series(values = raw_list)$to_r()
 #'
 #'
 #' # NB: a plain list of raws yield a polars Series of DateType [list[Binary]]
 #' # which is not the same
-#' pl$Series(list(raw(1), raw(2)))
+#' pl$Series(values = list(raw(1), raw(2)))
 #'
 #' # to regular list, use as.list or unclass
 #' as.list(raw_list)

--- a/R/functions__lazy.R
+++ b/R/functions__lazy.R
@@ -14,7 +14,7 @@
 #'
 #' # vector to literal explicitly via Series and back again
 #' # R vector to expression and back again
-#' pl$select(pl$lit(pl$Series(1:4)))$to_list()[[1L]]
+#' pl$select(pl$lit(as_polars_series(1:4)))$to_list()[[1L]]
 #'
 #' # r vector to literal and back r vector
 #' pl$lit(1:4)$to_r()
@@ -585,7 +585,7 @@ pl_var = function(..., ddof = 1) {
 #' # concat Expr a Series and an R obejct
 #' pl$concat_list(list(
 #'   pl$lit(1:5),
-#'   pl$Series(5:1),
+#'   as_polars_series(5:1),
 #'   rep(0L, 5)
 #' ))$alias("alice")$to_series()
 #'

--- a/R/lazyframe__lazy.R
+++ b/R/lazyframe__lazy.R
@@ -1903,7 +1903,9 @@ LazyFrame_rolling = function(
 #' )$collect()
 #'
 #' # Dynamic group bys can also be combined with grouping on normal keys
-#' lf = lf$with_columns(groups = pl$Series(c("a", "a", "a", "b", "b", "a", "a")))
+#' lf = lf$with_columns(
+#'   groups = as_polars_series(c("a", "a", "a", "b", "b", "a", "a"))
+#' )
 #' lf$collect()
 #'
 #' lf$group_by_dynamic(

--- a/R/s3-methods-operator.R
+++ b/R/s3-methods-operator.R
@@ -35,9 +35,9 @@
 #'   error = function(e) e
 #' )
 #'
-#' pl$Series(5) + 10
-#' +pl$Series(5)
-#' -pl$Series(5)
+#' as_polars_series(5) + 10
+#' +as_polars_series(5)
+#' -as_polars_series(5)
 NULL
 
 
@@ -158,7 +158,7 @@ NULL
 #' @rdname S3_arithmetic
 `-.RPolarsSeries` = function(x, y) {
   result(if (missing(y)) {
-    pl$Series(0L)$sub(as_polars_series(x))
+    as_polars_series(0L)$sub(as_polars_series(x))
   } else {
     as_polars_series(x)$sub(y)
   }) |>

--- a/R/s3-methods.R
+++ b/R/s3-methods.R
@@ -426,7 +426,7 @@ as.vector.RPolarsSeries = function(x, mode) x$to_vector()
 #' @export
 #' @rdname S3_as.character
 #' @examples
-#' s = pl$Series(c("foo", "barbaz"))
+#' s = as_polars_series(c("foo", "barbaz"))
 #' as.character(s)
 #' as.character(s, str_length = 3)
 as.character.RPolarsSeries = function(x, ..., str_length = NULL) {
@@ -475,7 +475,7 @@ print.RPolarsSeries = function(x, ...) {
 #' All objects must have the same datatype. Combining does not rechunk. Read more
 #' about R vectors, Series and chunks in \code{\link[polars]{docs_translations}}:
 #' @examples
-#' s = c(pl$Series(1:5), 3:1, NA_integer_)
+#' s = c(as_polars_series(1:5), 3:1, NA_integer_)
 #' s$chunk_lengths() # the series contain three unmerged chunks
 #' @export
 #' @rdname S3_c

--- a/R/series__series.R
+++ b/R/series__series.R
@@ -244,8 +244,9 @@ Series_struct = method_as_active_binding(\() series_make_sub_ns(self, expr_struc
 #' @param ... Treated as `values`, `name`, and `dtype` in order.
 #' In future versions, the order of the arguments will be changed to
 #' `pl$Series(name, values, dtype, ..., nan_to_null)` and `...` will be ignored.
-#' @param values any vector
-#' @param name Name of the Series. If `NULL`, an empty string is used.
+#' @param values Vector of base R types, or `NULL` (default).
+#' If `NULL`, empty Series is created.
+#' @param name Name of the Series. If `NULL` (default), an empty string is used.
 #' @param dtype One of [polars data type][pl_dtypes] or `NULL`.
 #' If not `NULL`, that data type is used to [cast][Expr_cast] the Series created from the vector
 #' to a specific data type internally.

--- a/R/series__series.R
+++ b/R/series__series.R
@@ -235,18 +235,20 @@ Series_str = method_as_active_binding(\() series_make_sub_ns(self, expr_str_make
 Series_struct = method_as_active_binding(\() series_make_sub_ns(self, expr_struct_make_sub_ns))
 
 
-# TODO: change the arguments to be match to Python Polars before 0.16.0
+# TODO: change the arguments in 0.17.0
 #' Create new Series
 #'
 #' This function is a simple way to convert basic types of vectors provided by base R to
 #' [the Series class object][Series_class].
 #' For converting more types properly, use the generic function [as_polars_series()].
+#' @param ... Treated as `values`, `name`, and `dtype` in order.
+#' In future versions, the order of the arguments will be changed to
+#' `pl$Series(name, values, dtype, ..., nan_to_null)` and `...` will be ignored.
 #' @param values any vector
 #' @param name Name of the Series. If `NULL`, an empty string is used.
 #' @param dtype One of [polars data type][pl_dtypes] or `NULL`.
 #' If not `NULL`, that data type is used to [cast][Expr_cast] the Series created from the vector
 #' to a specific data type internally.
-#' @param ... Ignored.
 #' @param nan_to_null If `TRUE`, `NaN` values contained in the Series are replaced to `null`.
 #' Using the [`$fill_nan()`][Expr_fill_nan] method internally.
 #' @return [Series][Series_class]
@@ -254,30 +256,46 @@ Series_struct = method_as_active_binding(\() series_make_sub_ns(self, expr_struc
 #' @seealso
 #' - [as_polars_series()]
 #' @examples
-#' # Constructing a Series by specifying name and values positionally:
-#' s = pl$Series(1:3, "a")
+#' # Constructing a Series by specifying name and values positionally (deprecated):
+#' s = suppressWarnings(pl$Series(1:3, "a"))
 #' s
 #'
 #' # Notice that the dtype is automatically inferred as a polars Int32:
 #' s$dtype
 #'
 #' # Constructing a Series with a specific dtype:
-#' s2 = pl$Series(1:3, "a", dtype = pl$Float32)
+#' s2 = pl$Series(values = 1:3, name = "a", dtype = pl$Float32)
 #' s2
 pl_Series = function(
-    values,
+    ...,
+    values = NULL,
     name = NULL,
     dtype = NULL,
-    ...,
     nan_to_null = FALSE) {
   uw = function(x) unwrap(x, "in pl$Series():")
+
+  if (!missing(...)) {
+    warning(
+      "The argument position of `pl$Series()` will be changed as of 0.17.0:\n",
+      "Until 0.17.0, the first argument corresponds to the values and the second argument to the name of the Series.\n",
+      "As of 0.17.0, the first argument will correspond to the name and the second argument to the values.\n",
+      " - 0.15.x: pl$Series(x, name, dtype, ..., nan_to_null)\n",
+      " - 0.17.0: pl$Series(name, values, dtype, ..., nan_to_null)\n",
+      "Since detecting the positional arguments now, use these arguments as `values`, `name` and `dtype`.\n",
+      "Use named arguments `values`, `name`, and `dtype` in `pl$Series()` instead of positional arguments to silence this warning."
+    )
+    dots = list(...)
+    values = values %||% dots[[1]]
+    if (length(dots) >= 2) name = name %||% dots[[2]]
+    if (length(dots) >= 3) dtype = dtype %||% dots[[3]]
+  }
 
   if (!is.null(dtype) && !isTRUE(is_polars_dtype(dtype))) {
     Err_plain("The dtype argument is not a valid Polars data type and cannot be converted into one.") |>
       uw()
   }
 
-  out = .pr$Series$new(values, name) |>
+  out = .pr$Series$new(name %||% "", values) |>
     uw()
 
   if (!is.null(dtype)) {

--- a/R/series__series.R
+++ b/R/series__series.R
@@ -276,13 +276,10 @@ pl_Series = function(
 
   if (!missing(...)) {
     warning(
-      "The argument position of `pl$Series()` will be changed as of 0.17.0:\n",
-      "Until 0.17.0, the first argument corresponds to the values and the second argument to the name of the Series.\n",
-      "As of 0.17.0, the first argument will correspond to the name and the second argument to the values.\n",
-      " - 0.15.x: pl$Series(x, name, dtype, ..., nan_to_null)\n",
-      " - 0.17.0: pl$Series(name, values, dtype, ..., nan_to_null)\n",
-      "Since detecting the positional arguments now, use these arguments as `values`, `name` and `dtype`.\n",
-      "Use named arguments `values`, `name`, and `dtype` in `pl$Series()` instead of positional arguments to silence this warning."
+      "`pl$Series()` will handle unnamed arguments differently as of 0.17.0:\n",
+      "- until 0.17.0, the first argument corresponds to the values and the second argument to the name of the Series.\n",
+      "- as of 0.17.0, the first argument will correspond to the name and the second argument to the values.\n",
+      "Use named arguments in `pl$Series()` or replace `pl$Series(<values>, <name>)` by `as_polars_series(<values>, <name>)` to silence this warning.\n"
     )
     dots = list(...)
     values = values %||% dots[[1]]

--- a/R/series__series.R
+++ b/R/series__series.R
@@ -93,7 +93,7 @@
 #'
 #' @examples
 #' # make a Series
-#' s = pl$Series(c(1:3, 1L))
+#' s = as_polars_series(c(1:3, 1L))
 #'
 #' # call an active binding
 #' s$shape
@@ -105,8 +105,8 @@
 #' s$cos()
 #'
 #' # use Expr method in subnamespaces
-#' pl$Series(list(3:1, 1:2, NULL))$list$first()
-#' pl$Series(c(1, NA, 2))$str$concat("-")
+#' as_polars_series(list(3:1, 1:2, NULL))$list$first()
+#' as_polars_series(c(1, NA, 2))$str$concat("-")
 #'
 #' s = pl$date_range(
 #'   as.Date("2024-02-18"), as.Date("2024-02-24"),
@@ -315,7 +315,7 @@ pl_Series = function(
 #' @rdname Series_print
 #' @return self
 #'
-#' @examples pl$Series(1:3)
+#' @examples as_polars_series(1:3)
 Series_print = function() {
   .pr$Series$print(self)
   invisible(self)
@@ -331,11 +331,11 @@ Series_print = function() {
 #' @seealso
 #' - [Arithmetic operators][S3_arithmetic]
 #' @examples
-#' pl$Series(1:3)$add(pl$Series(11:13))
-#' pl$Series(1:3)$add(11:13)
-#' pl$Series(1:3)$add(1L)
+#' as_polars_series(1:3)$add(as_polars_series(11:13))
+#' as_polars_series(1:3)$add(11:13)
+#' as_polars_series(1:3)$add(1L)
 #'
-#' pl$Series("a")$add("-z")
+#' as_polars_series("a")$add("-z")
 Series_add = function(other) {
   .pr$Series$add(self, as_polars_series(other))
 }
@@ -350,11 +350,11 @@ Series_add = function(other) {
 #' @seealso
 #' - [Arithmetic operators][S3_arithmetic]
 #' @examples
-#' pl$Series(1:3)$sub(11:13)
-#' pl$Series(1:3)$sub(pl$Series(11:13))
-#' pl$Series(1:3)$sub(1L)
-#' 1L - pl$Series(1:3)
-#' pl$Series(1:3) - 1L
+#' as_polars_series(1:3)$sub(11:13)
+#' as_polars_series(1:3)$sub(as_polars_series(11:13))
+#' as_polars_series(1:3)$sub(1L)
+#' 1L - as_polars_series(1:3)
+#' as_polars_series(1:3) - 1L
 Series_sub = function(other) {
   .pr$Series$sub(self, as_polars_series(other))
 }
@@ -367,9 +367,9 @@ Series_sub = function(other) {
 #' @seealso
 #' - [Arithmetic operators][S3_arithmetic]
 #' @examples
-#' pl$Series(1:3)$div(11:13)
-#' pl$Series(1:3)$div(pl$Series(11:13))
-#' pl$Series(1:3)$div(1L)
+#' as_polars_series(1:3)$div(11:13)
+#' as_polars_series(1:3)$div(as_polars_series(11:13))
+#' as_polars_series(1:3)$div(1L)
 Series_div = function(other) {
   .pr$Series$div(self, as_polars_series(other))
 }
@@ -382,9 +382,9 @@ Series_div = function(other) {
 #' @seealso
 #' - [Arithmetic operators][S3_arithmetic]
 #' @examples
-#' pl$Series(1:3)$floor_div(11:13)
-#' pl$Series(1:3)$floor_div(pl$Series(11:13))
-#' pl$Series(1:3)$floor_div(1L)
+#' as_polars_series(1:3)$floor_div(11:13)
+#' as_polars_series(1:3)$floor_div(as_polars_series(11:13))
+#' as_polars_series(1:3)$floor_div(1L)
 Series_floor_div = function(other) {
   self$to_frame()$select(pl$col(self$name)$floor_div(as_polars_series(other)))$to_series(0)
 }
@@ -397,9 +397,9 @@ Series_floor_div = function(other) {
 #' @seealso
 #' - [Arithmetic operators][S3_arithmetic]
 #' @examples
-#' pl$Series(1:3)$mul(11:13)
-#' pl$Series(1:3)$mul(pl$Series(11:13))
-#' pl$Series(1:3)$mul(1L)
+#' as_polars_series(1:3)$mul(11:13)
+#' as_polars_series(1:3)$mul(as_polars_series(11:13))
+#' as_polars_series(1:3)$mul(1L)
 Series_mul = function(other) {
   .pr$Series$mul(self, as_polars_series(other))
 }
@@ -412,9 +412,9 @@ Series_mul = function(other) {
 #' @seealso
 #' - [Arithmetic operators][S3_arithmetic]
 #' @examples
-#' pl$Series(1:4)$mod(2L)
-#' pl$Series(1:3)$mod(pl$Series(11:13))
-#' pl$Series(1:3)$mod(1L)
+#' as_polars_series(1:4)$mod(2L)
+#' as_polars_series(1:3)$mod(as_polars_series(11:13))
+#' as_polars_series(1:3)$mod(1L)
 Series_mod = function(other) {
   .pr$Series$rem(self, as_polars_series(other))
 }
@@ -447,10 +447,10 @@ Series_pow = function(exponent) {
 #' @return [Series][Series_class]
 #' @examples
 #' # We can either use `compare()`...
-#' pl$Series(1:5)$compare(pl$Series(c(1:3, NA_integer_, 10L)), op = "equal")
+#' as_polars_series(1:5)$compare(as_polars_series(c(1:3, NA_integer_, 10L)), op = "equal")
 #'
 #' # ... or the more classic way
-#' pl$Series(1:5) == pl$Series(c(1:3, NA_integer_, 10L))
+#' as_polars_series(1:5) == as_polars_series(c(1:3, NA_integer_, 10L))
 Series_compare = function(other, op) {
   other_s = as_polars_series(other)
   s_len = self$len()
@@ -502,7 +502,7 @@ Series_compare = function(other, op) {
 #' @inheritSection DataFrame_class Conversion to R data types considerations
 #' @examples
 #' # Series with non-list type
-#' series_vec = pl$Series(letters[1:3])
+#' series_vec = as_polars_series(letters[1:3])
 #'
 #' series_vec$to_r() # as vector because Series DataType is not list (is String)
 #' series_vec$to_list() # implicit call as.list(), convert to list
@@ -510,7 +510,7 @@ Series_compare = function(other, op) {
 #'
 #'
 #' # make a Series with nested lists
-#' series_list = pl$Series(
+#' series_list = as_polars_series(
 #'   list(
 #'     list(c(1:5, NA_integer_)),
 #'     list(1:2, NA_integer_)
@@ -543,7 +543,7 @@ Series_to_list = \(int64_conversion = polars_options()$int64_conversion) {
 #'
 #' @return DataFrame
 #' @examples
-#' pl$Series(iris$Species, name = "flower species")$value_counts()
+#' as_polars_series(iris$Species, name = "flower species")$value_counts()
 Series_value_counts = function(sort = TRUE, parallel = FALSE) {
   unwrap(.pr$Series$value_counts(self, sort, parallel), "in $value_counts():")
 }
@@ -560,12 +560,12 @@ Series_value_counts = function(sort = TRUE, parallel = FALSE) {
 #' @aliases apply
 #'
 #' @examples
-#' s = pl$Series(letters[1:5], "ltrs")
+#' s = as_polars_series(letters[1:5], "ltrs")
 #' f = \(x) paste(x, ":", as.integer(charToRaw(x)))
 #' s$map_elements(f, pl$String)
 #'
 #' # same as
-#' pl$Series(sapply(s$to_r(), f), s$name)
+#' as_polars_series(sapply(s$to_r(), f), s$name)
 Series_map_elements = function(
     fun, datatype = NULL, strict_return_type = TRUE, allow_fail_eval = FALSE) {
   .pr$Series$map_elements(
@@ -578,7 +578,7 @@ Series_map_elements = function(
 #'
 #' @return A numeric value
 #' @examples
-#' pl$Series(1:10)$len()
+#' as_polars_series(1:10)$len()
 Series_len = use_extendr_wrapper
 
 #' Lengths of Series memory chunks
@@ -587,7 +587,7 @@ Series_len = use_extendr_wrapper
 #' the output is equal to the length of the full Series.
 #'
 #' @examples
-#' chunked_series = c(pl$Series(1:3), pl$Series(1:10))
+#' chunked_series = c(as_polars_series(1:3), as_polars_series(1:10))
 #' chunked_series$chunk_lengths()
 Series_chunk_lengths = use_extendr_wrapper
 
@@ -606,9 +606,9 @@ Series_chunk_lengths = use_extendr_wrapper
 #' @return [Series][Series_class]
 #' @examplesIf requireNamespace("withr", quietly = TRUE)
 #' # default immutable behavior, s_imut and s_imut_copy stay the same
-#' s_imut = pl$Series(1:3)
+#' s_imut = as_polars_series(1:3)
 #' s_imut_copy = s_imut
-#' s_new = s_imut$append(pl$Series(1:3))
+#' s_new = s_imut$append(as_polars_series(1:3))
 #' s_new
 #'
 #' # the original Series didn't change
@@ -619,9 +619,9 @@ Series_chunk_lengths = use_extendr_wrapper
 #' withr::with_options(
 #'   list(polars.strictly_immutable = FALSE),
 #'   {
-#'     s_mut = pl$Series(1:3)
+#'     s_mut = as_polars_series(1:3)
 #'     s_mut_copy = s_mut
-#'     s_new = s_mut$append(pl$Series(1:3), immutable = FALSE)
+#'     s_new = s_mut$append(as_polars_series(1:3), immutable = FALSE)
 #'     print(s_new)
 #'
 #'     # the original Series also changed since it's mutable
@@ -650,14 +650,14 @@ Series_append = function(other, immutable = TRUE) {
 #' @usage Series_alias(name)
 #' @return [Series][Series_class]
 #' @examples
-#' pl$Series(1:3, name = "alice")$alias("bob")
+#' as_polars_series(1:3, name = "alice")$alias("bob")
 Series_alias = use_extendr_wrapper
 
 #' Reduce boolean Series with ANY
 #'
 #' @return A logical value
 #' @examples
-#' pl$Series(c(TRUE, FALSE, NA))$any()
+#' as_polars_series(c(TRUE, FALSE, NA))$any()
 Series_any = function() {
   unwrap(.pr$Series$any(self), "in $any():")
 }
@@ -666,7 +666,7 @@ Series_any = function() {
 #'
 #' @return A logical value
 #' @examples
-#' pl$Series(c(TRUE, TRUE, NA))$all()
+#' as_polars_series(c(TRUE, TRUE, NA))$all()
 Series_all = function() {
   unwrap(.pr$Series$all(self), "in $all():")
 }
@@ -677,7 +677,7 @@ Series_all = function() {
 #'
 #' @return A numeric value
 #' @examples
-#' pl$Series(c(5, 1))$arg_max()
+#' as_polars_series(c(5, 1))$arg_max()
 Series_arg_max = use_extendr_wrapper
 
 #' Index of min value
@@ -686,7 +686,7 @@ Series_arg_max = use_extendr_wrapper
 #'
 #' @return A numeric value
 #' @examples
-#' pl$Series(c(5, 1))$arg_min()
+#' as_polars_series(c(5, 1))$arg_min()
 Series_arg_min = use_extendr_wrapper
 
 
@@ -699,7 +699,7 @@ Series_arg_min = use_extendr_wrapper
 #'
 #' @return [Series][Series_class]
 #' @examples
-#' df1 = pl$Series(1:10)
+#' df1 = as_polars_series(1:10)
 #'
 #' # Make a function to take a Series, add an attribute, and return a Series
 #' give_attr = function(data) {
@@ -717,7 +717,7 @@ Series_arg_min = use_extendr_wrapper
 #'   attr(data, "created_on") = "2024-01-29"
 #'   data
 #' }
-#' df1 = pl$Series(1:10)
+#' df1 = as_polars_series(1:10)
 #' df2 = give_attr(df1)
 #'
 #' # now, the original Series doesn't get this attribute
@@ -732,9 +732,9 @@ Series_clone = use_extendr_wrapper
 #' The Dtypes Int8, UInt8, Int16 and UInt16 are cast to Int64 before summing to
 #' prevent overflow issues.
 #' @examples
-#' pl$Series(c(1:2, NA, 3, 5))$sum() # a NA is dropped always
-#' pl$Series(c(1:2, NA, 3, NaN, 4, Inf))$sum() # NaN poisons the result
-#' pl$Series(c(1:2, 3, Inf, 4, -Inf, 5))$sum() # Inf-Inf is NaN
+#' as_polars_series(c(1:2, NA, 3, 5))$sum() # a NA is dropped always
+#' as_polars_series(c(1:2, NA, 3, NaN, 4, Inf))$sum() # NaN poisons the result
+#' as_polars_series(c(1:2, 3, Inf, 4, -Inf, 5))$sum() # Inf-Inf is NaN
 Series_sum = function() {
   unwrap(.pr$Series$sum(self), "in $sum():")
 }
@@ -743,9 +743,9 @@ Series_sum = function() {
 #'
 #' @inherit Series_sum details return
 #' @examples
-#' pl$Series(c(1:2, NA, 3, 5))$mean() # a NA is dropped always
-#' pl$Series(c(1:2, NA, 3, NaN, 4, Inf))$mean() # NaN carries / poisons
-#' pl$Series(c(1:2, 3, Inf, 4, -Inf, 5))$mean() # Inf-Inf is NaN
+#' as_polars_series(c(1:2, NA, 3, 5))$mean() # a NA is dropped always
+#' as_polars_series(c(1:2, NA, 3, NaN, 4, Inf))$mean() # NaN carries / poisons
+#' as_polars_series(c(1:2, 3, Inf, 4, -Inf, 5))$mean() # Inf-Inf is NaN
 Series_mean = function() {
   unwrap(.pr$Series$mean(self), "in $mean():")
 }
@@ -754,9 +754,9 @@ Series_mean = function() {
 #'
 #' @inherit Series_sum details return
 #' @examples
-#' pl$Series(c(1:2, NA, 3, 5))$median() # a NA is dropped always
-#' pl$Series(c(1:2, NA, 3, NaN, 4, Inf))$median() # NaN carries / poisons
-#' pl$Series(c(1:2, 3, Inf, 4, -Inf, 5))$median() # Inf-Inf is NaN
+#' as_polars_series(c(1:2, NA, 3, 5))$median() # a NA is dropped always
+#' as_polars_series(c(1:2, NA, 3, NaN, 4, Inf))$median() # NaN carries / poisons
+#' as_polars_series(c(1:2, 3, Inf, 4, -Inf, 5))$median() # Inf-Inf is NaN
 Series_median = function() {
   unwrap(.pr$Series$median(self), "in $median():")
 }
@@ -765,9 +765,9 @@ Series_median = function() {
 #'
 #' @inherit Series_sum details return
 #' @examples
-#' pl$Series(c(1:2, NA, 3, 5))$max() # a NA is dropped always
-#' pl$Series(c(1:2, NA, 3, NaN, 4, Inf))$max() # NaN carries / poisons
-#' pl$Series(c(1:2, 3, Inf, 4, -Inf, 5))$max() # Inf-Inf is NaN
+#' as_polars_series(c(1:2, NA, 3, 5))$max() # a NA is dropped always
+#' as_polars_series(c(1:2, NA, 3, NaN, 4, Inf))$max() # NaN carries / poisons
+#' as_polars_series(c(1:2, 3, Inf, 4, -Inf, 5))$max() # Inf-Inf is NaN
 Series_max = function() {
   unwrap(.pr$Series$max(self), "in $max():")
 }
@@ -776,9 +776,9 @@ Series_max = function() {
 #'
 #' @inherit Series_sum details return
 #' @examples
-#' pl$Series(c(1:2, NA, 3, 5))$min() # a NA is dropped always
-#' pl$Series(c(1:2, NA, 3, NaN, 4, Inf))$min() # NaN carries / poisons
-#' pl$Series(c(1:2, 3, Inf, 4, -Inf, 5))$min() # Inf-Inf is NaN
+#' as_polars_series(c(1:2, NA, 3, 5))$min() # a NA is dropped always
+#' as_polars_series(c(1:2, NA, 3, NaN, 4, Inf))$min() # NaN carries / poisons
+#' as_polars_series(c(1:2, 3, Inf, 4, -Inf, 5))$min() # Inf-Inf is NaN
 Series_min = function() {
   unwrap(.pr$Series$min(self), "in $min():")
 }
@@ -788,7 +788,7 @@ Series_min = function() {
 #' @inheritParams DataFrame_var
 #' @inherit Series_sum return
 #' @examples
-#' pl$Series(1:10)$var()
+#' as_polars_series(1:10)$var()
 Series_var = function(ddof = 1) {
   unwrap(.pr$Series$var(self, ddof), "in $var():")
 }
@@ -798,7 +798,7 @@ Series_var = function(ddof = 1) {
 #' @inheritParams DataFrame_var
 #' @inherit Series_sum return
 #' @examples
-#' pl$Series(1:10)$std()
+#' as_polars_series(1:10)$std()
 Series_std = function(ddof = 1) {
   unwrap(.pr$Series$std(self, ddof), "in $std():")
 }
@@ -810,7 +810,7 @@ Series_std = function(ddof = 1) {
 #' Use [`$set_sorted()`][Series_set_sorted] to add a "sorted" flag to the Series
 #' that could be used for faster operations later on.
 #' @examples
-#' pl$Series(1:4)$sort()$is_sorted()
+#' as_polars_series(1:4)$sort()$is_sorted()
 Series_is_sorted = function(descending = FALSE) {
   .pr$Series$is_sorted(self, descending) |> unwrap("in $is_sorted()")
 }
@@ -829,7 +829,7 @@ Series_is_sorted = function(descending = FALSE) {
 #'
 #' @return A [Series][Series_class] with a flag
 #' @examples
-#' s = pl$Series(1:4)$set_sorted()
+#' s = as_polars_series(1:4)$set_sorted()
 #' s$flags
 Series_set_sorted = function(descending = FALSE, in_place = FALSE) {
   if (in_place && polars_options()$strictly_immutable) {
@@ -856,8 +856,8 @@ Series_set_sorted = function(descending = FALSE, in_place = FALSE) {
 #' @return [Series][Series_class]
 #'
 #' @examples
-#' pl$Series(c(1.5, NA, 1, NaN, Inf, -Inf))$sort()
-#' pl$Series(c(1.5, NA, 1, NaN, Inf, -Inf))$sort(nulls_last = TRUE)
+#' as_polars_series(c(1.5, NA, 1, NaN, Inf, -Inf))$sort()
+#' as_polars_series(c(1.5, NA, 1, NaN, Inf, -Inf))$sort(nulls_last = TRUE)
 Series_sort = function(descending = FALSE, nulls_last = FALSE, in_place = FALSE) {
   if (in_place && polars_options()$strictly_immutable) {
     stop(paste(
@@ -877,9 +877,9 @@ Series_sort = function(descending = FALSE, nulls_last = FALSE, in_place = FALSE)
 #'
 #' @examples
 #' # default will be a DataFrame with empty name
-#' pl$Series(1:4)$to_frame()
+#' as_polars_series(1:4)$to_frame()
 #'
-#' pl$Series(1:4, "bob")$to_frame()
+#' as_polars_series(1:4, "bob")$to_frame()
 Series_to_frame = function() {
   unwrap(.pr$Series$to_frame(self), "in $to_frame():")
 }
@@ -896,18 +896,18 @@ Series_to_frame = function() {
 #'
 #' @return A logical value
 #' @examples
-#' pl$Series(1:4)$equals(pl$Series(1:4))
+#' as_polars_series(1:4)$equals(as_polars_series(1:4))
 #'
 #' # names are different
-#' pl$Series(1:4, "bob")$equals(pl$Series(1:4))
+#' as_polars_series(1:4, "bob")$equals(as_polars_series(1:4))
 #'
 #' # nulls are different by default
-#' pl$Series(c(1:4, NA))$equals(pl$Series(c(1:4, NA)))
-#' pl$Series(c(1:4, NA))$equals(pl$Series(c(1:4, NA)), null_equal = TRUE)
+#' as_polars_series(c(1:4, NA))$equals(as_polars_series(c(1:4, NA)))
+#' as_polars_series(c(1:4, NA))$equals(as_polars_series(c(1:4, NA)), null_equal = TRUE)
 #'
 #' # datatypes are ignored by default
-#' pl$Series(1:4)$cast(pl$Int16)$equals(pl$Series(1:4))
-#' pl$Series(1:4)$cast(pl$Int16)$equals(pl$Series(1:4), strict = TRUE)
+#' as_polars_series(1:4)$cast(pl$Int16)$equals(as_polars_series(1:4))
+#' as_polars_series(1:4)$cast(pl$Int16)$equals(as_polars_series(1:4), strict = TRUE)
 Series_equals = function(other, null_equal = FALSE, strict = FALSE) {
   .pr$Series$equals(self, other, null_equal, strict)
 }
@@ -921,7 +921,7 @@ Series_equals = function(other, null_equal = FALSE, strict = FALSE) {
 #'
 #' @return [Series][Series_class]
 #' @examples
-#' pl$Series(1:4, "bob")$rename("alice")
+#' as_polars_series(1:4, "bob")$rename("alice")
 Series_rename = function(name, in_place = FALSE) {
   if (identical(self$name, name)) {
     return(self)
@@ -953,7 +953,7 @@ Series_rename = function(name, in_place = FALSE) {
 #' @return [Series][Series_class]
 #'
 #' @examples
-#' pl$Series(1:2, "bob")$rep(3)
+#' as_polars_series(1:2, "bob")$rep(3)
 Series_rep = function(n, rechunk = TRUE) {
   if (!is.numeric(n)) stop("n must be numeric")
   if (!is_scalar_bool(rechunk)) stop("rechunk must be a bool")
@@ -969,8 +969,8 @@ in_DataType = function(l, rs) any(sapply(rs, function(r) l == r))
 #' @return A logical value
 #'
 #' @examples
-#' pl$Series(1:4)$is_numeric()
-#' pl$Series(c("a", "b", "c"))$is_numeric()
+#' as_polars_series(1:4)$is_numeric()
+#' as_polars_series(c("a", "b", "c"))$is_numeric()
 #' pl$numeric_dtypes
 Series_is_numeric = function() {
   in_DataType(self$dtype, pl$numeric_dtypes)
@@ -981,7 +981,7 @@ Series_is_numeric = function() {
 #'
 #' @return [Expr][Expr_class]
 #' @examples
-#' pl$Series(list(1:1, 1:2, 1:3, 1:4))$
+#' as_polars_series(list(1:1, 1:2, 1:3, 1:4))$
 #'   print()$
 #'   to_lit()$
 #'   list$len()$
@@ -996,7 +996,7 @@ Series_to_lit = function() {
 #'
 #' @return A numeric value
 #' @examples
-#' pl$Series(c(1, 2, 1, 4, 4, 1, 5))$n_unique()
+#' as_polars_series(c(1, 2, 1, 4, 4, 1, 5))$n_unique()
 Series_n_unique = function() {
   unwrap(.pr$Series$n_unique(self), "in $n_unique():")
 }

--- a/man/DataFrame_class.Rd
+++ b/man/DataFrame_class.Rd
@@ -103,7 +103,7 @@ explicitly specify the time zone before conversion.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{# Due to daylight savings, clocks were turned forward 1 hour on Sunday, March 8, 2020, 2:00:00 am
 # so this particular date-time doesn't exist
-non_existent_time = pl$Series("2020-03-08 02:00:00")$str$strptime(pl$Datetime(), "\%F \%T")
+non_existent_time = as_polars_series("2020-03-08 02:00:00")$str$strptime(pl$Datetime(), "\%F \%T")
 
 withr::with_envvar(
   new = c(TZ = "America/New_York"),

--- a/man/DataFrame_group_by_dynamic.Rd
+++ b/man/DataFrame_group_by_dynamic.Rd
@@ -151,7 +151,9 @@ df$group_by_dynamic("time", every = "1h", closed = "both")$agg(
 )
 
 # Dynamic group bys can also be combined with grouping on normal keys
-df = df$with_columns(groups = pl$Series(c("a", "a", "a", "b", "b", "a", "a")))
+df = df$with_columns(
+  groups = as_polars_series(c("a", "a", "a", "b", "b", "a", "a"))
+)
 df
 
 df$group_by_dynamic(

--- a/man/DataFrame_to_data_frame.Rd
+++ b/man/DataFrame_to_data_frame.Rd
@@ -46,7 +46,7 @@ explicitly specify the time zone before conversion.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{# Due to daylight savings, clocks were turned forward 1 hour on Sunday, March 8, 2020, 2:00:00 am
 # so this particular date-time doesn't exist
-non_existent_time = pl$Series("2020-03-08 02:00:00")$str$strptime(pl$Datetime(), "\%F \%T")
+non_existent_time = as_polars_series("2020-03-08 02:00:00")$str$strptime(pl$Datetime(), "\%F \%T")
 
 withr::with_envvar(
   new = c(TZ = "America/New_York"),

--- a/man/DataFrame_to_list.Rd
+++ b/man/DataFrame_to_list.Rd
@@ -56,7 +56,7 @@ explicitly specify the time zone before conversion.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{# Due to daylight savings, clocks were turned forward 1 hour on Sunday, March 8, 2020, 2:00:00 am
 # so this particular date-time doesn't exist
-non_existent_time = pl$Series("2020-03-08 02:00:00")$str$strptime(pl$Datetime(), "\%F \%T")
+non_existent_time = as_polars_series("2020-03-08 02:00:00")$str$strptime(pl$Datetime(), "\%F \%T")
 
 withr::with_envvar(
   new = c(TZ = "America/New_York"),

--- a/man/DynamicGroupBy_agg.Rd
+++ b/man/DynamicGroupBy_agg.Rd
@@ -53,7 +53,9 @@ df$group_by_dynamic("time", every = "1h", closed = "both")$agg(
 )
 
 # Dynamic group bys can also be combined with grouping on normal keys
-df = df$with_columns(groups = pl$Series(c("a", "a", "a", "b", "b", "a", "a")))
+df = df$with_columns(
+  groups = as_polars_series(c("a", "a", "a", "b", "b", "a", "a"))
+)
 df
 
 df$group_by_dynamic(

--- a/man/ExprStr_strptime.Rd
+++ b/man/ExprStr_strptime.Rd
@@ -60,7 +60,7 @@ If no fractional second component is found then the default is \code{"us"} (micr
 }
 \examples{
 # Dealing with a consistent format
-s = pl$Series(c("2020-01-01 01:00Z", "2020-01-01 02:00Z"))
+s = as_polars_series(c("2020-01-01 01:00Z", "2020-01-01 02:00Z"))
 
 s$str$strptime(pl$Datetime(), "\%Y-\%m-\%d \%H:\%M\%#z")
 
@@ -68,10 +68,10 @@ s$str$strptime(pl$Datetime(), "\%Y-\%m-\%d \%H:\%M\%#z")
 s$str$strptime(pl$Datetime())
 
 # Datetime with timezone is interpreted as UTC timezone
-pl$Series("2020-01-01T01:00:00+09:00")$str$strptime(pl$Datetime())
+as_polars_series("2020-01-01T01:00:00+09:00")$str$strptime(pl$Datetime())
 
 # Dealing with different formats.
-s = pl$Series(
+s = as_polars_series(
   c(
     "2021-04-22",
     "2022-01-04 00:00:00",
@@ -91,7 +91,7 @@ s$to_frame()$select(
 )
 
 # Ignore invalid time
-s = pl$Series(
+s = as_polars_series(
   c(
     "2023-01-01 11:22:33 -0100",
     "2023-01-01 11:22:33 +0300",

--- a/man/ExprStr_to_date.Rd
+++ b/man/ExprStr_to_date.Rd
@@ -41,12 +41,12 @@ conversion.}
 Convert a String column into a Date column
 }
 \examples{
-s = pl$Series(c("2020/01/01", "2020/02/01", "2020/03/01"))
+s = as_polars_series(c("2020/01/01", "2020/02/01", "2020/03/01"))
 
 s$str$to_date()
 
 # by default, this errors if some values cannot be converted
-s = pl$Series(c("2020/01/01", "2020 02 01", "2020-03-01"))
+s = as_polars_series(c("2020/01/01", "2020 02 01", "2020-03-01"))
 try(s$str$to_date())
 s$str$to_date(strict = FALSE)
 }

--- a/man/ExprStr_to_datetime.Rd
+++ b/man/ExprStr_to_datetime.Rd
@@ -57,7 +57,7 @@ conversion.}
 Convert a String column into a Datetime column
 }
 \examples{
-s = pl$Series(c("2020-01-01 01:00Z", "2020-01-01 02:00Z"))
+s = as_polars_series(c("2020-01-01 01:00Z", "2020-01-01 02:00Z"))
 
 s$str$to_datetime("\%Y-\%m-\%d \%H:\%M\%#z")
 s$str$to_datetime(time_unit = "ms")

--- a/man/ExprStr_to_time.Rd
+++ b/man/ExprStr_to_time.Rd
@@ -35,7 +35,7 @@ conversion.}
 Convert a String column into a Time column
 }
 \examples{
-s = pl$Series(c("01:00", "02:00", "03:00"))
+s = as_polars_series(c("01:00", "02:00", "03:00"))
 
 s$str$to_time("\%H:\%M")
 }

--- a/man/LazyFrame_class.Rd
+++ b/man/LazyFrame_class.Rd
@@ -73,7 +73,7 @@ explicitly specify the time zone before conversion.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{# Due to daylight savings, clocks were turned forward 1 hour on Sunday, March 8, 2020, 2:00:00 am
 # so this particular date-time doesn't exist
-non_existent_time = pl$Series("2020-03-08 02:00:00")$str$strptime(pl$Datetime(), "\%F \%T")
+non_existent_time = as_polars_series("2020-03-08 02:00:00")$str$strptime(pl$Datetime(), "\%F \%T")
 
 withr::with_envvar(
   new = c(TZ = "America/New_York"),

--- a/man/LazyFrame_group_by_dynamic.Rd
+++ b/man/LazyFrame_group_by_dynamic.Rd
@@ -155,7 +155,9 @@ lf$group_by_dynamic("time", every = "1h", closed = "both")$agg(
 )$collect()
 
 # Dynamic group bys can also be combined with grouping on normal keys
-lf = lf$with_columns(groups = pl$Series(c("a", "a", "a", "b", "b", "a", "a")))
+lf = lf$with_columns(
+  groups = as_polars_series(c("a", "a", "a", "b", "b", "a", "a"))
+)
 lf$collect()
 
 lf$group_by_dynamic(

--- a/man/S3_arithmetic.Rd
+++ b/man/S3_arithmetic.Rd
@@ -72,9 +72,9 @@ tryCatch(
   error = function(e) e
 )
 
-pl$Series(5) + 10
-+pl$Series(5)
--pl$Series(5)
+as_polars_series(5) + 10
++as_polars_series(5)
+-as_polars_series(5)
 }
 \seealso{
 \itemize{

--- a/man/S3_as.character.Rd
+++ b/man/S3_as.character.Rd
@@ -18,7 +18,7 @@ will be formatted to a string of this length.}
 Convert to a character vector
 }
 \examples{
-s = pl$Series(c("foo", "barbaz"))
+s = as_polars_series(c("foo", "barbaz"))
 as.character(s)
 as.character(s, str_length = 3)
 }

--- a/man/S3_as.data.frame.Rd
+++ b/man/S3_as.data.frame.Rd
@@ -97,7 +97,7 @@ explicitly specify the time zone before conversion.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{# Due to daylight savings, clocks were turned forward 1 hour on Sunday, March 8, 2020, 2:00:00 am
 # so this particular date-time doesn't exist
-non_existent_time = pl$Series("2020-03-08 02:00:00")$str$strptime(pl$Datetime(), "\%F \%T")
+non_existent_time = as_polars_series("2020-03-08 02:00:00")$str$strptime(pl$Datetime(), "\%F \%T")
 
 withr::with_envvar(
   new = c(TZ = "America/New_York"),

--- a/man/S3_as.vector.Rd
+++ b/man/S3_as.vector.Rd
@@ -33,7 +33,7 @@ explicitly specify the time zone before conversion.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{# Due to daylight savings, clocks were turned forward 1 hour on Sunday, March 8, 2020, 2:00:00 am
 # so this particular date-time doesn't exist
-non_existent_time = pl$Series("2020-03-08 02:00:00")$str$strptime(pl$Datetime(), "\%F \%T")
+non_existent_time = as_polars_series("2020-03-08 02:00:00")$str$strptime(pl$Datetime(), "\%F \%T")
 
 withr::with_envvar(
   new = c(TZ = "America/New_York"),

--- a/man/S3_c.Rd
+++ b/man/S3_c.Rd
@@ -22,6 +22,6 @@ All objects must have the same datatype. Combining does not rechunk. Read more
 about R vectors, Series and chunks in \code{\link[polars]{docs_translations}}:
 }
 \examples{
-s = c(pl$Series(1:5), 3:1, NA_integer_)
+s = c(as_polars_series(1:5), 3:1, NA_integer_)
 s$chunk_lengths() # the series contain three unmerged chunks
 }

--- a/man/Series_add.Rd
+++ b/man/Series_add.Rd
@@ -17,11 +17,11 @@ Converted to \link[=Series_class]{Series} by \code{\link[=as_polars_series]{as_p
 Method equivalent of addition operator \code{series + other}.
 }
 \examples{
-pl$Series(1:3)$add(pl$Series(11:13))
-pl$Series(1:3)$add(11:13)
-pl$Series(1:3)$add(1L)
+as_polars_series(1:3)$add(as_polars_series(11:13))
+as_polars_series(1:3)$add(11:13)
+as_polars_series(1:3)$add(1L)
 
-pl$Series("a")$add("-z")
+as_polars_series("a")$add("-z")
 }
 \seealso{
 \itemize{

--- a/man/Series_alias.Rd
+++ b/man/Series_alias.Rd
@@ -16,5 +16,5 @@ Series_alias(name)
 Change name of Series
 }
 \examples{
-pl$Series(1:3, name = "alice")$alias("bob")
+as_polars_series(1:3, name = "alice")$alias("bob")
 }

--- a/man/Series_all.Rd
+++ b/man/Series_all.Rd
@@ -13,5 +13,5 @@ A logical value
 Reduce Boolean Series with ALL
 }
 \examples{
-pl$Series(c(TRUE, TRUE, NA))$all()
+as_polars_series(c(TRUE, TRUE, NA))$all()
 }

--- a/man/Series_any.Rd
+++ b/man/Series_any.Rd
@@ -13,5 +13,5 @@ A logical value
 Reduce boolean Series with ANY
 }
 \examples{
-pl$Series(c(TRUE, FALSE, NA))$any()
+as_polars_series(c(TRUE, FALSE, NA))$any()
 }

--- a/man/Series_append.Rd
+++ b/man/Series_append.Rd
@@ -27,9 +27,9 @@ and cloning Polars Series is a cheap operation.
 \examples{
 \dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 # default immutable behavior, s_imut and s_imut_copy stay the same
-s_imut = pl$Series(1:3)
+s_imut = as_polars_series(1:3)
 s_imut_copy = s_imut
-s_new = s_imut$append(pl$Series(1:3))
+s_new = s_imut$append(as_polars_series(1:3))
 s_new
 
 # the original Series didn't change
@@ -40,9 +40,9 @@ s_imut_copy
 withr::with_options(
   list(polars.strictly_immutable = FALSE),
   {
-    s_mut = pl$Series(1:3)
+    s_mut = as_polars_series(1:3)
     s_mut_copy = s_mut
-    s_new = s_mut$append(pl$Series(1:3), immutable = FALSE)
+    s_new = s_mut$append(as_polars_series(1:3), immutable = FALSE)
     print(s_new)
 
     # the original Series also changed since it's mutable

--- a/man/Series_arg_max.Rd
+++ b/man/Series_arg_max.Rd
@@ -13,5 +13,5 @@ A numeric value
 Note that this is 0-indexed.
 }
 \examples{
-pl$Series(c(5, 1))$arg_max()
+as_polars_series(c(5, 1))$arg_max()
 }

--- a/man/Series_arg_min.Rd
+++ b/man/Series_arg_min.Rd
@@ -13,5 +13,5 @@ A numeric value
 Note that this is 0-indexed.
 }
 \examples{
-pl$Series(c(5, 1))$arg_min()
+as_polars_series(c(5, 1))$arg_min()
 }

--- a/man/Series_chunk_lengths.Rd
+++ b/man/Series_chunk_lengths.Rd
@@ -14,6 +14,6 @@ the output is equal to the length of the full Series.
 Lengths of Series memory chunks
 }
 \examples{
-chunked_series = c(pl$Series(1:3), pl$Series(1:10))
+chunked_series = c(as_polars_series(1:3), as_polars_series(1:10))
 chunked_series$chunk_lengths()
 }

--- a/man/Series_class.Rd
+++ b/man/Series_class.Rd
@@ -125,7 +125,7 @@ explicitly specify the time zone before conversion.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{# Due to daylight savings, clocks were turned forward 1 hour on Sunday, March 8, 2020, 2:00:00 am
 # so this particular date-time doesn't exist
-non_existent_time = pl$Series("2020-03-08 02:00:00")$str$strptime(pl$Datetime(), "\%F \%T")
+non_existent_time = as_polars_series("2020-03-08 02:00:00")$str$strptime(pl$Datetime(), "\%F \%T")
 
 withr::with_envvar(
   new = c(TZ = "America/New_York"),

--- a/man/Series_class.Rd
+++ b/man/Series_class.Rd
@@ -152,7 +152,7 @@ withr::with_envvar(
 
 \examples{
 # make a Series
-s = pl$Series(c(1:3, 1L))
+s = as_polars_series(c(1:3, 1L))
 
 # call an active binding
 s$shape
@@ -164,8 +164,8 @@ s$sort()$flags
 s$cos()
 
 # use Expr method in subnamespaces
-pl$Series(list(3:1, 1:2, NULL))$list$first()
-pl$Series(c(1, NA, 2))$str$concat("-")
+as_polars_series(list(3:1, 1:2, NULL))$list$first()
+as_polars_series(c(1, NA, 2))$str$concat("-")
 
 s = pl$date_range(
   as.Date("2024-02-18"), as.Date("2024-02-24"),

--- a/man/Series_clone.Rd
+++ b/man/Series_clone.Rd
@@ -16,7 +16,7 @@ immutable. Any modification of a \code{Series} should lead to a clone anyways, b
 this can be useful when dealing with attributes (see examples).
 }
 \examples{
-df1 = pl$Series(1:10)
+df1 = as_polars_series(1:10)
 
 # Make a function to take a Series, add an attribute, and return a Series
 give_attr = function(data) {
@@ -34,7 +34,7 @@ give_attr = function(data) {
   attr(data, "created_on") = "2024-01-29"
   data
 }
-df1 = pl$Series(1:10)
+df1 = as_polars_series(1:10)
 df2 = give_attr(df1)
 
 # now, the original Series doesn't get this attribute

--- a/man/Series_compare.Rd
+++ b/man/Series_compare.Rd
@@ -42,8 +42,8 @@ Check the (in)equality of two Series.
 }
 \examples{
 # We can either use `compare()`...
-pl$Series(1:5)$compare(pl$Series(c(1:3, NA_integer_, 10L)), op = "equal")
+as_polars_series(1:5)$compare(as_polars_series(c(1:3, NA_integer_, 10L)), op = "equal")
 
 # ... or the more classic way
-pl$Series(1:5) == pl$Series(c(1:3, NA_integer_, 10L))
+as_polars_series(1:5) == as_polars_series(c(1:3, NA_integer_, 10L))
 }

--- a/man/Series_div.Rd
+++ b/man/Series_div.Rd
@@ -17,9 +17,9 @@ Converted to \link[=Series_class]{Series} by \code{\link[=as_polars_series]{as_p
 Method equivalent of division operator \code{series / other}.
 }
 \examples{
-pl$Series(1:3)$div(11:13)
-pl$Series(1:3)$div(pl$Series(11:13))
-pl$Series(1:3)$div(1L)
+as_polars_series(1:3)$div(11:13)
+as_polars_series(1:3)$div(as_polars_series(11:13))
+as_polars_series(1:3)$div(1L)
 }
 \seealso{
 \itemize{

--- a/man/Series_equals.Rd
+++ b/man/Series_equals.Rd
@@ -22,16 +22,16 @@ A logical value
 This checks whether two Series are equal in values and in their name.
 }
 \examples{
-pl$Series(1:4)$equals(pl$Series(1:4))
+as_polars_series(1:4)$equals(as_polars_series(1:4))
 
 # names are different
-pl$Series(1:4, "bob")$equals(pl$Series(1:4))
+as_polars_series(1:4, "bob")$equals(as_polars_series(1:4))
 
 # nulls are different by default
-pl$Series(c(1:4, NA))$equals(pl$Series(c(1:4, NA)))
-pl$Series(c(1:4, NA))$equals(pl$Series(c(1:4, NA)), null_equal = TRUE)
+as_polars_series(c(1:4, NA))$equals(as_polars_series(c(1:4, NA)))
+as_polars_series(c(1:4, NA))$equals(as_polars_series(c(1:4, NA)), null_equal = TRUE)
 
 # datatypes are ignored by default
-pl$Series(1:4)$cast(pl$Int16)$equals(pl$Series(1:4))
-pl$Series(1:4)$cast(pl$Int16)$equals(pl$Series(1:4), strict = TRUE)
+as_polars_series(1:4)$cast(pl$Int16)$equals(as_polars_series(1:4))
+as_polars_series(1:4)$cast(pl$Int16)$equals(as_polars_series(1:4), strict = TRUE)
 }

--- a/man/Series_floor_div.Rd
+++ b/man/Series_floor_div.Rd
@@ -17,9 +17,9 @@ Converted to \link[=Series_class]{Series} by \code{\link[=as_polars_series]{as_p
 Method equivalent of floor division operator \code{series \%/\% other}.
 }
 \examples{
-pl$Series(1:3)$floor_div(11:13)
-pl$Series(1:3)$floor_div(pl$Series(11:13))
-pl$Series(1:3)$floor_div(1L)
+as_polars_series(1:3)$floor_div(11:13)
+as_polars_series(1:3)$floor_div(as_polars_series(11:13))
+as_polars_series(1:3)$floor_div(1L)
 }
 \seealso{
 \itemize{

--- a/man/Series_is_numeric.Rd
+++ b/man/Series_is_numeric.Rd
@@ -13,7 +13,7 @@ A logical value
 This checks whether the Series DataType is in \code{pl$numeric_dtypes}.
 }
 \examples{
-pl$Series(1:4)$is_numeric()
-pl$Series(c("a", "b", "c"))$is_numeric()
+as_polars_series(1:4)$is_numeric()
+as_polars_series(c("a", "b", "c"))$is_numeric()
 pl$numeric_dtypes
 }

--- a/man/Series_is_sorted.Rd
+++ b/man/Series_is_sorted.Rd
@@ -16,7 +16,7 @@ A logical value
 Check if the Series is sorted
 }
 \examples{
-pl$Series(1:4)$sort()$is_sorted()
+as_polars_series(1:4)$sort()$is_sorted()
 }
 \seealso{
 Use \code{\link[=Series_set_sorted]{$set_sorted()}} to add a "sorted" flag to the Series

--- a/man/Series_len.Rd
+++ b/man/Series_len.Rd
@@ -13,5 +13,5 @@ A numeric value
 Length of a Series
 }
 \examples{
-pl$Series(1:10)$len()
+as_polars_series(1:10)$len()
 }

--- a/man/Series_map_elements.Rd
+++ b/man/Series_map_elements.Rd
@@ -28,11 +28,11 @@ Series_map_elements(
 About as slow as regular non-vectorized R. Similar to using R sapply on a vector.
 }
 \examples{
-s = pl$Series(letters[1:5], "ltrs")
+s = as_polars_series(letters[1:5], "ltrs")
 f = \(x) paste(x, ":", as.integer(charToRaw(x)))
 s$map_elements(f, pl$String)
 
 # same as
-pl$Series(sapply(s$to_r(), f), s$name)
+as_polars_series(sapply(s$to_r(), f), s$name)
 }
 \keyword{Series}

--- a/man/Series_max.Rd
+++ b/man/Series_max.Rd
@@ -17,7 +17,7 @@ The Dtypes Int8, UInt8, Int16 and UInt16 are cast to Int64 before summing to
 prevent overflow issues.
 }
 \examples{
-pl$Series(c(1:2, NA, 3, 5))$max() # a NA is dropped always
-pl$Series(c(1:2, NA, 3, NaN, 4, Inf))$max() # NaN carries / poisons
-pl$Series(c(1:2, 3, Inf, 4, -Inf, 5))$max() # Inf-Inf is NaN
+as_polars_series(c(1:2, NA, 3, 5))$max() # a NA is dropped always
+as_polars_series(c(1:2, NA, 3, NaN, 4, Inf))$max() # NaN carries / poisons
+as_polars_series(c(1:2, 3, Inf, 4, -Inf, 5))$max() # Inf-Inf is NaN
 }

--- a/man/Series_mean.Rd
+++ b/man/Series_mean.Rd
@@ -17,7 +17,7 @@ The Dtypes Int8, UInt8, Int16 and UInt16 are cast to Int64 before summing to
 prevent overflow issues.
 }
 \examples{
-pl$Series(c(1:2, NA, 3, 5))$mean() # a NA is dropped always
-pl$Series(c(1:2, NA, 3, NaN, 4, Inf))$mean() # NaN carries / poisons
-pl$Series(c(1:2, 3, Inf, 4, -Inf, 5))$mean() # Inf-Inf is NaN
+as_polars_series(c(1:2, NA, 3, 5))$mean() # a NA is dropped always
+as_polars_series(c(1:2, NA, 3, NaN, 4, Inf))$mean() # NaN carries / poisons
+as_polars_series(c(1:2, 3, Inf, 4, -Inf, 5))$mean() # Inf-Inf is NaN
 }

--- a/man/Series_median.Rd
+++ b/man/Series_median.Rd
@@ -17,7 +17,7 @@ The Dtypes Int8, UInt8, Int16 and UInt16 are cast to Int64 before summing to
 prevent overflow issues.
 }
 \examples{
-pl$Series(c(1:2, NA, 3, 5))$median() # a NA is dropped always
-pl$Series(c(1:2, NA, 3, NaN, 4, Inf))$median() # NaN carries / poisons
-pl$Series(c(1:2, 3, Inf, 4, -Inf, 5))$median() # Inf-Inf is NaN
+as_polars_series(c(1:2, NA, 3, 5))$median() # a NA is dropped always
+as_polars_series(c(1:2, NA, 3, NaN, 4, Inf))$median() # NaN carries / poisons
+as_polars_series(c(1:2, 3, Inf, 4, -Inf, 5))$median() # Inf-Inf is NaN
 }

--- a/man/Series_min.Rd
+++ b/man/Series_min.Rd
@@ -17,7 +17,7 @@ The Dtypes Int8, UInt8, Int16 and UInt16 are cast to Int64 before summing to
 prevent overflow issues.
 }
 \examples{
-pl$Series(c(1:2, NA, 3, 5))$min() # a NA is dropped always
-pl$Series(c(1:2, NA, 3, NaN, 4, Inf))$min() # NaN carries / poisons
-pl$Series(c(1:2, 3, Inf, 4, -Inf, 5))$min() # Inf-Inf is NaN
+as_polars_series(c(1:2, NA, 3, 5))$min() # a NA is dropped always
+as_polars_series(c(1:2, NA, 3, NaN, 4, Inf))$min() # NaN carries / poisons
+as_polars_series(c(1:2, 3, Inf, 4, -Inf, 5))$min() # Inf-Inf is NaN
 }

--- a/man/Series_mod.Rd
+++ b/man/Series_mod.Rd
@@ -17,9 +17,9 @@ Converted to \link[=Series_class]{Series} by \code{\link[=as_polars_series]{as_p
 Method equivalent of modulo operator \code{series \%\% other}.
 }
 \examples{
-pl$Series(1:4)$mod(2L)
-pl$Series(1:3)$mod(pl$Series(11:13))
-pl$Series(1:3)$mod(1L)
+as_polars_series(1:4)$mod(2L)
+as_polars_series(1:3)$mod(as_polars_series(11:13))
+as_polars_series(1:3)$mod(1L)
 }
 \seealso{
 \itemize{

--- a/man/Series_mul.Rd
+++ b/man/Series_mul.Rd
@@ -17,9 +17,9 @@ Converted to \link[=Series_class]{Series} by \code{\link[=as_polars_series]{as_p
 Method equivalent of multiplication operator \code{series * other}.
 }
 \examples{
-pl$Series(1:3)$mul(11:13)
-pl$Series(1:3)$mul(pl$Series(11:13))
-pl$Series(1:3)$mul(1L)
+as_polars_series(1:3)$mul(11:13)
+as_polars_series(1:3)$mul(as_polars_series(11:13))
+as_polars_series(1:3)$mul(1L)
 }
 \seealso{
 \itemize{

--- a/man/Series_n_unique.Rd
+++ b/man/Series_n_unique.Rd
@@ -13,5 +13,5 @@ A numeric value
 Count unique values in Series
 }
 \examples{
-pl$Series(c(1, 2, 1, 4, 4, 1, 5))$n_unique()
+as_polars_series(c(1, 2, 1, 4, 4, 1, 5))$n_unique()
 }

--- a/man/Series_print.Rd
+++ b/man/Series_print.Rd
@@ -13,5 +13,5 @@ self
 Print Series
 }
 \examples{
-pl$Series(1:3)
+as_polars_series(1:3)
 }

--- a/man/Series_rename.Rd
+++ b/man/Series_rename.Rd
@@ -20,5 +20,5 @@ it will throw an error.}
 Rename a series
 }
 \examples{
-pl$Series(1:4, "bob")$rename("alice")
+as_polars_series(1:4, "bob")$rename("alice")
 }

--- a/man/Series_rep.Rd
+++ b/man/Series_rep.Rd
@@ -20,5 +20,5 @@ memory.}
 Note that this function doesn't exist in Python Polars.
 }
 \examples{
-pl$Series(1:2, "bob")$rep(3)
+as_polars_series(1:2, "bob")$rep(3)
 }

--- a/man/Series_set_sorted.Rd
+++ b/man/Series_set_sorted.Rd
@@ -24,6 +24,6 @@ Set a sorted flag on a Series
 Use \code{\link[=Series_class]{$flags}} to see the values of the sorted flags.
 }
 \examples{
-s = pl$Series(1:4)$set_sorted()
+s = as_polars_series(1:4)$set_sorted()
 s$flags
 }

--- a/man/Series_sort.Rd
+++ b/man/Series_sort.Rd
@@ -23,6 +23,6 @@ return a cloned Series with the flag.}
 Sort a Series
 }
 \examples{
-pl$Series(c(1.5, NA, 1, NaN, Inf, -Inf))$sort()
-pl$Series(c(1.5, NA, 1, NaN, Inf, -Inf))$sort(nulls_last = TRUE)
+as_polars_series(c(1.5, NA, 1, NaN, Inf, -Inf))$sort()
+as_polars_series(c(1.5, NA, 1, NaN, Inf, -Inf))$sort(nulls_last = TRUE)
 }

--- a/man/Series_std.Rd
+++ b/man/Series_std.Rd
@@ -17,5 +17,5 @@ A numeric value
 Compute the standard deviation of a Series
 }
 \examples{
-pl$Series(1:10)$std()
+as_polars_series(1:10)$std()
 }

--- a/man/Series_sub.Rd
+++ b/man/Series_sub.Rd
@@ -17,11 +17,11 @@ Converted to \link[=Series_class]{Series} by \code{\link[=as_polars_series]{as_p
 Method equivalent of subtraction operator \code{series - other}.
 }
 \examples{
-pl$Series(1:3)$sub(11:13)
-pl$Series(1:3)$sub(pl$Series(11:13))
-pl$Series(1:3)$sub(1L)
-1L - pl$Series(1:3)
-pl$Series(1:3) - 1L
+as_polars_series(1:3)$sub(11:13)
+as_polars_series(1:3)$sub(as_polars_series(11:13))
+as_polars_series(1:3)$sub(1L)
+1L - as_polars_series(1:3)
+as_polars_series(1:3) - 1L
 }
 \seealso{
 \itemize{

--- a/man/Series_sum.Rd
+++ b/man/Series_sum.Rd
@@ -17,7 +17,7 @@ The Dtypes Int8, UInt8, Int16 and UInt16 are cast to Int64 before summing to
 prevent overflow issues.
 }
 \examples{
-pl$Series(c(1:2, NA, 3, 5))$sum() # a NA is dropped always
-pl$Series(c(1:2, NA, 3, NaN, 4, Inf))$sum() # NaN poisons the result
-pl$Series(c(1:2, 3, Inf, 4, -Inf, 5))$sum() # Inf-Inf is NaN
+as_polars_series(c(1:2, NA, 3, 5))$sum() # a NA is dropped always
+as_polars_series(c(1:2, NA, 3, NaN, 4, Inf))$sum() # NaN poisons the result
+as_polars_series(c(1:2, 3, Inf, 4, -Inf, 5))$sum() # Inf-Inf is NaN
 }

--- a/man/Series_to_frame.Rd
+++ b/man/Series_to_frame.Rd
@@ -14,7 +14,7 @@ Convert Series to DataFrame
 }
 \examples{
 # default will be a DataFrame with empty name
-pl$Series(1:4)$to_frame()
+as_polars_series(1:4)$to_frame()
 
-pl$Series(1:4, "bob")$to_frame()
+as_polars_series(1:4, "bob")$to_frame()
 }

--- a/man/Series_to_lit.Rd
+++ b/man/Series_to_lit.Rd
@@ -13,7 +13,7 @@ Series_to_lit()
 Convert a Series to literal
 }
 \examples{
-pl$Series(list(1:1, 1:2, 1:3, 1:4))$
+as_polars_series(list(1:1, 1:2, 1:3, 1:4))$
   print()$
   to_lit()$
   list$len()$

--- a/man/Series_to_r.Rd
+++ b/man/Series_to_r.Rd
@@ -76,7 +76,7 @@ withr::with_envvar(
 
 \examples{
 # Series with non-list type
-series_vec = pl$Series(letters[1:3])
+series_vec = as_polars_series(letters[1:3])
 
 series_vec$to_r() # as vector because Series DataType is not list (is String)
 series_vec$to_list() # implicit call as.list(), convert to list
@@ -84,7 +84,7 @@ series_vec$to_vector() # implicit call unlist(), same as to_r() as already vecto
 
 
 # make a Series with nested lists
-series_list = pl$Series(
+series_list = as_polars_series(
   list(
     list(c(1:5, NA_integer_)),
     list(1:2, NA_integer_)

--- a/man/Series_to_r.Rd
+++ b/man/Series_to_r.Rd
@@ -49,7 +49,7 @@ explicitly specify the time zone before conversion.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{# Due to daylight savings, clocks were turned forward 1 hour on Sunday, March 8, 2020, 2:00:00 am
 # so this particular date-time doesn't exist
-non_existent_time = pl$Series("2020-03-08 02:00:00")$str$strptime(pl$Datetime(), "\%F \%T")
+non_existent_time = as_polars_series("2020-03-08 02:00:00")$str$strptime(pl$Datetime(), "\%F \%T")
 
 withr::with_envvar(
   new = c(TZ = "America/New_York"),

--- a/man/Series_value_counts.Rd
+++ b/man/Series_value_counts.Rd
@@ -19,5 +19,5 @@ DataFrame
 Count the occurrences of unique values
 }
 \examples{
-pl$Series(iris$Species, name = "flower species")$value_counts()
+as_polars_series(iris$Species, name = "flower species")$value_counts()
 }

--- a/man/Series_var.Rd
+++ b/man/Series_var.Rd
@@ -17,5 +17,5 @@ A numeric value
 Compute the variance of a Series
 }
 \examples{
-pl$Series(1:10)$var()
+as_polars_series(1:10)$var()
 }

--- a/man/pl_PTime.Rd
+++ b/man/pl_PTime.Rd
@@ -56,7 +56,7 @@ pl$PTime(runif(5) * 3600 * 24 * 1E9, tu = "ns")
 pl$PTime("23:59:59")
 
 
-pl$Series(pl$PTime(runif(5) * 3600 * 24 * 1E0, tu = "s"))
+as_polars_series(pl$PTime(runif(5) * 3600 * 24 * 1E0, tu = "s"))
 pl$lit(pl$PTime("23:59:59"))$to_series()
 
 pl$lit(pl$PTime("23:59:59"))$to_r()

--- a/man/pl_Series.Rd
+++ b/man/pl_Series.Rd
@@ -5,9 +5,13 @@
 \alias{Series}
 \title{Create new Series}
 \usage{
-pl_Series(values, name = NULL, dtype = NULL, ..., nan_to_null = FALSE)
+pl_Series(..., values = NULL, name = NULL, dtype = NULL, nan_to_null = FALSE)
 }
 \arguments{
+\item{...}{Treated as \code{values}, \code{name}, and \code{dtype} in order.
+In future versions, the order of the arguments will be changed to
+\code{pl$Series(name, values, dtype, ..., nan_to_null)} and \code{...} will be ignored.}
+
 \item{values}{any vector}
 
 \item{name}{Name of the Series. If \code{NULL}, an empty string is used.}
@@ -15,8 +19,6 @@ pl_Series(values, name = NULL, dtype = NULL, ..., nan_to_null = FALSE)
 \item{dtype}{One of \link[=pl_dtypes]{polars data type} or \code{NULL}.
 If not \code{NULL}, that data type is used to \link[=Expr_cast]{cast} the Series created from the vector
 to a specific data type internally.}
-
-\item{...}{Ignored.}
 
 \item{nan_to_null}{If \code{TRUE}, \code{NaN} values contained in the Series are replaced to \code{null}.
 Using the \code{\link[=Expr_fill_nan]{$fill_nan()}} method internally.}
@@ -30,15 +32,15 @@ This function is a simple way to convert basic types of vectors provided by base
 For converting more types properly, use the generic function \code{\link[=as_polars_series]{as_polars_series()}}.
 }
 \examples{
-# Constructing a Series by specifying name and values positionally:
-s = pl$Series(1:3, "a")
+# Constructing a Series by specifying name and values positionally (deprecated):
+s = suppressWarnings(pl$Series(1:3, "a"))
 s
 
 # Notice that the dtype is automatically inferred as a polars Int32:
 s$dtype
 
 # Constructing a Series with a specific dtype:
-s2 = pl$Series(1:3, "a", dtype = pl$Float32)
+s2 = pl$Series(values = 1:3, name = "a", dtype = pl$Float32)
 s2
 }
 \seealso{

--- a/man/pl_Series.Rd
+++ b/man/pl_Series.Rd
@@ -12,9 +12,10 @@ pl_Series(..., values = NULL, name = NULL, dtype = NULL, nan_to_null = FALSE)
 In future versions, the order of the arguments will be changed to
 \code{pl$Series(name, values, dtype, ..., nan_to_null)} and \code{...} will be ignored.}
 
-\item{values}{any vector}
+\item{values}{Vector of base R types, or \code{NULL} (default).
+If \code{NULL}, empty Series is created.}
 
-\item{name}{Name of the Series. If \code{NULL}, an empty string is used.}
+\item{name}{Name of the Series. If \code{NULL} (default), an empty string is used.}
 
 \item{dtype}{One of \link[=pl_dtypes]{polars data type} or \code{NULL}.
 If not \code{NULL}, that data type is used to \link[=Expr_cast]{cast} the Series created from the vector

--- a/man/pl_concat_list.Rd
+++ b/man/pl_concat_list.Rd
@@ -30,7 +30,7 @@ df$with_columns(lapply(
 # concat Expr a Series and an R obejct
 pl$concat_list(list(
   pl$lit(1:5),
-  pl$Series(5:1),
+  as_polars_series(5:1),
   rep(0L, 5)
 ))$alias("alice")$to_series()
 

--- a/man/pl_dtypes.Rd
+++ b/man/pl_dtypes.Rd
@@ -21,6 +21,6 @@ pl$Struct(pl$Field("CityNames", pl$String))
 
 # The function changes type from Int32 to String
 # Specifying the output DataType: String solves the problem
-pl$Series(1:4)$map_elements(\(x) letters[x], datatype = pl$dtypes$String)
+as_polars_series(1:4)$map_elements(\(x) letters[x], datatype = pl$dtypes$String)
 
 }

--- a/man/pl_lit.Rd
+++ b/man/pl_lit.Rd
@@ -24,7 +24,7 @@ pl$col("some_column") / pl$lit(42) + 2
 
 # vector to literal explicitly via Series and back again
 # R vector to expression and back again
-pl$select(pl$lit(pl$Series(1:4)))$to_list()[[1L]]
+pl$select(pl$lit(as_polars_series(1:4)))$to_list()[[1L]]
 
 # r vector to literal and back r vector
 pl$lit(1:4)$to_r()

--- a/man/pl_mem_address.Rd
+++ b/man/pl_mem_address.Rd
@@ -19,5 +19,5 @@ Get underlying mem address a rust object (via ExtPtr). Expert use only.
 Does not give meaningful answers for regular R objects.
 }
 \examples{
-pl$mem_address(pl$Series(1:3))
+pl$mem_address(pl$Series(values = 1:3))
 }

--- a/man/pl_raw_list.Rd
+++ b/man/pl_raw_list.Rd
@@ -42,16 +42,16 @@ elements must be raw or \code{NULL} (encoded as missing), and the S3 class is
 raw_list = pl$raw_list(raw(1), raw(3), charToRaw("alice"), NULL)
 
 # pass it to Series or lit
-pl$Series(raw_list)
+pl$Series(values = raw_list)
 pl$lit(raw_list)
 
 # convert polars bianry Series to rpolars_raw_list
-pl$Series(raw_list)$to_r()
+pl$Series(values = raw_list)$to_r()
 
 
 # NB: a plain list of raws yield a polars Series of DateType [list[Binary]]
 # which is not the same
-pl$Series(list(raw(1), raw(2)))
+pl$Series(values = list(raw(1), raw(2)))
 
 # to regular list, use as.list or unclass
 as.list(raw_list)

--- a/src/rust/src/series.rs
+++ b/src/rust/src/series.rs
@@ -55,8 +55,8 @@ impl From<&RPolarsExpr> for pl::PolarsResult<RPolarsSeries> {
 #[extendr]
 impl RPolarsSeries {
     //utility methods
-    pub fn new(x: Robj, name: Robj) -> RResult<RPolarsSeries> {
-        robjname2series(x, robj_to!(Option, str, name)?.unwrap_or(""))
+    pub fn new(name: Robj, values: Robj) -> RResult<RPolarsSeries> {
+        robjname2series(values, robj_to!(str, name)?)
             .map_err(polars_to_rpolars_err)
             .map(RPolarsSeries)
     }

--- a/tests/testthat/_snaps/s3-methods.md
+++ b/tests/testthat/_snaps/s3-methods.md
@@ -1,7 +1,7 @@
 # Series as.character v=a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z
 
     Code
-      as.character(pl$Series(v))
+      as.character(as_polars_series(v))
     Output
        [1] "a" "b" "c" "d" "e" "f" "g" "h" "i" "j" "k" "l" "m" "n" "o" "p" "q" "r" "s"
       [20] "t" "u" "v" "w" "x" "y" "z"
@@ -9,7 +9,7 @@
 ---
 
     Code
-      as.character(pl$Series(v), str_length = 15)
+      as.character(as_polars_series(v), str_length = 15)
     Output
        [1] "\"a\"" "\"b\"" "\"c\"" "\"d\"" "\"e\"" "\"f\"" "\"g\"" "\"h\"" "\"i\""
       [10] "\"j\"" "\"k\"" "\"l\"" "\"m\"" "\"n\"" "\"o\"" "\"p\"" "\"q\"" "\"r\""
@@ -18,7 +18,7 @@
 ---
 
     Code
-      as.character(pl$Series(v), str_length = 2)
+      as.character(as_polars_series(v), str_length = 2)
     Output
        [1] "\"a…" "\"b…" "\"c…" "\"d…" "\"e…" "\"f…" "\"g…" "\"h…" "\"i…" "\"j…"
       [11] "\"k…" "\"l…" "\"m…" "\"n…" "\"o…" "\"p…" "\"q…" "\"r…" "\"s…" "\"t…"
@@ -27,91 +27,91 @@
 # Series as.character v=1, 2, 3, 4, 5, 6, 7, 8, 9, 10
 
     Code
-      as.character(pl$Series(v))
+      as.character(as_polars_series(v))
     Output
        [1] "1"  "2"  "3"  "4"  "5"  "6"  "7"  "8"  "9"  "10"
 
 ---
 
     Code
-      as.character(pl$Series(v), str_length = 15)
+      as.character(as_polars_series(v), str_length = 15)
     Output
        [1] "1"  "2"  "3"  "4"  "5"  "6"  "7"  "8"  "9"  "10"
 
 ---
 
     Code
-      as.character(pl$Series(v), str_length = 2)
+      as.character(as_polars_series(v), str_length = 2)
     Output
        [1] "1"  "2"  "3"  "4"  "5"  "6"  "7"  "8"  "9"  "10"
 
 ---
 
     Code
-      as.character(pl$Series(v))
+      as.character(as_polars_series(v))
     Output
        [1] "1"  "2"  "3"  "4"  "5"  "6"  "7"  "8"  "9"  "10"
 
 ---
 
     Code
-      as.character(pl$Series(v), str_length = 15)
+      as.character(as_polars_series(v), str_length = 15)
     Output
        [1] "1.0"  "2.0"  "3.0"  "4.0"  "5.0"  "6.0"  "7.0"  "8.0"  "9.0"  "10.0"
 
 ---
 
     Code
-      as.character(pl$Series(v), str_length = 2)
+      as.character(as_polars_series(v), str_length = 2)
     Output
        [1] "1.0"  "2.0"  "3.0"  "4.0"  "5.0"  "6.0"  "7.0"  "8.0"  "9.0"  "10.0"
 
 # Series as.character v=bar
 
     Code
-      as.character(pl$Series(v))
+      as.character(as_polars_series(v))
     Output
       [1] "bar"
 
 ---
 
     Code
-      as.character(pl$Series(v), str_length = 15)
+      as.character(as_polars_series(v), str_length = 15)
     Output
       [1] "\"bar\""
 
 ---
 
     Code
-      as.character(pl$Series(v), str_length = 2)
+      as.character(as_polars_series(v), str_length = 2)
     Output
       [1] "\"b…"
 
 # Series as.character v=TRUE, FALSE
 
     Code
-      as.character(pl$Series(v))
+      as.character(as_polars_series(v))
     Output
       [1] "TRUE"  "FALSE"
 
 ---
 
     Code
-      as.character(pl$Series(v), str_length = 15)
+      as.character(as_polars_series(v), str_length = 15)
     Output
       [1] "true"  "false"
 
 ---
 
     Code
-      as.character(pl$Series(v), str_length = 2)
+      as.character(as_polars_series(v), str_length = 2)
     Output
       [1] "true"  "false"
 
 # Series as.character v=1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26
 
     Code
-      as.character(pl$Series(v))
+      as.character(as_polars_series(v))
     Output
        [1] "a" "b" "c" "d" "e" "f" "g" "h" "i" "j" "k" "l" "m" "n" "o" "p" "q" "r" "s"
       [20] "t" "u" "v" "w" "x" "y" "z"
@@ -119,7 +119,7 @@
 ---
 
     Code
-      as.character(pl$Series(v), str_length = 15)
+      as.character(as_polars_series(v), str_length = 15)
     Output
        [1] "\"a\"" "\"b\"" "\"c\"" "\"d\"" "\"e\"" "\"f\"" "\"g\"" "\"h\"" "\"i\""
       [10] "\"j\"" "\"k\"" "\"l\"" "\"m\"" "\"n\"" "\"o\"" "\"p\"" "\"q\"" "\"r\""
@@ -128,7 +128,7 @@
 ---
 
     Code
-      as.character(pl$Series(v), str_length = 2)
+      as.character(as_polars_series(v), str_length = 2)
     Output
        [1] "\"a…" "\"b…" "\"c…" "\"d…" "\"e…" "\"f…" "\"g…" "\"h…" "\"i…" "\"j…"
       [11] "\"k…" "\"l…" "\"m…" "\"n…" "\"o…" "\"p…" "\"q…" "\"r…" "\"s…" "\"t…"
@@ -137,21 +137,21 @@
 # Series as.character v=foooo  , barrrrr
 
     Code
-      as.character(pl$Series(v))
+      as.character(as_polars_series(v))
     Output
       [1] "foooo"   "barrrrr"
 
 ---
 
     Code
-      as.character(pl$Series(v), str_length = 15)
+      as.character(as_polars_series(v), str_length = 15)
     Output
       [1] "\"foooo\""   "\"barrrrr\""
 
 ---
 
     Code
-      as.character(pl$Series(v), str_length = 2)
+      as.character(as_polars_series(v), str_length = 2)
     Output
       [1] "\"f…" "\"b…"
 

--- a/tests/testthat/test-as_polars.R
+++ b/tests/testthat/test-as_polars.R
@@ -128,7 +128,7 @@ if (requireNamespace("arrow", quietly = TRUE) && requireNamespace("nanoarrow", q
     tibble::tribble(
       ~.test_name, ~x, ~expected_name,
       "vector", 1, "",
-      "Series", pl$Series(1, "foo"), "foo",
+      "Series", as_polars_series(1, "foo"), "foo",
       "Expr", pl$lit(1)$alias("foo"), "foo",
       "Then", pl$when(TRUE)$then(1), "literal",
       "ChainedThen", pl$when(FALSE)$then(0)$when(TRUE)$then(1), "literal",

--- a/tests/testthat/test-bit64.R
+++ b/tests/testthat/test-bit64.R
@@ -2,7 +2,7 @@ test_that("from r to series and reverse", {
   skip_if_not_installed("bit64")
   # R to series
   values = c(-1, 0, 1, NA, 2^61, -2^61)
-  s_act = pl$Series(bit64::as.integer64(values))
+  s_act = pl$Series(values = bit64::as.integer64(values))
   s_ref = pl$lit(values)$cast(pl$Int64)$to_series()
   expect_true(all((s_act == s_ref)$to_r(), na.rm = TRUE))
   # series to R

--- a/tests/testthat/test-concat.R
+++ b/tests/testthat/test-concat.R
@@ -82,7 +82,7 @@ test_that("concat dataframe", {
 
   # can concat Series
   expect_identical(
-    pl$concat(1:5, pl$Series(5:1, "b"), how = "horizontal")$to_list(),
+    pl$concat(1:5, as_polars_series(5:1, "b"), how = "horizontal")$to_list(),
     list(x = 1:5, b = 5:1)
   )
 

--- a/tests/testthat/test-dataframe.R
+++ b/tests/testthat/test-dataframe.R
@@ -56,9 +56,9 @@ expected_iris_select_df = structure(list(miah = c(
 patrick::with_parameters_test_that("DataFrame, mixed input, create and print",
   {
     input_vectors_and_series = list(
-      newname = pl$Series(c(1, 2, 3, 4, 5), name = "b"), # overwrite name b with newname
-      pl$Series((1:5) * 5, "a"),
-      pl$Series(letters[1:5], "b"),
+      newname = as_polars_series(c(1, 2, 3, 4, 5), name = "b"), # overwrite name b with newname
+      as_polars_series((1:5) * 5, "a"),
+      as_polars_series(letters[1:5], "b"),
       c(5, 4, 3, 2, 1), # unnamed vector
       named_vector = c(15, 14, 13, 12, 11), # named provide
       c(5, 4, 3, 2, 0)
@@ -369,7 +369,7 @@ test_that("get column(s)", {
   expected_list_of_series = {
     expected = lapply(
       1:5,
-      function(i) pl$Series(iris[[i]],names(iris)[i])
+      function(i) as_polars_series(iris[[i]],names(iris)[i])
     )
     names(expected) = names(iris)
     expected
@@ -393,7 +393,7 @@ test_that("get column(s)", {
 test_that("get column", {
   expect_true(
     pl$DataFrame(iris)$get_column("Sepal.Length")$equals(
-      pl$Series(iris$Sepal.Length, "Sepal.Length")
+      as_polars_series(iris$Sepal.Length, "Sepal.Length")
     )
   )
 
@@ -1068,7 +1068,7 @@ test_that("describe", {
   )
 
   # names using internal separator ":" in column names, should also just work.
-  df = pl$DataFrame("foo:bar:jazz" = 1, pl$Series(2, name = ""), "foobar" = 3)
+  df = pl$DataFrame("foo:bar:jazz" = 1, as_polars_series(2, name = ""), "foobar" = 3)
   expect_identical(
     df$describe()$columns,
     c("statistic", df$columns)

--- a/tests/testthat/test-datatype.R
+++ b/tests/testthat/test-datatype.R
@@ -44,8 +44,8 @@ test_that("POSIXct data conversion", {
   )
   # TODO: infer timezone from string, change the arugment name from `tz`
   expect_true(
-    pl$Series("2022-01-01 UTC")$str$strptime(pl$Datetime(time_zone = "UTC"), "%F %Z")$eq(
-      pl$Series(as.POSIXct("2022-01-01", tz = "UTC"))
+    as_polars_series("2022-01-01 UTC")$str$strptime(pl$Datetime(time_zone = "UTC"), "%F %Z")$eq(
+      as_polars_series(as.POSIXct("2022-01-01", tz = "UTC"))
     )$to_r()
   )
 
@@ -58,8 +58,8 @@ test_that("POSIXct data conversion", {
       )
       # TODO: infer timezone from string, change the arugment name from `tz`
       expect_true(
-        pl$Series("2022-01-01 UTC")$str$strptime(pl$Datetime(time_zone = "UTC"), "%F %Z")$eq(
-          pl$Series(as.POSIXct("2022-01-01", tz = "UTC"))
+        as_polars_series("2022-01-01 UTC")$str$strptime(pl$Datetime(time_zone = "UTC"), "%F %Z")$eq(
+          as_polars_series(as.POSIXct("2022-01-01", tz = "UTC"))
         )$to_r()
       )
 
@@ -111,15 +111,15 @@ test_that("String and Utf8 are identical", {
 
 test_that("Categorical", {
   expect_identical(
-    pl$Series(c("z", "z", "k", "a"))$cast(pl$Categorical())$sort()$to_r(),
+    as_polars_series(c("z", "z", "k", "a"))$cast(pl$Categorical())$sort()$to_r(),
     factor(c("z", "z", "k", "a"))
   )
   expect_identical(
-    pl$Series(c("z", "z", "k", "a"))$cast(pl$Categorical("lexical"))$sort()$to_r(),
+    as_polars_series(c("z", "z", "k", "a"))$cast(pl$Categorical("lexical"))$sort()$to_r(),
     factor(c("a", "k", "z", "z"))
   )
   expect_error(
-    pl$Series(c("z", "z", "k", "a"))$cast(pl$Categorical("foobar"))
+    as_polars_series(c("z", "z", "k", "a"))$cast(pl$Categorical("foobar"))
   )
 })
 

--- a/tests/testthat/test-expr_binary.R
+++ b/tests/testthat/test-expr_binary.R
@@ -85,23 +85,23 @@ test_that("bin$encode and bin$decode", {
 test_that("Raw to lit and series", {
   # craete a rpolars_raw_list
   raw_list = pl$raw_list(raw(1), raw(3), charToRaw("alice"), NULL)
-  bin_series = pl$Series(raw_list)
+  bin_series = as_polars_series(raw_list)
 
   # round trip conversion
   expect_identical(bin_series$to_r(), raw_list)
 
   # non isomorphic conversions of plain Raw, via Series and lit
-  expect_identical(pl$Series(raw())$to_r(), pl$raw_list(raw())) # plain raw becomes, rpolars_raw_list
+  expect_identical(as_polars_series(raw())$to_r(), pl$raw_list(raw())) # plain raw becomes, rpolars_raw_list
   expect_identical(pl$lit(raw())$to_r(), pl$raw_list(raw())) # plain lit becomes, rpolars_raw_list
 
   # raw -> lit -> s -> R == raw -> s -> R
-  expect_identical(pl$lit(raw())$to_series()$to_r(), pl$Series(raw())$to_r())
+  expect_identical(pl$lit(raw())$to_series()$to_r(), as_polars_series(raw())$to_r())
 
   # raw -> s -> lit -> R  == raw -> lit -> R
-  expect_identical(pl$lit(pl$Series(raw()))$to_r(), pl$lit(raw())$to_r())
+  expect_identical(pl$lit(as_polars_series(raw()))$to_r(), pl$lit(raw())$to_r())
 
   # empty raw_list
-  expect_identical(pl$Series(pl$raw_list())$to_r(), raw_list[c()])
+  expect_identical(as_polars_series(pl$raw_list())$to_r(), raw_list[c()])
 
   # subset
   expect_identical(pl$raw_list(raw(1), raw(2), raw(3))[2:4], pl$raw_list(raw(2), raw(3), NULL))

--- a/tests/testthat/test-expr_expr.R
+++ b/tests/testthat/test-expr_expr.R
@@ -330,7 +330,7 @@ test_that("lit expr", {
 
   # explicit vector to series to literal
   expect_identical(
-    pl$DataFrame(list())$select(pl$lit(pl$Series(1:4)))$to_list()[[1L]],
+    pl$DataFrame(list())$select(pl$lit(as_polars_series(1:4)))$to_list()[[1L]],
     1:4
   )
 
@@ -1146,7 +1146,7 @@ test_that("fill_null  + forward backward _fill + fill_nan", {
       pl$col("a")$fill_nan("hej")$alias("fnan_str"),
       pl$col("a")$fill_nan(TRUE)$alias("fnan_bool"),
       pl$col("a")$fill_nan(pl$lit(10) / 2)$alias("fnan_expr"),
-      pl$col("a")$fill_nan(pl$Series(10))$alias("fnan_series")
+      pl$col("a")$fill_nan(as_polars_series(10))$alias("fnan_series")
     )$to_list(),
     list(
       fnan_NULL = R_replace_nan(l$a, NA_real_),
@@ -1155,12 +1155,12 @@ test_that("fill_null  + forward backward _fill + fill_nan", {
       fnan_str = c("1.0", "hej", NA, "hej", "3.0"),
       fnan_bool = R_replace_nan(l$a, TRUE),
       fnan_expr = R_replace_nan(l$a, pl$select(pl$lit(10) / 2)$to_list()[[1L]]),
-      fnan_series = R_replace_nan(l$a, pl$Series(10)$to_r())
+      fnan_series = R_replace_nan(l$a, as_polars_series(10)$to_r())
     )
   )
   # series with length not allowed
   expect_error(
-    pl$DataFrame(l)$select(pl$col("a")$fill_nan(pl$Series(10:11))$alias("fnan_series2"))
+    pl$DataFrame(l)$select(pl$col("a")$fill_nan(as_polars_series(10:11))$alias("fnan_series2"))
   )
 })
 
@@ -1562,7 +1562,7 @@ test_that("inspect", {
   )
   ref_fun = \(s) {
     cat("before dropping half the column it was:")
-    pl$Series(1:5)$print()
+    as_polars_series(1:5)$print()
     cat("and not it is dropped", "\n", sep = "")
   }
   ref_text = capture_output(ref_fun())
@@ -2299,7 +2299,7 @@ test_that("concat_list", {
   # concat Expr a Series and an R obejct
   df_act = pl$select(pl$concat_list(list(
     pl$lit(1:5),
-    pl$Series(5:1),
+    as_polars_series(5:1),
     rep(0L, 5)
   ))$alias("alice"))
 

--- a/tests/testthat/test-expr_list.R
+++ b/tests/testthat/test-expr_list.R
@@ -1,5 +1,5 @@
 test_that("list$len", {
-  df = pl$DataFrame(list_of_strs = pl$Series(list(c("a", "b"), "c", character(), list(), NULL)))
+  df = pl$DataFrame(list_of_strs = as_polars_series(list(c("a", "b"), "c", character(), list(), NULL)))
   l = df$with_columns(pl$col("list_of_strs")$list$len()$alias("list_of_strs_lengths"))$to_list()
 
   expect_identical(
@@ -244,7 +244,7 @@ test_that("first last head tail", {
 
 test_that("join", {
   l = list(letters, as.character(1:5))
-  s = pl$Series(l)
+  s = as_polars_series(l)
   l_act = pl$select(s$to_lit()$list$join("-"))$to_list()
   l_exp = list(sapply(l, paste, collapse = "-"))
   names(l_exp) = ""

--- a/tests/testthat/test-expr_string.R
+++ b/tests/testthat/test-expr_string.R
@@ -790,7 +790,7 @@ make_datetime_format_cases = function() {
 patrick::with_parameters_test_that(
   "parse time without format specified",
   {
-    s = pl$Series(time_str)$str$strptime(dtype)
+    s = as_polars_series(time_str)$str$strptime(dtype)
     expect_true(s$dtype == type_expected)
   },
   .cases = make_datetime_format_cases()

--- a/tests/testthat/test-s3-methods.R
+++ b/tests/testthat/test-s3-methods.R
@@ -75,7 +75,7 @@ make_cases = function() {
 }
 patrick::with_parameters_test_that("RPolarsSeries",
   {
-    d = pl$Series(mtcars$mpg)
+    d = as_polars_series(mtcars$mpg)
     x = base(mtcars$mpg)
     y = base(d)
     z = d[[pola]]()
@@ -99,17 +99,17 @@ vecs_to_test = list(
 
 patrick::with_parameters_test_that("Series as.vector",
   {
-    expect_equal(as.vector(pl$Series(v)), v, ignore_attr = TRUE)
+    expect_equal(as.vector(as_polars_series(v)), v, ignore_attr = TRUE)
   },
   v = vecs_to_test
 )
 
 patrick::with_parameters_test_that("Series as.character",
   {
-    expect_equal(as.character(pl$Series(v)), as.character(v), ignore_attr = TRUE)
-    expect_snapshot(as.character(pl$Series(v)), cran = TRUE)
-    expect_snapshot(as.character(pl$Series(v), str_length = 15), cran = TRUE)
-    expect_snapshot(as.character(pl$Series(v), str_length = 2), cran = TRUE)
+    expect_equal(as.character(as_polars_series(v)), as.character(v), ignore_attr = TRUE)
+    expect_snapshot(as.character(as_polars_series(v)), cran = TRUE)
+    expect_snapshot(as.character(as_polars_series(v), str_length = 15), cran = TRUE)
+    expect_snapshot(as.character(as_polars_series(v), str_length = 2), cran = TRUE)
   },
   v = vecs_to_test
 )
@@ -261,8 +261,8 @@ test_that("brackets", {
   )
 
   # Series
-  expect_equal(pl$Series(letters)[1:5]$to_vector(), letters[1:5])
-  expect_equal(pl$Series(letters)[-5]$to_vector(), letters[-5])
+  expect_equal(as_polars_series(letters)[1:5]$to_vector(), letters[1:5])
+  expect_equal(as_polars_series(letters)[-5]$to_vector(), letters[-5])
 })
 
 

--- a/tests/testthat/test-series-sub-namespace.R
+++ b/tests/testthat/test-series-sub-namespace.R
@@ -1,13 +1,13 @@
 test_that("string sub namespace", {
   expect_identical(
-    pl$Series(c("A", "B", NA, "D"))$str$to_lowercase()$to_r(),
+    as_polars_series(c("A", "B", NA, "D"))$str$to_lowercase()$to_r(),
     c("a", "b", NA, "d")
   )
 })
 
 test_that("List sub namespace", {
   expect_identical(
-    pl$Series(list(3:1, 1:2, NULL))$list$first()$to_r(),
+    as_polars_series(list(3:1, 1:2, NULL))$list$first()$to_r(),
     c(3L, 1L, NA)
   )
 })
@@ -25,7 +25,7 @@ test_that("datetime sub namespace", {
 })
 
 test_that("binary subnamespace", {
-  s = pl$Series(c(r"(\x00\x00\x00)", r"(\xff\xff\x00)", r"(\x00\x00\xff)"))$
+  s = as_polars_series(c(r"(\x00\x00\x00)", r"(\xff\xff\x00)", r"(\x00\x00\xff)"))$
     to_lit()$
     cast(pl$Binary)$
     to_series()
@@ -36,7 +36,7 @@ test_that("binary subnamespace", {
 })
 
 test_that("categorical sub namespace", {
-  s = pl$Series(factor(c("foo", "bar", "foo", "foo", "ham")))
+  s = as_polars_series(factor(c("foo", "bar", "foo", "foo", "ham")))
   expect_identical(
     s$cat$get_categories()$to_r(),
     c("foo", "bar", "ham")
@@ -45,7 +45,7 @@ test_that("categorical sub namespace", {
 
 # TODO: this panicks
 # test_that("array sub namespace", {
-#   s = pl$Series(list(3:1, 1:2, c(NA_integer_, 4L)))$
+#   s = as_polars_series(list(3:1, 1:2, c(NA_integer_, 4L)))$
 #     to_lit()$
 #     cast(pl$Array(width = 2))$
 #     to_series()

--- a/tests/testthat/test-series.R
+++ b/tests/testthat/test-series.R
@@ -581,3 +581,36 @@ test_that("the dtype argument of pl$Series", {
 test_that("the nan_to_null argument of pl$Series", {
   expect_identical(pl$Series(values = c(1, 2, NA, NaN), nan_to_null = TRUE)$to_r(), c(1, 2, NA, NA))
 })
+
+# TODO: remove this
+test_that("Positional arguments deprecation", {
+  expect_warning(
+    pl$Series("foo"),
+    "the first argument"
+  )
+  expect_true(
+    suppressWarnings(pl$Series("foo"))$equals(
+      pl$Series(values = "foo")
+    )
+  )
+  expect_true(
+    suppressWarnings(pl$Series("foo", "bar"))$equals(
+      pl$Series(values = "foo", name = "bar")
+    )
+  )
+  expect_true(
+    suppressWarnings(pl$Series(1, "bar", pl$UInt8))$equals(
+      pl$Series(values = 1, name = "bar", dtype = pl$UInt8)
+    )
+  )
+  expect_true(
+    suppressWarnings(pl$Series(1, name = "bar", dtype = pl$UInt8))$equals(
+      pl$Series(values = 1, name = "bar", dtype = pl$UInt8)
+    )
+  )
+  expect_true(
+    suppressWarnings(pl$Series(values = "foo", "bar"))$equals(
+      pl$Series(values = "foo")
+    )
+  )
+})

--- a/vignettes/polars.Rmd
+++ b/vignettes/polars.Rmd
@@ -107,7 +107,7 @@ via `pl$`:
 ```{r}
 library(polars)
 
-pl$Series((1:5) * 5)
+pl$Series(name = "a", values = (1:5) * 5)
 
 pl$DataFrame(a = 1:5, b = letters[1:5])
 ```
@@ -132,9 +132,9 @@ vectors.
 
 ```{r}
 pl$DataFrame(
-  a = pl$Series((1:5) * 5),
-  b = pl$Series(letters[1:5]),
-  c = pl$Series(c(1, 2, 3, 4, 5)),
+  a = as_polars_series((1:5) * 5),
+  b = as_polars_series(letters[1:5]),
+  c = as_polars_series(c(1, 2, 3, 4, 5)),
   d = c(15, 14, 13, 12, 11),
   c(5, 4, 3, 2, 1),
   1:5

--- a/vignettes/userguide.Rmd
+++ b/vignettes/userguide.Rmd
@@ -75,7 +75,7 @@ df$
 # Polars quick exploration guide
 
 ```{r}
-series = pl$Series(c(1, 2, 3, 4, 5))
+series = as_polars_series(c(1, 2, 3, 4, 5))
 series
 
 df = pl$DataFrame(


### PR DESCRIPTION
Part of #903

As of version 0.16, positional arguments are deprecated and a warning is occurred.