### PR TITLE
chore: update extendr-api to prevent crashing R session

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -120,6 +120,9 @@
   functions. This renaming is now made (#964).
 - Evaluating `Series` methods from `Expr` inside functions now works correctly (#973).
   Thanks @Yunuuuu for the report.
+- The dependent crate `extendr-api` is updated to 2024-03-31 unreleased version (#995).
+  The issue that the R session crashes when a panic occurs in the Rust side is resolved.
+  Thanks @CGMossa for the upstream fix.
 
 ## Polars R Package 0.15.1
 

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -477,7 +477,7 @@ checksum = "b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c"
 [[package]]
 name = "extendr-api"
 version = "0.6.0"
-source = "git+https://github.com/extendr/extendr?rev=b26adfedc20a979c5fcb164a4f7d2a0bd1721c18#b26adfedc20a979c5fcb164a4f7d2a0bd1721c18"
+source = "git+https://github.com/extendr/extendr?rev=1895bfc8ee22347665900caa0e48da4f0b13232f#1895bfc8ee22347665900caa0e48da4f0b13232f"
 dependencies = [
  "extendr-macros",
  "libR-sys",
@@ -489,7 +489,7 @@ dependencies = [
 [[package]]
 name = "extendr-macros"
 version = "0.6.0"
-source = "git+https://github.com/extendr/extendr?rev=b26adfedc20a979c5fcb164a4f7d2a0bd1721c18#b26adfedc20a979c5fcb164a4f7d2a0bd1721c18"
+source = "git+https://github.com/extendr/extendr?rev=1895bfc8ee22347665900caa0e48da4f0b13232f#1895bfc8ee22347665900caa0e48da4f0b13232f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -38,7 +38,7 @@ opt-level = 3 # was 1 to support 1.66, but since 1.70 is needed anyway it does n
 opt-level = 3
 
 [dependencies]
-extendr-api = { git = "https://github.com/extendr/extendr", rev = "b26adfedc20a979c5fcb164a4f7d2a0bd1721c18", default-features = false, features = [
+extendr-api = { git = "https://github.com/extendr/extendr", rev = "1895bfc8ee22347665900caa0e48da4f0b13232f", default-features = false, features = [
   "result_list",
   "serde",
 ] }


### PR DESCRIPTION
See extendr/extendr#716 (Related to #929 and #993)