### PR TITLE
refactor: swap `pl$Series` and `as_polars_series.default`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -90,6 +90,8 @@
 
 ### New features
 
+- `pl$Series()` now calls `as_polars_series()` internally, so it can convert
+  more classes to Series properly (#1015).
 - New functions `pl$datetime()`, `pl$date()`, and `pl$time()` to easily create
   Expr of class datetime, date, and time via columns and literals (#918).
 - New function `pl$arg_where()` to get the indices that match a condition (#922).

--- a/R/as_polars.R
+++ b/R/as_polars.R
@@ -303,11 +303,12 @@ as_polars_lf.RPolarsLazyGroupBy = function(x, ...) {
 
 #' To polars Series
 #'
-#' [as_polars_series()] is a generic function that converts an R object to a
-#' polars Series. It is basically a wrapper for [pl$Series()][pl_Series].
-#' @param x Object to convert into a polars Series
-#' @param name A string to use as the name of the Series.
-#' If `NULL` (default), the name of `x` is used or an unnamed Series is created.
+#' [as_polars_series()] is a generic function that converts an R object to
+#' [a polars Series][Series_class].
+#' @param x Object to convert into [a polars Series][Series_class].
+#' @param name A character to use as the name of the [Series][Series_class].
+#' If `NULL` (default), the name of `x` is used or an empty character `""`
+#' will be used if `x` has no name.
 #' @inheritParams as_polars_df
 #' @return a [Series][Series_class]
 #' @export
@@ -329,7 +330,8 @@ as_polars_series = function(x, name = NULL, ...) {
 #' @rdname as_polars_series
 #' @export
 as_polars_series.default = function(x, name = NULL, ...) {
-  pl$Series(values = x, name = name)
+  .pr$Series$new(name %||% "", x) |>
+    unwrap("in as_polars_series():")
 }
 
 
@@ -367,13 +369,15 @@ as_polars_series.POSIXlt = function(x, name = NULL, ...) {
 #' @rdname as_polars_series
 #' @export
 as_polars_series.data.frame = function(x, name = NULL, ...) {
-  pl$DataFrame(unclass(x))$to_struct(name = name)
+  as_polars_df(x)$to_struct(name = name)
 }
 
 
 #' @rdname as_polars_series
 #' @export
-as_polars_series.vctrs_rcrd = as_polars_series.data.frame
+as_polars_series.vctrs_rcrd = function(x, name = NULL, ...) {
+  pl$select(unclass(x))$to_struct(name = name)
+}
 
 
 #' @rdname as_polars_series

--- a/R/series__series.R
+++ b/R/series__series.R
@@ -279,15 +279,16 @@ Series_struct = method_as_active_binding(
 # TODO: change the arguments in 0.17.0
 #' Create new Series
 #'
-#' This function is a simple way to convert basic types of vectors provided by base R to
+#' This function is a simple way to convert R vectors to
 #' [the Series class object][Series_class].
-#' For converting more types properly, use the generic function [as_polars_series()].
+#' Internally, this function is a simple wrapper of [as_polars_series()].
 #' @param ... Treated as `values`, `name`, and `dtype` in order.
 #' In future versions, the order of the arguments will be changed to
 #' `pl$Series(name, values, dtype, ..., nan_to_null)` and `...` will be ignored.
-#' @param values Vector of base R types, or `NULL` (default).
-#' If `NULL`, empty Series is created.
-#' @param name Name of the Series. If `NULL` (default), an empty string is used.
+#' @param values Object to convert into a polars Series.
+#' Passed to the `x` argument in [as_polars_series()][as_polars_series].
+#' @param name A character to use as the name of the Series, or `NULL` (default).
+#' Passed to the `name` argument in [as_polars_series()][as_polars_series].
 #' @param dtype One of [polars data type][pl_dtypes] or `NULL`.
 #' If not `NULL`, that data type is used to [cast][Expr_cast] the Series created from the vector
 #' to a specific data type internally.
@@ -334,7 +335,7 @@ pl_Series = function(
       uw()
   }
 
-  out = .pr$Series$new(name %||% "", values) |>
+  out = result(as_polars_series(values, name)) |>
     uw()
 
   if (!is.null(dtype)) {

--- a/man/as_polars_series.Rd
+++ b/man/as_polars_series.Rd
@@ -52,10 +52,11 @@ as_polars_series(x, name = NULL, ...)
 \method{as_polars_series}{clock_zoned_time}(x, name = NULL, ...)
 }
 \arguments{
-\item{x}{Object to convert into a polars Series}
+\item{x}{Object to convert into \link[=Series_class]{a polars Series}.}
 
-\item{name}{A string to use as the name of the Series.
-If \code{NULL} (default), the name of \code{x} is used or an unnamed Series is created.}
+\item{name}{A character to use as the name of the \link[=Series_class]{Series}.
+If \code{NULL} (default), the name of \code{x} is used or an empty character \code{""}
+will be used if \code{x} has no name.}
 
 \item{...}{Additional arguments passed to methods.}
 
@@ -65,8 +66,8 @@ If \code{NULL} (default), the name of \code{x} is used or an unnamed Series is c
 a \link[=Series_class]{Series}
 }
 \description{
-\code{\link[=as_polars_series]{as_polars_series()}} is a generic function that converts an R object to a
-polars Series. It is basically a wrapper for \link[=pl_Series]{pl$Series()}.
+\code{\link[=as_polars_series]{as_polars_series()}} is a generic function that converts an R object to
+\link[=Series_class]{a polars Series}.
 }
 \examples{
 as_polars_series(1:4)

--- a/man/pl_Series.Rd
+++ b/man/pl_Series.Rd
@@ -12,10 +12,11 @@ pl_Series(..., values = NULL, name = NULL, dtype = NULL, nan_to_null = FALSE)
 In future versions, the order of the arguments will be changed to
 \code{pl$Series(name, values, dtype, ..., nan_to_null)} and \code{...} will be ignored.}
 
-\item{values}{Vector of base R types, or \code{NULL} (default).
-If \code{NULL}, empty Series is created.}
+\item{values}{Object to convert into a polars Series.
+Passed to the \code{x} argument in \link[=as_polars_series]{as_polars_series()}.}
 
-\item{name}{Name of the Series. If \code{NULL} (default), an empty string is used.}
+\item{name}{A character to use as the name of the Series, or \code{NULL} (default).
+Passed to the \code{name} argument in \link[=as_polars_series]{as_polars_series()}.}
 
 \item{dtype}{One of \link[=pl_dtypes]{polars data type} or \code{NULL}.
 If not \code{NULL}, that data type is used to \link[=Expr_cast]{cast} the Series created from the vector
@@ -28,9 +29,9 @@ Using the \code{\link[=Expr_fill_nan]{$fill_nan()}} method internally.}
 \link[=Series_class]{Series}
 }
 \description{
-This function is a simple way to convert basic types of vectors provided by base R to
+This function is a simple way to convert R vectors to
 \link[=Series_class]{the Series class object}.
-For converting more types properly, use the generic function \code{\link[=as_polars_series]{as_polars_series()}}.
+Internally, this function is a simple wrapper of \code{\link[=as_polars_series]{as_polars_series()}}.
 }
 \examples{
 # Constructing a Series by specifying name and values positionally (deprecated):


### PR DESCRIPTION
Related to #1012.

`as_polars_series.default()` used to call `pl$Series()`, but will be changed so that `pl$Series()` calls `as_polars_series()`.
This will ensure that every object is properly converted to a Series.

Python's `polars.Series.__init__()` internally converts various objects into a Series through a large number of conditional branches. This update is very similar to that.