### PR TITLE
fix expr methods to series evaluation environment

### DIFF
--- a/R/series__series.R
+++ b/R/series__series.R
@@ -179,7 +179,7 @@ add_expr_methods_to_series = function() {
         self = pl$col(col_name)
         # Override `self` in `$.RPolarsExpr`
         environment(f) = environment()
-        expr = do.call(f, scall)
+        expr = do.call(f, scall, envir = parent.frame())
 
         pcase(
           inherits(expr, "RPolarsExpr"), df$select(expr)$to_series(0),


### PR DESCRIPTION
fix https://github.com/pola-rs/r-polars/issues/970

```r
[R]> devtools::load_all()
ℹ Loading polars

[R]> fn <- function() {
             message("I'm from function")
             fn_value <- pl$Series("a")
             pl$DataFrame(mtcars)$get_column("mpg")$ca
     st(pl$String)$is_in(fn_value)
         }

[R]> fn()
I'm from function
polars Series: shape: (32,)
Series: 'mpg' [bool]
[
        false
        false
        false
        false
        false
        …
        false
        false
        false
        false
        false
]
Warning message:
In pl$Series("a") :
  `pl$Series()` will handle unnamed arguments differently as of 0.17.0:
- until 0.17.0, the first argument corresponds to the values and the second argument to the name of the Series.
- as of 0.17.0, the first argument will correspond to the name and the second argument to the values.
Use named arguments in `pl$Series()` or replace `pl$Series(<values>, <name>)` by `as_polars_series(<values>, <name>)` to silence this warning.

```