### PR TITLE
fix: nested null data type Series treated as an empty Series

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,7 +14,7 @@
 ### Other breaking changes
 
 - R objects inside an R list are now converted to Polars data types via
-  `as_polars_series()` (#1021, #1022). For example, up to polars 0.15.1,
+  `as_polars_series()` (#1021, #1022, #1023). For example, up to polars 0.15.1,
   a list containing a data.frame with a column of `{clock}` naive-time class
   was converted to a nested List type of Float64:
 

--- a/R/as_polars.R
+++ b/R/as_polars.R
@@ -319,9 +319,12 @@ as_polars_lf.RPolarsLazyGroupBy = function(x, ...) {
 #'
 #' as_polars_series(data.frame(a = 1:4))
 #'
-#' as_polars_series(pl$Series(1:4, name = "foo"))
+#' as_polars_series(as_polars_series(1:4, name = "foo"))
 #'
 #' as_polars_series(pl$lit(1:4))
+#'
+#' # Nested type support
+#' as_polars_series(list(data.frame(a = I(list(1:4)))))
 as_polars_series = function(x, name = NULL, ...) {
   UseMethod("as_polars_series")
 }
@@ -525,7 +528,6 @@ as_polars_series.clock_zoned_time = function(x, name = NULL, ...) {
 }
 
 
-# TODO: rewrite `recursive_robjname2series_tree` in Rust side
 #' @rdname as_polars_series
 #' @export
 as_polars_series.list = function(x, name = NULL, ...) {

--- a/man/as_polars_series.Rd
+++ b/man/as_polars_series.Rd
@@ -79,7 +79,10 @@ as_polars_series(list(1:4))
 
 as_polars_series(data.frame(a = 1:4))
 
-as_polars_series(pl$Series(1:4, name = "foo"))
+as_polars_series(as_polars_series(1:4, name = "foo"))
 
 as_polars_series(pl$lit(1:4))
+
+# Nested type support
+as_polars_series(list(data.frame(a = I(list(1:4)))))
 }

--- a/tests/testthat/test-as_polars.R
+++ b/tests/testthat/test-as_polars.R
@@ -433,10 +433,17 @@ test_that("as_polars_series for nested type", {
   expect_true(
     as_polars_series(list(list(data.frame(a = 1))))$dtype == pl$List(pl$List(pl$Struct(a = pl$Float64)))
   )
-
-  # TODO: this shouldn't error
-  expect_grepl_error(
-    as_polars_series(list(as_polars_series(NULL), as_polars_series(1L))),
-    "One element was null and another was i32"
+  expect_true(
+    as_polars_series(list(as_polars_series(NULL), as_polars_series(1L)))$dtype == pl$List(pl$Int32)
+  )
+  expect_true(
+    as_polars_series(list(NULL, list(1, 2)))$equals(
+      as_polars_series(list(list(), list(1, 2)))
+    )
+  )
+  expect_true(
+    as_polars_series(list(as_polars_series(NULL), list(1, 2)))$equals(
+      as_polars_series(list(list(), list(1, 2)))
+    )
   )
 })


### PR DESCRIPTION
A follow up for #1021

This change will allow for more proper conversion from lists that contain NULLs or empty lists.

For example, in 0.15.1, a strange error occurs in the following case:

```r
> as_polars_series(list(list(), list(1, 2)))
Error: Execution halted with the following contexts
   0: In R: in pl$Series():
   0: During function call [as_polars_series(list(list(), list(1, 2)))]
   1: Encountered the following error in Rust-Polars:
        data types don't match: When building series from R list; some parsed sub-elements did not match: One element was f64 and another was list[f64]
```