### PR TITLE
Refactor `expect_grepl_error()`

### DIFF
--- a/tests/testthat/_snaps/after-wrappers.md
+++ b/tests/testthat/_snaps/after-wrappers.md
@@ -168,6 +168,39 @@
       [55] "with_columns"            "with_columns_seq"       
       [57] "with_context"            "with_row_index"         
 
+---
+
+    Code
+      ls(.pr[[private_key]])
+    Output
+       [1] "clone_in_rust"           "collect"                
+       [3] "collect_in_background"   "debug_plan"             
+       [5] "describe_optimized_plan" "describe_plan"          
+       [7] "drop"                    "drop_nulls"             
+       [9] "explode"                 "fetch"                  
+      [11] "fill_nan"                "fill_null"              
+      [13] "filter"                  "first"                  
+      [15] "get_optimization_toggle" "group_by"               
+      [17] "group_by_dynamic"        "join"                   
+      [19] "join_asof"               "last"                   
+      [21] "max"                     "mean"                   
+      [23] "median"                  "melt"                   
+      [25] "min"                     "print"                  
+      [27] "profile"                 "quantile"               
+      [29] "rename"                  "reverse"                
+      [31] "rolling"                 "schema"                 
+      [33] "select"                  "select_seq"             
+      [35] "set_optimization_toggle" "shift"                  
+      [37] "shift_and_fill"          "sink_csv"               
+      [39] "sink_ipc"                "sink_json"              
+      [41] "sink_parquet"            "slice"                  
+      [43] "sort_by_exprs"           "std"                    
+      [45] "sum"                     "tail"                   
+      [47] "to_dot"                  "unique"                 
+      [49] "unnest"                  "var"                    
+      [51] "with_columns"            "with_columns_seq"       
+      [53] "with_context"            "with_row_index"         
+
 # public and private methods of each class Expr
 
     Code

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -31,7 +31,7 @@ expect_grepl_error = function(expr, expected_err = NULL, do_not_repeat_call = TR
     conditionMessage(e)
   })
 
-  match_patterns <- vapply(
+  match_patterns = vapply(
     expected_err,
     \(x) grepl(x, err, ignore.case = TRUE),
     FUN.VALUE = logical(1)

--- a/tests/testthat/test-after-wrappers.R
+++ b/tests/testthat/test-after-wrappers.R
@@ -37,5 +37,5 @@ patrick::with_parameters_test_that("public and private methods of each class",
 test_that("check the polars object is valid", {
   raw = as_polars_df(mtcars) |>
     serialize(connection = NULL)
-  expect_error(print(unserialize(raw)), "restart the R session")
+  expect_grepl_error(print(unserialize(raw)), "restart the R session")
 })

--- a/tests/testthat/test-as_polars.R
+++ b/tests/testthat/test-as_polars.R
@@ -32,7 +32,7 @@ if (requireNamespace("arrow", quietly = TRUE) && requireNamespace("nanoarrow", q
 
       if (inherits(x, "nanoarrow_array_stream")) {
         # The stream should be released after conversion
-        expect_error(x$get_next(), "already been released")
+        expect_grepl_error(x$get_next(), "already been released")
       }
 
       actual = as.data.frame(pl_df)
@@ -81,11 +81,11 @@ patrick::with_parameters_test_that("rownames option of as_polars_df",
 
 
 test_that("as_polars_df throws error when rownames is not a single string or already used", {
-  expect_error(as_polars_df(mtcars, rownames = "cyl"), "already used")
-  expect_error(as_polars_df(mtcars, rownames = c("cyl", "disp")), "must be a single string")
-  expect_error(as_polars_df(mtcars, rownames = 1), "must be a single string")
-  expect_error(as_polars_df(mtcars, rownames = NA_character_), "must be a single string")
-  expect_error(
+  expect_grepl_error(as_polars_df(mtcars, rownames = "cyl"), "already used")
+  expect_grepl_error(as_polars_df(mtcars, rownames = c("cyl", "disp")), "must be a single string")
+  expect_grepl_error(as_polars_df(mtcars, rownames = 1), "must be a single string")
+  expect_grepl_error(as_polars_df(mtcars, rownames = NA_character_), "must be a single string")
+  expect_grepl_error(
     as_polars_df(data.frame(a = 1, a = 2, check.names = FALSE), rownames = "a_1"),
     "already used"
   )
@@ -93,7 +93,7 @@ test_that("as_polars_df throws error when rownames is not a single string or alr
 
 
 test_that("as_polars_df throws error when make_names_unique = FALSE and there are duplicated column names", {
-  expect_error(
+  expect_grepl_error(
     as_polars_df(data.frame(a = 1, a = 2, check.names = FALSE), make_names_unique = FALSE),
     "not allowed"
   )
@@ -119,7 +119,7 @@ test_that("schema option and schema_overrides for as_polars_df.data.frame", {
     data.frame(a = as.character(1:3), b = 4:6)
   )
 
-  expect_error(as_polars_df(mtcars, schema = "cyl"), "schema length does not match")
+  expect_grepl_error(as_polars_df(mtcars, schema = "cyl"), "schema length does not match")
 })
 
 
@@ -153,7 +153,7 @@ if (requireNamespace("arrow", quietly = TRUE) && requireNamespace("nanoarrow", q
 
       if (inherits(x, "nanoarrow_array_stream")) {
         # The stream should be released after conversion
-        expect_error(x$get_next(), "already been released")
+        expect_grepl_error(x$get_next(), "already been released")
 
         # Re-create the stream for the next test
         x = nanoarrow::as_nanoarrow_array_stream(data.frame(x = 1))
@@ -239,7 +239,7 @@ test_that("from arrow Table and ChunkedArray", {
     lapply(at$columns, \(x) length(as_polars_series.ChunkedArray(x, rechunk = FALSE)$chunk_lengths())),
     lapply(at$columns, \(x) x$num_chunks)
   )
-  expect_error(expect_identical(
+  expect_grepl_error(expect_identical(
     lapply(at$columns, \(x) length(as_polars_series.ChunkedArray(x, rechunk = TRUE)$chunk_lengths())),
     lapply(at$columns, \(x) x$num_chunks)
   ))
@@ -252,7 +252,7 @@ test_that("from arrow Table and ChunkedArray", {
     lapply(at$columns, \(x) x$num_chunks)
   )
 
-  expect_error(expect_identical(
+  expect_grepl_error(expect_identical(
     as_polars_df.ArrowTabular(at, rechunk = TRUE)$
       select(pl$all()$map_batches(\(s) s$chunk_lengths()))$
       to_list() |>
@@ -290,7 +290,7 @@ test_that("from arrow Table and ChunkedArray", {
   )
   iris_str = iris
   iris_str$Species = as.character(iris_str$Species)
-  expect_error(expect_equal(df$to_list(), as.list(iris_str)))
+  expect_grepl_error(expect_equal(df$to_list(), as.list(iris_str)))
   expect_equal(df$to_list(), as.list(iris_str), tolerance = 0.0001)
 
   # change column name via char schema
@@ -350,7 +350,7 @@ patrick::with_parameters_test_that("as_polars_df for nanoarrow_array_stream",
 
     pl_df = as_polars_df(x)
     expect_s3_class(pl_df, "RPolarsDataFrame")
-    expect_error(x$get_next(), "already been released")
+    expect_grepl_error(x$get_next(), "already been released")
 
     expect_identical(dim(pl_df), c(2L, 2L))
   },
@@ -363,7 +363,7 @@ patrick::with_parameters_test_that("as_polars_series for nanoarrow_array_stream"
 
     pl_series = as_polars_series(x)
     expect_s3_class(pl_series, "RPolarsSeries")
-    expect_error(x$get_next(), "already been released")
+    expect_grepl_error(x$get_next(), "already been released")
 
     expect_identical(length(pl_series), 2L)
   },

--- a/tests/testthat/test-completion.R
+++ b/tests/testthat/test-completion.R
@@ -7,7 +7,7 @@ test_that("code completion: method names are found", {
 })
 
 test_that("code completion: check mode name", {
-  expect_error(
+  expect_grepl_error(
     polars_code_completion_activate(mode = "foobar"),
     "should be one of"
   )

--- a/tests/testthat/test-concat.R
+++ b/tests/testthat/test-concat.R
@@ -45,7 +45,7 @@ test_that("concat dataframe", {
   )
 
   # type 'relaxed' vertical concatenation is not allowed by default
-  expect_error(pl$concat(l_ver[[1L]], pl$DataFrame(a = 2, b = 42L), how = "vertical"), "data types don't match")
+  expect_grepl_error(pl$concat(l_ver[[1L]], pl$DataFrame(a = 2, b = 42L), how = "vertical"), "data types don't match")
 
   # check lazy eager is identical
   l_ver_lazy = lapply(l_ver, \(df) df$lazy())

--- a/tests/testthat/test-context.R
+++ b/tests/testthat/test-context.R
@@ -18,8 +18,8 @@ patrick::with_parameters_test_that("lazy functions in context",
     x = df$select(pl[[pola]]("mpg", "hp"))$to_data_frame()
     y = data.frame(lapply(mtcars[, c("mpg", "hp")], base))
     expect_equal(x, y, ignore_attr = TRUE)
-    expect_error(df$select(pl[[pola]]()))
-    expect_error(df$select(pl[[pola]]("mpg", pl$col("hp"))))
+    expect_grepl_error(df$select(pl[[pola]]()))
+    expect_grepl_error(df$select(pl[[pola]]("mpg", pl$col("hp"))))
   },
   .cases = make_cases()
 )

--- a/tests/testthat/test-csv-read.R
+++ b/tests/testthat/test-csv-read.R
@@ -83,7 +83,7 @@ test_that("arg raise_if_empty works", {
   tmpf = tempfile()
   writeLines("", tmpf)
 
-  expect_error(
+  expect_grepl_error(
     pl$read_csv(tmpf),
     "no data: empty CSV"
   )
@@ -136,7 +136,7 @@ test_that("arg encoding works", {
   tmpf = tempfile()
   write.csv(dat, tmpf, row.names = FALSE)
 
-  expect_error(
+  expect_grepl_error(
     pl$read_csv(tmpf, encoding = "foo"),
     "encoding choice"
   )
@@ -164,7 +164,7 @@ test_that("multiple files errors if different schema", {
   write.csv(dat1, tmpf1, row.names = FALSE)
   write.csv(dat2, tmpf2, row.names = FALSE)
 
-  expect_error(
+  expect_grepl_error(
     pl$read_csv(c(tmpf1, tmpf2)),
     "lengths don't match"
   )
@@ -176,7 +176,7 @@ test_that("bad paths", {
     c(ctx$BadArgument, ctx$PlainErrorMessage),
     c("path", "path cannot have zero length")
   )
-  expect_error(
+  expect_grepl_error(
     pl$read_csv("not a valid path"),
     "failed to locate file"
   )

--- a/tests/testthat/test-csv-write.R
+++ b/tests/testthat/test-csv-write.R
@@ -14,7 +14,7 @@ test_that("write_csv: path works", {
 })
 
 test_that("write_csv: null_values works", {
-  expect_error(
+  expect_grepl_error(
     dat_pl$write_csv(temp_out, null_values = NULL)
   )
   dat_pl$write_csv(temp_out, null_values = "hello")

--- a/tests/testthat/test-dataframe.R
+++ b/tests/testthat/test-dataframe.R
@@ -107,7 +107,7 @@ test_that("get set properties", {
   expect_different(df2$columns, df$columns)
 
   # cannot set property without setter method
-  expect_error(df$height <- 10)
+  expect_grepl_error(df$height <- 10)
 
   # other getable properties
   expect_equal(df$height, 5L)
@@ -159,14 +159,14 @@ test_that("DataFrame, custom schema", {
     pl$DataFrame(list(schema = 1), schema = list(schema = pl$Float32))
   )
   # incorrect datatype
-  expect_error(pl$DataFrame(x = 1, schema = list(schema = foo)))
-  expect_error(
+  expect_grepl_error(pl$DataFrame(x = 1, schema = list(schema = foo)))
+  expect_grepl_error(
     pl$DataFrame(x = 1, schema = list(x = "foo")),
     "expected RPolarsDataType"
   )
 
   # wrong variable name in schema
-  expect_error(
+  expect_grepl_error(
     pl$DataFrame(x = 1, schema = list(schema = pl$Float32)),
     "Some columns in `schema` are not in the DataFrame"
   )
@@ -418,7 +418,7 @@ test_that("get column", {
     )
   )
 
-  expect_error(
+  expect_grepl_error(
     pl$DataFrame(iris)$get_column("wrong_name")
   )
 })
@@ -547,13 +547,13 @@ test_that("head lazy/eager", {
 
   # lazy bounds
   expect_identical(df$head(0)$to_data_frame(), rdf[integer(), ])
-  expect_error(ldf$head(-1))
-  expect_error(ldf$head(2^32))
+  expect_grepl_error(ldf$head(-1))
+  expect_grepl_error(ldf$head(2^32))
   expect_identical(ldf$head(2^32 - 1)$collect()$to_data_frame(), rdf)
 
   # eager bounds
   expect_identical(ldf$head(0)$collect()$to_data_frame(), rdf[integer(), ])
-  expect_error(df$head(2^32))
+  expect_grepl_error(df$head(2^32))
   expect_identical(df$head(2^32 - 1)$to_data_frame(), rdf)
 })
 
@@ -735,7 +735,7 @@ test_that("drop_nulls", {
   expect_equal(tmp$drop_nulls("hp")$height, 32, ignore_attr = TRUE)
   expect_equal(tmp$drop_nulls(c("mpg", "hp"))$height, 29, ignore_attr = TRUE)
 
-  expect_error(
+  expect_grepl_error(
     pl$DataFrame(mtcars)$drop_nulls("bad column name")$height,
     "not found: unable to find column \"bad column name\""
   )
@@ -840,11 +840,11 @@ test_that("sort", {
   expect_true(is.na(b$mpg[1]))
 
   # error if descending is NULL
-  expect_error(
+  expect_grepl_error(
     df$sort("mpg", descending = NULL),
     "must be of length 1 or of the same length as `by`"
   )
-  expect_error(
+  expect_grepl_error(
     df$sort(c("mpg", "drat"), descending = NULL),
     "must be of length 1 or of the same length as `by`"
   )
@@ -1090,7 +1090,7 @@ test_that("describe", {
   expect_snapshot(df$describe())
   expect_snapshot(pl$DataFrame(mtcars)$describe())
   expect_snapshot(pl$DataFrame(mtcars)$describe(interpolation = "linear"))
-  expect_error(pl$DataFrame(mtcars)$describe("not a percentile"))
+  expect_grepl_error(pl$DataFrame(mtcars)$describe("not a percentile"))
 
   # min/max different depending on categorical ordering
   expect_snapshot(df$select(pl$col("cat")$cast(pl$Categorical("lexical")))$describe())
@@ -1199,8 +1199,8 @@ test_that("sample", {
   expect_identical(df$sample(frac = 0.1)$height, 15)
 
   # must pass either n or fraction and not both
-  expect_error(df$sample(), "Pass either arg")
-  expect_error(df$sample(n = 2, fraction = 0.1), "not both")
+  expect_grepl_error(df$sample(), "Pass either arg")
+  expect_grepl_error(df$sample(n = 2, fraction = 0.1), "not both")
 
   # single check of some conversion errors
   ctx = df$sample(frac = 0.1, seed = "not even a written number") |> get_err_ctx()
@@ -1409,8 +1409,8 @@ test_that("partition_by", {
   )
 
   # Test errors
-  expect_error(df$partition_by("foo"), "not found: foo")
-  expect_error(df$partition_by(pl$Int8), "There is no column to partition by")
+  expect_grepl_error(df$partition_by("foo"), "not found: foo")
+  expect_grepl_error(df$partition_by(pl$Int8), "There is no column to partition by")
 
   # Test `as_nested_list = TRUE`
   expect_true(

--- a/tests/testthat/test-datatype.R
+++ b/tests/testthat/test-datatype.R
@@ -25,7 +25,7 @@ test_that("plStruct", {
   expect_no_error(pl$Struct(bin = pl$Binary, pl$Boolean, pl$Boolean))
 
   # wrong uses
-  expect_error(
+  expect_grepl_error(
     pl$Struct(bin = pl$Binary, pl$Boolean, "abc"),
     "must either be a Field"
   )
@@ -69,11 +69,11 @@ test_that("POSIXct data conversion", {
         pl$lit(as.POSIXct(non_exsitent_time_chr))$to_r(),
         as.POSIXct(non_exsitent_time_chr)
       )
-      expect_error(
+      expect_grepl_error(
         pl$lit(non_exsitent_time_chr)$str$strptime(pl$Datetime(), "%F %T")$to_r(),
         "non-existent"
       )
-      expect_error(
+      expect_grepl_error(
         pl$lit(ambiguous_time_chr)$str$strptime(pl$Datetime(), "%F %T")$to_r(),
         "ambiguous"
       )
@@ -118,7 +118,7 @@ test_that("Categorical", {
     as_polars_series(c("z", "z", "k", "a"))$cast(pl$Categorical("lexical"))$sort()$to_r(),
     factor(c("a", "k", "z", "z"))
   )
-  expect_error(
+  expect_grepl_error(
     as_polars_series(c("z", "z", "k", "a"))$cast(pl$Categorical("foobar"))
   )
 })

--- a/tests/testthat/test-enable_string_cache.R
+++ b/tests/testthat/test-enable_string_cache.R
@@ -12,7 +12,7 @@ test_that("string cache", {
   } else {
     pl$disable_string_cache()
   }
-  expect_error(pl$enable_string_cache(42))
+  expect_grepl_error(pl$enable_string_cache(42))
 
   # # with before TRUE
   pl$enable_string_cache()

--- a/tests/testthat/test-expr_array.R
+++ b/tests/testthat/test-expr_array.R
@@ -61,12 +61,12 @@ test_that("arr$max and arr$min error if the nightly feature is false", {
     )
   )
   # max ---
-  expect_error(
+  expect_grepl_error(
     df$select(pl$col("ints")$arr$max())$to_list()
   )
 
   # min ---
-  expect_error(
+  expect_grepl_error(
     df$select(pl$col("ints")$arr$min())$to_list()
   )
 })

--- a/tests/testthat/test-expr_datetime.R
+++ b/tests/testthat/test-expr_datetime.R
@@ -210,7 +210,7 @@ test_that("dt$combine", {
     as.POSIXct("2020-12-31 22:30:00", tz = "GMT")
   )
 
-  expect_error(
+  expect_grepl_error(
     pl$lit(as.Date("2021-01-01"))$dt$combine(1, tu = "s")
   )
 })
@@ -517,11 +517,11 @@ test_that("dt$timestamp", {
   expect_identical(as.numeric(l_exp$timestamp_us), base_r_s_timestamp * 1E6)
   expect_identical(suppressWarnings(as.numeric(l_exp$timestamp_ns)), base_r_s_timestamp * 1E9)
 
-  expect_error(
+  expect_grepl_error(
     as_polars_series(as.Date("2022-1-1"))$dt$timestamp("bob")
   )
 
-  expect_error(
+  expect_grepl_error(
     as_polars_series(as.Date("2022-1-1"))$dt$timestamp(42)
   )
 })

--- a/tests/testthat/test-expr_expr.R
+++ b/tests/testthat/test-expr_expr.R
@@ -1732,7 +1732,7 @@ test_that("Expr_diff", {
   )
   expect_equal(df, known, ignore_attr = TRUE)
 
-  expect_grepl_error(pl$select(pl$lit(1:5)$diff(0)), NA)
+  expect_silent(pl$select(pl$lit(1:5)$diff(0)))
   expect_grepl_error(pl$lit(1:5)$diff(99^99))
   expect_grepl_error(pl$lit(1:5)$diff(5, "not a null behavior"))
 })

--- a/tests/testthat/test-expr_expr.R
+++ b/tests/testthat/test-expr_expr.R
@@ -507,7 +507,7 @@ test_that("to_physical + cast", {
 
 
   # cast error raised for String to Boolean
-  expect_error(
+  expect_grepl_error(
     pl$DataFrame(iris)$with_columns(
       pl$col("Species")$cast(pl$dtypes$String)$cast(pl$dtypes$Boolean)
     )
@@ -519,7 +519,7 @@ test_that("to_physical + cast", {
 
 
   # error overflow, strict TRUE
-  expect_error(df_big_n$with_columns(pl$col("big")$cast(pl$Int32)))
+  expect_grepl_error(df_big_n$with_columns(pl$col("big")$cast(pl$Int32)))
 
   # NA_int for strict_
   expect_identical(
@@ -596,7 +596,7 @@ test_that("exclude", {
     df$select(pl$all()$exclude(list("Species", "Petal.Width")))$columns,
     c("Sepal.Length", "Sepal.Width", "Petal.Length")
   )
-  expect_error(
+  expect_grepl_error(
     df$select(pl$all()$exclude(list("Species", pl$Boolean)))$columns
   )
 
@@ -618,10 +618,10 @@ test_that("exclude", {
   )
 
   # wrong cast is not possible
-  expect_error(
+  expect_grepl_error(
     unwrap(.pr$DataTypeVector$from_rlist(list(pl$Float64, pl$Categorical(), "imNoYourType")))
   )
-  expect_error(
+  expect_grepl_error(
     df$select(pl$all()$exclude(list(pl$Float64, pl$Categorical(), "bob")))$columns
   )
 })
@@ -703,7 +703,7 @@ test_that("Expr_append", {
     list(literal = c("Bob", "false"))
   )
 
-  expect_error(
+  expect_grepl_error(
     pl$DataFrame(list())$select(pl$lit("Bob")$append(FALSE, upcast = FALSE)),
     "match"
   )
@@ -1017,7 +1017,7 @@ test_that("gather that", {
     c(1L, 6L)
   )
 
-  expect_error(
+  expect_grepl_error(
     pl$select(pl$lit(0:10)$gather(11))$to_list()[[1L]]
   )
 
@@ -1192,7 +1192,7 @@ test_that("fill_null  + forward backward _fill + fill_nan", {
     )
   )
   # series with length not allowed
-  expect_error(
+  expect_grepl_error(
     pl$DataFrame(l)$select(pl$col("a")$fill_nan(as_polars_series(10:11))$alias("fnan_series2"))
   )
 })
@@ -1349,7 +1349,7 @@ test_that("Expr_quantile", {
     unname(quantile(v, v2))
   )
 
-  expect_error(
+  expect_grepl_error(
     pl$lit(1)$quantile(1, "some_unknwon_interpolation_method")
   )
 
@@ -1539,7 +1539,7 @@ test_that("is_between with Inf/NaN", {
 
 test_that("is_between errors if wrong 'closed' arg", {
   df = pl$DataFrame(var = c(1, 2, 3, 4, 5))
-  expect_error(
+  expect_grepl_error(
     df$select(pl$col("var")$is_between(1, 2, "foo")),
     "must be one of"
   )
@@ -1604,10 +1604,10 @@ test_that("inspect", {
 
   pl$lit(1)$inspect("{}") # no error
   pl$lit(1)$inspect("ssdds{}sdsfsd") # no error
-  expect_error(pl$lit(1)$inspect(""))
-  expect_error(pl$lit(1)$inspect("{}{}"))
-  expect_error(pl$lit(1)$inspect("sd{}sdfsf{}sdsdf"))
-  expect_error(pl$lit(1)$inspect("ssdds{sdds}sdsfsd"))
+  expect_grepl_error(pl$lit(1)$inspect(""))
+  expect_grepl_error(pl$lit(1)$inspect("{}{}"))
+  expect_grepl_error(pl$lit(1)$inspect("sd{}sdfsf{}sdsdf"))
+  expect_grepl_error(pl$lit(1)$inspect("ssdds{sdds}sdsfsd"))
 })
 
 test_that("interpolate", {
@@ -1732,9 +1732,9 @@ test_that("Expr_diff", {
   )
   expect_equal(df, known, ignore_attr = TRUE)
 
-  expect_error(pl$select(pl$lit(1:5)$diff(0)), NA)
-  expect_error(pl$lit(1:5)$diff(99^99))
-  expect_error(pl$lit(1:5)$diff(5, "not a null behavior"))
+  expect_grepl_error(pl$select(pl$lit(1:5)$diff(0)), NA)
+  expect_grepl_error(pl$lit(1:5)$diff(99^99))
+  expect_grepl_error(pl$lit(1:5)$diff(5, "not a null behavior"))
 })
 
 
@@ -2035,10 +2035,10 @@ test_that("reshape", {
     )
   )
 
-  expect_error(pl$lit(1:12)$reshape("hej"))
-  expect_error(pl$lit(1:12)$reshape(c(3, 4, 3)))
-  expect_error(pl$lit(1:12)$reshape(NaN))
-  expect_error(pl$lit(1:12)$reshape(NA_real_))
+  expect_grepl_error(pl$lit(1:12)$reshape("hej"))
+  expect_grepl_error(pl$lit(1:12)$reshape(c(3, 4, 3)))
+  expect_grepl_error(pl$lit(1:12)$reshape(NaN))
+  expect_grepl_error(pl$lit(1:12)$reshape(NA_real_))
 })
 
 
@@ -2064,10 +2064,10 @@ test_that("shuffle", {
     pl$DataFrame(a = letters)$select(pl$col("a")$shuffle(seed = 1))$to_list()
   )
 
-  expect_error(pl$lit(1:12)$shuffle("hej"))
-  expect_error(pl$lit(1:12)$shuffle(-2))
-  expect_error(pl$lit(1:12)$shuffle(NaN))
-  expect_error(pl$lit(1:12)$shuffle(10^73))
+  expect_grepl_error(pl$lit(1:12)$shuffle("hej"))
+  expect_grepl_error(pl$lit(1:12)$shuffle(-2))
+  expect_grepl_error(pl$lit(1:12)$shuffle(NaN))
+  expect_grepl_error(pl$lit(1:12)$shuffle(10^73))
 })
 
 
@@ -2156,8 +2156,8 @@ test_that("extend_constant", {
     ),
     c(5L, NA_integer_)
   )
-  expect_error(pl$lit(1)$extend_constant(5, -1))
-  expect_error(pl$lit(1)$extend_constant(5, Inf))
+  expect_grepl_error(pl$lit(1)$extend_constant(5, -1))
+  expect_grepl_error(pl$lit(1)$extend_constant(5, Inf))
 })
 
 
@@ -2167,8 +2167,8 @@ test_that("rep", {
   expect_identical(pl$lit((1:3) * 1)$rep(5)$to_r(), rep((1:3) * 1, 5))
   expect_identical(pl$lit(c("a", "b"))$rep(5)$to_r(), rep(c("a", "b"), 5))
   expect_identical(pl$lit(c(T, T, F))$rep(2)$to_r(), rep(c(T, T, F), 2))
-  expect_error(pl$lit(1:4)$rep(-1))
-  expect_error(pl$lit(1:4)$rep(Inf))
+  expect_grepl_error(pl$lit(1:4)$rep(-1))
+  expect_grepl_error(pl$lit(1:4)$rep(Inf))
 })
 
 test_that("rep_extend", {
@@ -2188,8 +2188,8 @@ test_that("rep_extend", {
     c(1:4, 2:1, 2:1) * 1.0
   )
   expect_identical(pl$lit(1)$rep_extend(numeric(), 5)$to_r(), 1)
-  expect_error(pl$lit(1)$rep_extend(1, -1))
-  expect_error(pl$lit(1)$rep_extend(1, Inf))
+  expect_grepl_error(pl$lit(1)$rep_extend(1, -1))
+  expect_grepl_error(pl$lit(1)$rep_extend(1, Inf))
 })
 
 test_that("to_r", {
@@ -2599,7 +2599,7 @@ test_that("rolling, arg check_sorted", {
     pl$col("dt")$str$strptime(pl$Datetime("us"), format = "%Y-%m-%d %H:%M:%S")
   )
 
-  expect_error(
+  expect_grepl_error(
     df$with_columns(
       sum_a_offset1 = pl$sum("a")$rolling(index_column = "dt", period = "2d")
     ),

--- a/tests/testthat/test-expr_list.R
+++ b/tests/testthat/test-expr_list.R
@@ -159,7 +159,7 @@ test_that("gather", {
     list(c(1:3, NA), 4L, 6L)
   )
 
-  expect_error(
+  expect_grepl_error(
     pl$lit(l)$list$gather(list(c(0:3), 0L, 0L))$to_r(),
     "gather indices are out of bounds"
   )
@@ -180,21 +180,21 @@ test_that("gather_every", {
   )
 
   # wrong n
-  expect_error(
+  expect_grepl_error(
     df$select(
       out = pl$col("a")$list$gather_every(-1)
     )
   )
 
   # missing n
-  expect_error(
+  expect_grepl_error(
     df$select(
       out = pl$col("a")$list$gather_every()
     )
   )
 
   # wrong offset
-  expect_error(
+  expect_grepl_error(
     df$select(
       out = pl$col("a")$list$gather_every(n = 2, offset = -1)
     )

--- a/tests/testthat/test-expr_meta.R
+++ b/tests/testthat/test-expr_meta.R
@@ -14,7 +14,7 @@ test_that("meta$eq meta$neq", {
   expect_true(e2$meta$eq(42))
 
   # error if not wrappable
-  expect_error(e2$meta$eq(complex(1)))
+  expect_grepl_error(e2$meta$eq(complex(1)))
 })
 
 

--- a/tests/testthat/test-expr_name.R
+++ b/tests/testthat/test-expr_name.R
@@ -34,7 +34,7 @@ test_that("name map", {
       )
       lf = df$lazy()
       expect_identical(lf$collect()$columns, "alice_and_bob")
-      expect_error(
+      expect_grepl_error(
         pl$DataFrame(list(alice = 1:3))$select(
           pl$col("alice")$name$map(\(x) 42) # wrong return
         ),
@@ -43,7 +43,7 @@ test_that("name map", {
 
       # TODO: this works but always prints the error message of log("a"), how
       # can we silence it?
-      # expect_error(
+      # expect_grepl_error(
       #   pl$DataFrame(list(alice=1:3))$select(
       #     pl$col("alice")$name$map(\(x) log("a"))
       #   )
@@ -62,7 +62,7 @@ test_that("name prefix_fields", {
     list(col_a = 1, col_b = 2)
   )
 
-  expect_error(
+  expect_grepl_error(
     pl$DataFrame(a = 1, b = 2)$select(pl$col("a")$name$prefix_fields("col_"))
   )
 })
@@ -77,7 +77,7 @@ test_that("name suffix_fields", {
     list(a_post = 1, b_post = 2)
   )
 
-  expect_error(
+  expect_grepl_error(
     pl$DataFrame(a = 1, b = 2)$select(pl$col("a")$name$suffix_fields("col_"))
   )
 })

--- a/tests/testthat/test-expr_string.R
+++ b/tests/testthat/test-expr_string.R
@@ -5,7 +5,7 @@ test_that("str$strptime datetime", {
     "invalid time"
   )
 
-  expect_error(
+  expect_grepl_error(
     pl$lit(txt_datetimes)$str$strptime(pl$Datetime(), format = "%Y-%m-%d %H:%M:%S")$to_series(),
     "conversion .* failed"
   )
@@ -88,7 +88,7 @@ test_that("$str$to_date", {
     out,
     as.Date(c("2009-01-02", "2009-01-03", "2009-01-04"))
   )
-  expect_error(
+  expect_grepl_error(
     pl$lit(c("2009-01-02", "2009-01-03", "2009-1-4"))$
       str$to_date(format = "%Y / %m / %d")$to_r()
   )
@@ -106,7 +106,7 @@ test_that("$str$to_time", {
     out,
     pl$PTime(c("01:20:01", "28:00:02", "03:00:02"), tu = "ns")
   )
-  expect_error(
+  expect_grepl_error(
     ppl$lit(c("01:20:01", "28:00:02", "03:00:02"))$
       str$to_time()
   )
@@ -119,7 +119,7 @@ test_that("$str$to_datetime", {
     out,
     as.POSIXct(c("2009-01-02 01:00:00", "2009-01-03 02:00:00", "2009-01-04 03:00:00"), tz = "UTC")
   )
-  expect_error(
+  expect_grepl_error(
     pl$lit(c("2009-01-02 01:00", "2009-01-03 02:00", "2009-1-4"))$
       str$to_date(format = "%Y / %m / %d")$to_r()
   )
@@ -203,7 +203,7 @@ test_that("to_titlecase - enabled via the nightly feature", {
 
 test_that("to_titlecase - enabled via the nightly feature", {
   skip_if(polars_info()$features$nightly)
-  expect_error(pl$col("foo")$str$to_titlecase())
+  expect_grepl_error(pl$col("foo")$str$to_titlecase())
 })
 
 
@@ -257,13 +257,13 @@ test_that("zfill", {
   )
 
   # test wrong input type
-  expect_error(
+  expect_grepl_error(
     pl$lit(c(-1, 2, 10, "5"))$str$zfill(pl$lit("a"))$to_r(),
     "u64"
   )
 
   # test wrong input range
-  expect_error(
+  expect_grepl_error(
     pl$lit(c(-1, 2, 10, "5"))$str$zfill(-3)$to_r(),
     "conversion from"
   )
@@ -706,7 +706,7 @@ test_that("str$parse_int", {
     c(110, 101, NA)
   )
 
-  expect_error(pl$lit("foo")$str$parse_int()$to_r(), "strict integer parsing failed for 1 value")
+  expect_grepl_error(pl$lit("foo")$str$parse_int()$to_r(), "strict integer parsing failed for 1 value")
 })
 
 test_that("str$reverse()", {
@@ -763,7 +763,7 @@ test_that("str$replace_many()", {
   )
 
   # error if different lengths
-  expect_error(
+  expect_grepl_error(
     pl$lit(c("hello there", "hi there", "good bye", NA))$
       str$
       replace_many(c("hi", "hello"), c("foo", "bar", "foo2"))$
@@ -771,7 +771,7 @@ test_that("str$replace_many()", {
     "same amount of patterns as replacement"
   )
 
-  expect_error(
+  expect_grepl_error(
     pl$lit(c("hello there", "hi there", "good bye", NA))$
       str$
       replace_many(c("hi", "hello", "good morning"), c("foo", "bar"))$

--- a/tests/testthat/test-groupby.R
+++ b/tests/testthat/test-groupby.R
@@ -268,7 +268,7 @@ test_that("group_by_dynamic for LazyFrame: error if not explicitly sorted", {
     index = c(1L, 2L, 3L, 4L, 8L, 9L),
     a = c(3, 7, 5, 9, 2, 1)
   )
-  expect_error(
+  expect_grepl_error(
     df$group_by_dynamic(index_column = "index", every = "2i")$agg(pl$col("a"))$collect(),
     "not explicitly sorted"
   )
@@ -295,7 +295,7 @@ test_that("group_by_dynamic for LazyFrame: arg 'closed' works", {
     c(0, 1.5, 3.5, 5.5)
   )
 
-  expect_error(
+  expect_grepl_error(
     df$group_by_dynamic(index_column = "dt", closed = "foobar", every = "1h")$agg(
       pl$col("n")$mean()
     )$collect(),
@@ -327,7 +327,7 @@ test_that("group_by_dynamic for LazyFrame: arg 'label' works", {
     )
   )
 
-  expect_error(
+  expect_grepl_error(
     df$group_by_dynamic(index_column = "dt", label = "foobar", every = "1h")$agg(
       pl$col("n")$mean()
     )$collect(),
@@ -362,7 +362,7 @@ test_that("group_by_dynamic for LazyFrame: arg 'start_by' works", {
     )
   )
 
-  expect_error(
+  expect_grepl_error(
     df$group_by_dynamic(index_column = "dt", start_by = "foobar", every = "1h")$agg(
       pl$col("n")$mean()
     )$collect(),
@@ -409,7 +409,7 @@ test_that("group_by_dynamic for LazyFrame: argument 'check_sorted' works", {
     grp = c("a", "a", rep("b", 4)),
     a = c(3, 7, 5, 9, 2, 1)
   )
-  expect_error(
+  expect_grepl_error(
     df$group_by_dynamic(index_column = "index", every = "2i", group_by = "grp")$agg(
       pl$sum("a")$alias("sum_a")
     )$collect(),
@@ -428,7 +428,7 @@ test_that("group_by_dynamic for LazyFrame: error if index not int or date/time",
     a = c(3, 7, 5, 9, 2, 1)
   )$with_columns(pl$col("index")$set_sorted())
 
-  expect_error(
+  expect_grepl_error(
     df$group_by_dynamic(index_column = "index", every = "2i")$agg(
       pl$sum("a")$alias("sum_a")
     )$collect()

--- a/tests/testthat/test-ipc.R
+++ b/tests/testthat/test-ipc.R
@@ -28,11 +28,11 @@ test_that("Test reading data from Apache Arrow IPC", {
   )
 
   # Test error handling
-  expect_error(pl$scan_ipc(0))
-  expect_error(pl$scan_ipc(tmpf, n_rows = "?"))
-  expect_error(pl$scan_ipc(tmpf, cache = 0L))
-  expect_error(pl$scan_ipc(tmpf, rechunk = list()))
-  expect_error(pl$scan_ipc(tmpf, row_index_name = c("x", "y")))
-  expect_error(pl$scan_ipc(tmpf, row_index_name = "name", row_index_offset = data.frame()))
-  expect_error(pl$scan_ipc(tmpf, memmap = NULL))
+  expect_grepl_error(pl$scan_ipc(0))
+  expect_grepl_error(pl$scan_ipc(tmpf, n_rows = "?"))
+  expect_grepl_error(pl$scan_ipc(tmpf, cache = 0L))
+  expect_grepl_error(pl$scan_ipc(tmpf, rechunk = list()))
+  expect_grepl_error(pl$scan_ipc(tmpf, row_index_name = c("x", "y")))
+  expect_grepl_error(pl$scan_ipc(tmpf, row_index_name = "name", row_index_offset = data.frame()))
+  expect_grepl_error(pl$scan_ipc(tmpf, memmap = NULL))
 })

--- a/tests/testthat/test-joins.R
+++ b/tests/testthat/test-joins.R
@@ -31,13 +31,13 @@ test_that("lazyframe join examples", {
   )
 
   # error on unknown how choice
-  expect_error(
+  expect_grepl_error(
     df$join(other_df, on = "ham", how = "foobar"),
     "must be one of"
   )
 
   # error on invalid choice
-  expect_error(
+  expect_grepl_error(
     df$join(other_df, on = "ham", how = 42),
     "Not a valid R choice"
   )
@@ -133,7 +133,7 @@ test_that("cross join, DataFrame", {
 })
 
 test_that("'other' must be a LazyFrame", {
-  expect_error(
+  expect_grepl_error(
     pl$LazyFrame(x = letters[1:5], y = 1:5)$join(mtcars, on = "x"),
     "`other` must be a LazyFrame"
   )
@@ -144,49 +144,49 @@ test_that("argument 'validate' works", {
   df2 = pl$DataFrame(x = c("a", letters[1:4]), y2 = 6:10)
 
   # eager 1:1
-  expect_error(
+  expect_grepl_error(
     df1$join(df2, on = "x", validate = "1:1"),
     "join keys did not fulfil 1:1 validation"
   )
 
   # lazy 1:1
-  expect_error(
+  expect_grepl_error(
     df1$lazy()$join(df2$lazy(), on = "x", validate = "1:1")$collect(),
     "join keys did not fulfil 1:1 validation"
   )
 
   # eager m:1
-  expect_error(
+  expect_grepl_error(
     df1$join(df2, on = "x", validate = "m:1"),
     "join keys did not fulfil m:1 validation"
   )
 
   # lazy m:1
-  expect_error(
+  expect_grepl_error(
     df1$lazy()$join(df2$lazy(), on = "x", validate = "m:1")$collect(),
     "join keys did not fulfil m:1 validation"
   )
 
   # eager 1:m
-  expect_error(
+  expect_grepl_error(
     df2$join(df1, on = "x", validate = "1:m"),
     "join keys did not fulfil 1:m validation"
   )
 
   # lazy 1:m
-  expect_error(
+  expect_grepl_error(
     df2$lazy()$join(df1$lazy(), on = "x", validate = "1:m")$collect(),
     "join keys did not fulfil 1:m validation"
   )
 
   # eager error on unknown validate choice
-  expect_error(
+  expect_grepl_error(
     df2$join(df1, on = "x", validate = "foobar"),
     "must be one of"
   )
 
   # lazy error on unknown validate choice
-  expect_error(
+  expect_grepl_error(
     df2$lazy()$join(df1$lazy(), on = "x", validate = "foobar")$collect(),
     "must be one of"
   )

--- a/tests/testthat/test-json_read.R
+++ b/tests/testthat/test-json_read.R
@@ -64,7 +64,7 @@ test_that("multiple paths works", {
 #   df = data.frame(a = letters[1:3], b = c(1, 2.5, 3))
 #   jsonlite::stream_out(df, file(ndjson_filename), verbose = FALSE)
 #   jsonlite::stream_out(iris, file(ndjson_filename2), verbose = FALSE)
-#   expect_error(
+#   expect_grepl_error(
 #     pl$read_ndjson(c(ndjson_filename, ndjson_filename2)),
 #     "lengths don't match"
 #   )
@@ -76,7 +76,7 @@ test_that("bad paths", {
     c(ctx$BadArgument, ctx$PlainErrorMessage),
     c("path", "path cannot have zero length")
   )
-  expect_error(
+  expect_grepl_error(
     pl$read_ndjson("not a valid path"),
     "failed to locate file"
   )

--- a/tests/testthat/test-lazy.R
+++ b/tests/testthat/test-lazy.R
@@ -52,8 +52,8 @@ test_that("LazyFrame, custom schema", {
     pl$LazyFrame(list(schema = 1), schema = list(schema = pl$Float32))
   )
   # errors if incorrect datatype
-  expect_error(pl$LazyFrame(x = 1, schema = list(schema = foo)))
-  expect_error(
+  expect_grepl_error(pl$LazyFrame(x = 1, schema = list(schema = foo)))
+  expect_grepl_error(
     pl$LazyFrame(x = 1, schema = list(x = "foo")),
     "expected RPolarsDataType"
   )
@@ -267,7 +267,7 @@ test_that("drop_nulls", {
   expect_equal(pl$DataFrame(tmp)$lazy()$drop_nulls("mpg")$collect()$height, 29, ignore_attr = TRUE)
   expect_equal(pl$DataFrame(tmp)$lazy()$drop_nulls("hp")$collect()$height, 32, ignore_attr = TRUE)
   expect_equal(pl$DataFrame(tmp)$lazy()$drop_nulls(c("mpg", "hp"))$collect()$height, 29, ignore_attr = TRUE)
-  expect_error(
+  expect_grepl_error(
     pl$DataFrame(mtcars)$lazy()$drop_nulls("bad")$collect(),
     "not found: unable to find column \"bad\""
   )
@@ -329,7 +329,7 @@ test_that("sort", {
 
 
   # check expect_grepl_error fails on unmet expectation
-  expect_error(expect_grepl_error(
+  expect_grepl_error(expect_grepl_error(
     pl$DataFrame(mtcars)$lazy()$sort(by = list("cyl", complex(1))),
     "not_in_error_text"
   ))
@@ -431,11 +431,11 @@ test_that("sort", {
   expect_true(is.na(b$mpg[1]))
 
   # error if descending is NULL
-  expect_error(
+  expect_grepl_error(
     df$sort("mpg", descending = NULL),
     "must be of length 1 or of the same length as `by`"
   )
-  expect_error(
+  expect_grepl_error(
     df$sort(c("mpg", "drat"), descending = NULL),
     "must be of length 1 or of the same length as `by`"
   )
@@ -929,7 +929,7 @@ test_that("rolling for LazyFrame: error if not explicitly sorted", {
     index = c(1L, 2L, 3L, 4L, 8L, 9L),
     a = c(3, 7, 5, 9, 2, 1)
   )
-  expect_error(
+  expect_grepl_error(
     df$rolling(index_column = "index", period = "2i")$agg(pl$col("a"))$collect(),
     "not explicitly sorted"
   )
@@ -973,7 +973,7 @@ test_that("rolling for LazyFrame: argument 'check_sorted' works", {
     grp = c("a", "a", rep("b", 4)),
     a = c(3, 7, 5, 9, 2, 1)
   )
-  expect_error(
+  expect_grepl_error(
     df$rolling(index_column = "index", period = "2i", group_by = "grp")$agg(
       pl$sum("a")$alias("sum_a")
     )$collect(),
@@ -992,7 +992,7 @@ test_that("rolling for LazyFrame: error if index not int or date/time", {
     a = c(3, 7, 5, 9, 2, 1)
   )$with_columns(pl$col("index")$set_sorted())
 
-  expect_error(
+  expect_grepl_error(
     df$rolling(index_column = "index", period = "2i")$agg(
       pl$sum("a")$alias("sum_a")
     )$collect()

--- a/tests/testthat/test-lazy_functions.R
+++ b/tests/testthat/test-lazy_functions.R
@@ -1,14 +1,14 @@
 test_that("pl$col", {
-  expect_error(pl$col(), "requires at least one argument")
+  expect_grepl_error(pl$col(), "requires at least one argument")
 
   expect_true(pl$col("a", "b")$meta$eq(pl$col(c("a", "b"))))
   expect_true(pl$col(c("a", "b"), "c")$meta$eq(pl$col("a", c("b", "c"))))
   expect_true(pl$col(pl$Int32, pl$Float64)$meta$eq(pl$col(list(pl$Int32, pl$Float64))))
 
-  expect_error(pl$col(list("a", "b")))
-  expect_error(pl$col("a", pl$Int32))
-  expect_error(pl$col(list(pl$Int32, pl$Float64), pl$String))
-  expect_error(pl$col(pl$String, list(pl$Int32, pl$Float64)))
+  expect_grepl_error(pl$col(list("a", "b")))
+  expect_grepl_error(pl$col("a", pl$Int32))
+  expect_grepl_error(pl$col(list(pl$Int32, pl$Float64), pl$String))
+  expect_grepl_error(pl$col(pl$String, list(pl$Int32, pl$Float64)))
 })
 
 
@@ -113,8 +113,8 @@ test_that("pl$first pl$last", {
   expect_identical(df$select(pl$first("b"))$to_list(), list(b = 4L))
   expect_identical(df$select(pl$last("b"))$to_list(), list(b = 6L))
 
-  expect_error(pl$first(1))
-  expect_error(pl$last(1))
+  expect_grepl_error(pl$first(1))
+  expect_grepl_error(pl$last(1))
 })
 
 
@@ -130,7 +130,7 @@ test_that("pl$len and pl$count", {
   expect_identical(df$select(pl$len())$to_list(), list(len = 3))
 
   # pass invalid column name type to pl$count
-  expect_error(pl$count(1))
+  expect_grepl_error(pl$count(1))
 })
 
 
@@ -146,8 +146,8 @@ test_that("pl$n_unique", {
   expr_act = pl$n_unique("bob")
   expect_true(expr_act$meta$eq(pl$col("bob")$n_unique()))
 
-  expect_error(pl$n_unique(pl$all()))
-  expect_error(pl$n_unique(1))
+  expect_grepl_error(pl$n_unique(pl$all()))
+  expect_grepl_error(pl$n_unique(1))
 })
 
 test_that("pl$approx_n_unique", {
@@ -160,8 +160,8 @@ test_that("pl$approx_n_unique", {
   expr_act = pl$approx_n_unique("bob")
   expect_true(expr_act$meta$eq(pl$col("bob")$approx_n_unique()))
 
-  expect_error(pl$approx_n_unique(pl$all()))
-  expect_error(pl$approx_n_unique(1:99))
+  expect_grepl_error(pl$approx_n_unique(pl$all()))
+  expect_grepl_error(pl$approx_n_unique(1:99))
 })
 
 
@@ -181,8 +181,8 @@ test_that("pl$head", {
     head(df$to_data_frame(), 2)$a
   )
 
-  expect_error(df$select(pl$head(pl$col("a"), 2)))
-  expect_error(pl$head(df$get_column("a"), -2))
+  expect_grepl_error(df$select(pl$head(pl$col("a"), 2)))
+  expect_grepl_error(pl$head(df$get_column("a"), -2))
 })
 
 
@@ -202,7 +202,7 @@ test_that("pl$tail", {
     tail(df$to_data_frame(), 2)$a
   )
 
-  expect_error(pl$tail(pl$col("a"), 2))
+  expect_grepl_error(pl$tail(pl$col("a"), 2))
 })
 
 test_that("pl$cov pl$rolling_cov pl$corr pl$rolling_corr", {
@@ -299,7 +299,7 @@ test_that("pl$from_epoch() works", {
 
 test_that("pl$from_epoch() errors if wrong time unit", {
   df = pl$DataFrame(timestamp = c(12345, 12346))
-  expect_error(
+  expect_grepl_error(
     df$select(pl$from_epoch(pl$col("timestamp"), time_unit = "foobar")),
     "one of"
   )

--- a/tests/testthat/test-parquet.R
+++ b/tests/testthat/test-parquet.R
@@ -79,7 +79,7 @@ test_that("throw error if invalid compression is passed", {
   tmpf = tempfile()
   on.exit(unlink(tmpf))
   df_exp = pl$DataFrame(mtcars)
-  expect_error(
+  expect_grepl_error(
     df_exp$write_parquet(tmpf, compression = "invalid"),
     "Failed to set parquet compression method"
   )

--- a/tests/testthat/test-polars_options.R
+++ b/tests/testthat/test-polars_options.R
@@ -25,13 +25,13 @@ test_that("polars_options() read-write", {
   # 'maintain_order' only accepts booleans (but error only shown later when
   # polars_options() is called, either directly or in internal functions)
   options(polars.maintain_order = 42)
-  expect_error(
+  expect_grepl_error(
     polars_options(),
     "input must be TRUE or FALSE."
   )
 
   options(polars.maintain_order = FALSE, polars.strictly_immutable = c(TRUE, TRUE))
-  expect_error(
+  expect_grepl_error(
     polars_options(),
     "input must be TRUE or FALSE."
   )
@@ -51,7 +51,7 @@ test_that("option 'int64_conversion ' works", {
 
   # check value of int64_conversion
   options(polars.int64_conversion = "foobar")
-  expect_error(
+  expect_grepl_error(
     polars_options(),
     "input must be one of"
   )
@@ -66,7 +66,7 @@ test_that("option 'int64_conversion ' works", {
   # can convert to bit64, but *only* if bit64 is attached
   try(detach("package:bit64"), silent = TRUE)
   options(polars.int64_conversion = "bit64")
-  expect_error(
+  expect_grepl_error(
     polars_options(),
     "must be attached"
   )

--- a/tests/testthat/test-rbackground.R
+++ b/tests/testthat/test-rbackground.R
@@ -97,14 +97,14 @@ test_that("rpool errors", {
   skip_if_not_installed("withr")
   withr::with_options(
     list(polars.rpool_cap = c(1, 2)),
-    expect_error(
+    expect_grepl_error(
       polars_options(),
       "integer of length 1"
     )
   )
   withr::with_options(
     list(polars.rpool_cap = -1),
-    expect_error(
+    expect_grepl_error(
       polars_options(),
       "integer of length 1"
     )

--- a/tests/testthat/test-rust_result.R
+++ b/tests/testthat/test-rust_result.R
@@ -45,16 +45,16 @@
 #   for(i in not_results) expect_true(!is_result(i), info = paste("testcase was ",str_string(i)))
 #
 #   #test guard_result
-#   for(i in not_results) expect_error( guard_result(i), info = paste("testcase was ",str_string(i)))
+#   for(i in not_results) expect_grepl_error( guard_result(i), info = paste("testcase was ",str_string(i)))
 #   for(i in are_results) expect_no_error(guard_result(i))
 #
 #   #test is_ok
-#   for(i in not_results) expect_error( is_ok(i), info = paste("testcase was ",str_string(i)))
+#   for(i in not_results) expect_grepl_error( is_ok(i), info = paste("testcase was ",str_string(i)))
 #   for(i in are_ok_result) expect_true( is_ok(i), info = paste("testcase was ",str_string(i)))
 #   for(i in are_err_result) expect_false( is_ok(i), info = paste("testcase was ",str_string(i)))
 #
 #   #test is_err
-#   for(i in not_results) expect_error( is_err(i), info = paste("testcase was ",str_string(i)))
+#   for(i in not_results) expect_grepl_error( is_err(i), info = paste("testcase was ",str_string(i)))
 #   for(i in are_ok_result) expect_false( is_err(i), info = paste("testcase was ",str_string(i)))
 #   for(i in are_err_result) expect_true( is_err(i), info = paste("testcase was ",str_string(i)))
 #
@@ -65,7 +65,7 @@
 #   for(i in are_ok_result) expect_identical(
 #     unwrap(i), i$ok, info = paste("testcase was ",str_string(i))
 #   )
-#   for(i in are_err_result)  expect_error(
+#   for(i in are_err_result)  expect_grepl_error(
 #     unwrap(i), info = paste("testcase was ",str_string(i))
 #   )
 #

--- a/tests/testthat/test-s3-methods.R
+++ b/tests/testthat/test-s3-methods.R
@@ -123,14 +123,14 @@ test_that("drop_nulls", {
   expect_equal(nrow(na.omit(d)), 28)
   expect_equal(nrow(na.omit(d, subset = "hp")), 31)
   expect_equal(nrow(na.omit(d, subset = c("mpg", "hp"))), 28)
-  expect_error(
+  expect_grepl_error(
     na.omit(d, "bad")$collect(),
     "not found: unable to find column \"bad\""
   )
   expect_equal(nrow(na.omit(dl)$collect()), 28)
   expect_equal(nrow(na.omit(dl, subset = "hp")$collect()), 31)
   expect_equal(nrow(na.omit(dl, subset = c("mpg", "hp"))$collect()), 28)
-  expect_error(
+  expect_grepl_error(
     na.omit(dl, "bad")$collect(),
     "not found: unable to find column \"bad\""
   )
@@ -158,11 +158,11 @@ test_that("brackets", {
   # informative errors
   df = pl$DataFrame(mtcars)
 
-  expect_error(df[, "bad"], regexp = "not found")
-  expect_error(df[c(1, 4, 3), ], regexp = "increasing order")
-  expect_error(df[, rep(TRUE, 50)], regexp = "length 11")
-  expect_error(df[, 1:32], regexp = "less than")
-  expect_error(df[, mtcars], regexp = "atomic vector")
+  expect_grepl_error(df[, "bad"], regexp = "not found")
+  expect_grepl_error(df[c(1, 4, 3), ], regexp = "increasing order")
+  expect_grepl_error(df[, rep(TRUE, 50)], regexp = "length 11")
+  expect_grepl_error(df[, 1:32], regexp = "less than")
+  expect_grepl_error(df[, mtcars], regexp = "atomic vector")
 
   # eager
 
@@ -250,8 +250,8 @@ test_that("brackets", {
   )
 
   # Not supported for lazy
-  expect_error(lf[1:3, ], "not supported")
-  expect_error(lf[, "cyl"], "not supported")
+  expect_grepl_error(lf[1:3, ], "not supported")
+  expect_grepl_error(lf[, "cyl"], "not supported")
 
   # Test for drop = FALSE
   expect_equal(

--- a/tests/testthat/test-series.R
+++ b/tests/testthat/test-series.R
@@ -8,7 +8,7 @@ test_that("pl$Series_apply", {
   )
 
   # strict type casting, throws an error
-  expect_error(
+  expect_grepl_error(
     as_polars_series(1:3, "integers")$map_elements(function(x) "wrong type", NULL, strict = TRUE)
   )
 
@@ -141,7 +141,7 @@ test_that("Series_append", {
     }
   )
 
-  expect_error(
+  expect_grepl_error(
     s_mut$append(as_polars_series(1:3), immutable = FALSE),
     regexp = "breaks immutability"
   )
@@ -166,14 +166,14 @@ test_that("all any", {
   expect_false(as_polars_series(c(TRUE, TRUE, FALSE))$all())
   expect_false(as_polars_series(c(NA, NA, NA))$all())
   expect_true(as_polars_series(c(TRUE, TRUE, TRUE))$all())
-  expect_error(as_polars_series(1:3)$all())
+  expect_grepl_error(as_polars_series(1:3)$all())
 
   expect_true(as_polars_series(c(TRUE, TRUE, NA))$any())
   expect_true(as_polars_series(c(TRUE, NA, FALSE))$any())
   expect_true(as_polars_series(c(TRUE, FALSE, FALSE))$any())
   expect_false(as_polars_series(c(FALSE, FALSE, NA))$any())
   expect_false(as_polars_series(c(NA, NA, NA))$any())
-  expect_error(as_polars_series(1:3)$any())
+  expect_grepl_error(as_polars_series(1:3)$any())
 })
 
 
@@ -326,7 +326,7 @@ test_that("$is_sorted() works", {
 })
 
 test_that("set_sorted", {
-  expect_error(
+  expect_grepl_error(
     as_polars_series(c(1, 3, 2, 4))$set_sorted(in_place = TRUE),
     regexp = "breaks immutability"
   )
@@ -421,7 +421,7 @@ test_that("series comparison", {
   expect_true((as_polars_series(1:5) <= 5)$all())
   expect_false((as_polars_series(1:5) <= 3)$all())
   expect_true((as_polars_series(1:5) < 11:15)$all())
-  expect_error(
+  expect_grepl_error(
     (as_polars_series(1:5) <= c(1:2))$all(),
     regexp = "not same length or either of length 1."
   )
@@ -457,7 +457,7 @@ test_that("rep", {
     integer(0)
   )
 
-  expect_error(
+  expect_grepl_error(
     as_polars_series(1:2, "alice")$rep(-1)$to_r(),
     regexp = "cannot be less than zero"
   )
@@ -591,7 +591,7 @@ test_that("cum_sum", {
 
 test_that("the dtype argument of pl$Series", {
   expect_identical(pl$Series(values = 1, dtype = pl$String)$to_r(), "1.0")
-  expect_error(pl$Series(values = "foo", dtype = pl$Int32), "conversion from `str` to `i32`")
+  expect_grepl_error(pl$Series(values = "foo", dtype = pl$Int32), "conversion from `str` to `i32`")
 })
 
 test_that("the nan_to_null argument of pl$Series", {

--- a/tests/testthat/test-sink_stream.R
+++ b/tests/testthat/test-sink_stream.R
@@ -4,7 +4,7 @@ rdf = lf$collect()$to_data_frame()
 test_that("Test sinking data to parquet file", {
   tmpf = tempfile()
   on.exit(unlink(tmpf))
-  expect_error(lf$sink_parquet(tmpf, compression = "rar"))
+  expect_grepl_error(lf$sink_parquet(tmpf, compression = "rar"))
   lf$sink_parquet(tmpf)
   expect_equal(pl$scan_parquet(tmpf)$collect()$to_data_frame(), rdf)
 })
@@ -13,7 +13,7 @@ test_that("Test sinking data to parquet file", {
   tmpf = tempfile()
   on.exit(unlink(tmpf))
   lf$sink_ipc(tmpf)
-  expect_error(lf$sink_ipc(tmpf, compression = "rar"))
+  expect_grepl_error(lf$sink_ipc(tmpf, compression = "rar"))
   expect_identical(pl$scan_ipc(tmpf, memmap = FALSE)$collect()$to_data_frame(), rdf)
 
 
@@ -95,7 +95,7 @@ test_that("sink_csv works", {
 })
 
 test_that("sink_csv: null_values works", {
-  expect_error(
+  expect_grepl_error(
     dat_pl$sink_csv(temp_out, null_values = NULL)
   )
   dat_pl$sink_csv(temp_out, null_values = "hello")

--- a/tests/testthat/test-whenthen.R
+++ b/tests/testthat/test-whenthen.R
@@ -110,7 +110,7 @@ test_that("when-then multiple predicates", {
 })
 
 test_that("named input is not allowed in when", {
-  expect_error(pl$when(foo = 1), "Detected a named input")
+  expect_grepl_error(pl$when(foo = 1), "Detected a named input")
 })
 
 test_that("$otherwise is optional", {


### PR DESCRIPTION
This PR rewrites `expect_grepl_error()` and uses it instead of `expect_error()` since the latter doesn't work well with `polars` error's structure (https://github.com/pola-rs/r-polars/pull/987#discussion_r1545263396).

We could also overwrite `expect_error()` instead of having this additional function (after all we already overwrite `expect_snapshot_file()`).