### PR TITLE
fix!: fix list type column conversion from data frame

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,7 +14,7 @@
 ### Other breaking changes
 
 - R objects inside an R list are now converted to Polars data types via
-  `as_polars_series()` (#1021). For example, up to polars 0.15.1,
+  `as_polars_series()` (#1021, #1022). For example, up to polars 0.15.1,
   a list containing a data.frame with a column of `{clock}` naive-time class
   was converted to a nested List type of Float64:
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,32 +15,40 @@
 
 - R objects inside an R list are now converted to Polars data types via
   `as_polars_series()` (#1021). For example, up to polars 0.15.1,
-  data.frames inside a list were converted to a nested List type:
+  a list containing a data.frame with a column of `{clock}` naive-time class
+  was converted to a nested List type of Float64:
 
   ```r
-  pl$select(nested_data = pl$lit(list(data.frame(a = 1))))
+  data = data.frame(time = clock::naive_time_parse("1990-01-01", precision = "day"))
+  pl$select(
+    nested_data = pl$lit(list(data))
+  )
   #> shape: (1, 1)
-  #> ┌─────────────────┐
-  #> │ nested_data     │
-  #> │ ---             │
-  #> │ list[list[f64]] │
-  #> ╞═════════════════╡
-  #> │ [[1.0]]         │
-  #> └─────────────────┘
+  #> ┌──────────────────────────┐
+  #> │ nested_data              │
+  #> │ ---                      │
+  #> │ list[list[list[f64]]]    │
+  #> ╞══════════════════════════╡
+  #> │ [[[2.1475e9], [7305.0]]] │
+  #> └──────────────────────────┘
   ```
 
-  From 0.16.0, data.frames inside a list are converted to the polars Struct type:
+  From 0.16.0, nested types are correctly converted, so that will be
+  a List type of Struct type containing a Datetime type.
 
   ```r
-  pl$select(nested_data = pl$lit(list(data.frame(a = 1))))
+  data = data.frame(time = clock::naive_time_parse("1990-01-01", precision = "day"))
+  pl$select(
+    nested_data = pl$lit(list(data))
+  )
   #> shape: (1, 1)
-  #> ┌─────────────────┐
-  #> │ nested_data     │
-  #> │ ---             │
-  #> │ list[struct[1]] │
-  #> ╞═════════════════╡
-  #> │ [{1.0}]         │
-  #> └─────────────────┘
+  #> ┌─────────────────────────┐
+  #> │ nested_data             │
+  #> │ ---                     │
+  #> │ list[struct[1]]         │
+  #> ╞═════════════════════════╡
+  #> │ [{1990-01-01 00:00:00}] │
+  #> └─────────────────────────┘
   ```
 
 - Several functions have been rewritten to match the behavior of Python Polars.

--- a/R/construction.R
+++ b/R/construction.R
@@ -223,7 +223,7 @@ df_to_rpldf = function(x, ..., schema = NULL, schema_overrides = NULL) {
       unwrap()
   }
 
-  out = lapply(x, as_polars_series) |>
+  out = lapply(x, \(col) as_polars_series(unAsIs(col))) |>
     pl$select()
 
   out$columns = col_names

--- a/tests/testthat/test-as_polars.R
+++ b/tests/testthat/test-as_polars.R
@@ -433,6 +433,11 @@ test_that("as_polars_series for nested type", {
   expect_true(
     as_polars_series(list(list(data.frame(a = 1))))$dtype == pl$List(pl$List(pl$Struct(a = pl$Float64)))
   )
+  expect_true(
+    as_polars_series(
+      list(data.frame(a = I(list(data.frame(b = 1L)))))
+    )$dtype == pl$List(pl$Struct(a = pl$List(pl$Struct(b = pl$Int32))))
+  )
 
   # TODO: this shouldn't error
   expect_grepl_error(


### PR DESCRIPTION
A follow up for #1021

I was trying more complex nested type cases and learned that the columns of list class of data.frame are `AsIs` class and the list class is hidden.

``` r
data.frame(a = I(list(data.frame(b = 1L))))$a |> class()
#> [1] "AsIs"
```

<sup>Created on 2024-04-11 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

So it was necessary to add a process here to convert this column back to the list class to convert it to the Series as intended.