### PR TITLE
docs: `$str$split()` doesn't use regexes

### DIFF
--- a/R/expr__string.R
+++ b/R/expr__string.R
@@ -668,9 +668,7 @@ ExprStr_count_matches = function(pattern, literal = FALSE) {
 
 #' Split the string by a substring
 #'
-#' @keywords ExprStr
-#' @param by String or Expr of a string, a valid regex pattern that will be
-#' used to split the string.
+#' @param by Substring to split by. Can be an Expr.
 #' @param inclusive If `TRUE`, include the split character/string in the results.
 #'
 #' @return

--- a/man/ExprStr_split.Rd
+++ b/man/ExprStr_split.Rd
@@ -7,8 +7,7 @@
 ExprStr_split(by, inclusive = FALSE)
 }
 \arguments{
-\item{by}{String or Expr of a string, a valid regex pattern that will be
-used to split the string.}
+\item{by}{Substring to split by. Can be an Expr.}
 
 \item{inclusive}{If \code{TRUE}, include the split character/string in the results.}
 }
@@ -29,4 +28,3 @@ df = pl$DataFrame(
 df
 df$select(pl$col("s")$str$split(by = pl$col("by"))$alias("split"))
 }
-\keyword{ExprStr}


### PR DESCRIPTION
Close #971 

Same behavior in R and Python:

``` r
library(polars)

pl$DataFrame(x = c("0:89 29442:2 2:2 1:5"))$with_columns(
  foo=pl$col("x")$str$split(" *")
)
#> shape: (1, 2)
#> ┌──────────────────────┬──────────────────────────┐
#> │ x                    ┆ foo                      │
#> │ ---                  ┆ ---                      │
#> │ str                  ┆ list[str]                │
#> ╞══════════════════════╪══════════════════════════╡
#> │ 0:89 29442:2 2:2 1:5 ┆ ["0:89 29442:2 2:2 1:5"] │
#> └──────────────────────┴──────────────────────────┘

pl$Series("0:89 29442:2 2:2 1:5")$str$split(" *")
#> polars Series: shape: (1,)
#> Series: '' [list[str]]
#> [
#>  ["0:89 29442:2 2:2 1:5"]
#> ]
```

```python
import polars as pl

pl.DataFrame({"x": ["0:89 29442:2 2:2 1:5"]}).with_columns(
    foo=pl.col("x").str.split(" *")
)

shape: (1, 2)
┌──────────────────────┬──────────────────────────┐
│ x                    ┆ foo                      │
│ ---                  ┆ ---                      │
│ str                  ┆ list[str]                │
╞══════════════════════╪══════════════════════════╡
│ 0:89 29442:2 2:2 1:5 ┆ ["0:89 29442:2 2:2 1:5"] │
└──────────────────────┴──────────────────────────┘

pl.Series(values=["0:89 29442:2 2:2 1:5"]).str.split(" *")

shape: (1,)
Series: '' [list[str]]
[
        ["0:89 29442:2 2:2 1:5"]
]
```
