### PR TITLE
refactor: `pl$DataFrame(<data.frame>)` uses `as_polars_df()`

### DIFF
--- a/R/dataframe__frame.R
+++ b/R/dataframe__frame.R
@@ -226,7 +226,7 @@ DataFrame_width = method_as_active_binding(\() .pr$DataFrame$shape(self)[2L])
 
 #' Create a new polars DataFrame
 #'
-#' @param ... One of the followings:
+#' @param ... One of the following:
 #'  - a list of mixed vectors and Series of equal length
 #'  - mixed vectors and/or Series of equal length
 #'  - a positional argument of a [data.frame] or a [DataFrame][DataFrame_class]

--- a/R/dataframe__frame.R
+++ b/R/dataframe__frame.R
@@ -224,13 +224,13 @@ DataFrame_width = method_as_active_binding(\() .pr$DataFrame$shape(self)[2L])
 
 
 
-#' Create new DataFrame
-#' @name pl_DataFrame
+#' Create a new polars DataFrame
 #'
-#' @param ... One of the following:
-#'  - a data.frame or something that inherits data.frame or DataFrame
+#' @param ... One of the followings:
 #'  - a list of mixed vectors and Series of equal length
 #'  - mixed vectors and/or Series of equal length
+#'  - a positional argument of a [data.frame] or a [DataFrame][DataFrame_class]
+#'    (not recommended use). In this case, the object will be passed to [as_polars_df()].
 #'
 #' Columns will be named as of named arguments or alternatively by names of
 #' Series or given a placeholder name.
@@ -239,9 +239,9 @@ DataFrame_width = method_as_active_binding(\() .pr$DataFrame$shape(self)[2L])
 #'  prefixed a running number.
 #' @param schema A named list that will be used to convert a variable to a
 #' specific DataType. See Examples.
-#'
-#' @return DataFrame
-#' @keywords DataFrame_new
+#' @seealso
+#' - [as_polars_df()]
+#' @return [DataFrame][DataFrame_class]
 #'
 #' @examples
 #' pl$DataFrame(
@@ -267,9 +267,21 @@ DataFrame_width = method_as_active_binding(\() .pr$DataFrame$shape(self)[2L])
 pl_DataFrame = function(..., make_names_unique = TRUE, schema = NULL) {
   uw = \(res) unwrap(res, "in $DataFrame():")
 
-  largs = unpack_list(...) |>
+  skip_classes = c("data.frame", "RPolarsDataFrame")
+  largs = unpack_list(..., skip_classes = skip_classes) |>
     result() |>
     uw()
+
+  # pass to `as_polars_df()`
+  if (length(largs) == 1L && is.null(names(largs)) &&
+    (inherits(largs[[1]], skip_classes))) {
+    # TODO: schema v.s. schema_overrides <https://github.com/pola-rs/r-polars/issues/897>
+    out = as_polars_df(largs[[1]], make_names_unique = make_names_unique, schema_overrides = schema) |>
+      result() |>
+      uw()
+
+    return(out)
+  }
 
   if (length(largs) > 0 && !is.null(schema) && !all(names(schema) %in% names(largs))) {
     Err_plain("Some columns in `schema` are not in the DataFrame.") |>
@@ -287,11 +299,6 @@ pl_DataFrame = function(..., make_names_unique = TRUE, schema = NULL) {
       out = .pr$DataFrame$default()
     }
     return(out)
-  }
-
-  # pass through if already a DataFrame
-  if (inherits(largs[[1L]], "RPolarsDataFrame")) {
-    return(largs[[1L]])
   }
 
   # keys are tentative new column names

--- a/man/pl_DataFrame.Rd
+++ b/man/pl_DataFrame.Rd
@@ -2,16 +2,17 @@
 % Please edit documentation in R/dataframe__frame.R
 \name{pl_DataFrame}
 \alias{pl_DataFrame}
-\title{Create new DataFrame}
+\title{Create a new polars DataFrame}
 \usage{
 pl_DataFrame(..., make_names_unique = TRUE, schema = NULL)
 }
 \arguments{
-\item{...}{One of the following:
+\item{...}{One of the followings:
 \itemize{
-\item a data.frame or something that inherits data.frame or DataFrame
 \item a list of mixed vectors and Series of equal length
 \item mixed vectors and/or Series of equal length
+\item a positional argument of a \link{data.frame} or a \link[=DataFrame_class]{DataFrame}
+(not recommended use). In this case, the object will be passed to \code{\link[=as_polars_df]{as_polars_df()}}.
 }
 
 Columns will be named as of named arguments or alternatively by names of
@@ -24,10 +25,10 @@ prefixed a running number.}
 specific DataType. See Examples.}
 }
 \value{
-DataFrame
+\link[=DataFrame_class]{DataFrame}
 }
 \description{
-Create new DataFrame
+Create a new polars DataFrame
 }
 \examples{
 pl$DataFrame(
@@ -51,4 +52,8 @@ pl$DataFrame(mtcars)
 # custom schema
 pl$DataFrame(iris, schema = list(Sepal.Length = pl$Float32, Species = pl$String))
 }
-\keyword{DataFrame_new}
+\seealso{
+\itemize{
+\item \code{\link[=as_polars_df]{as_polars_df()}}
+}
+}

--- a/man/pl_DataFrame.Rd
+++ b/man/pl_DataFrame.Rd
@@ -7,7 +7,7 @@
 pl_DataFrame(..., make_names_unique = TRUE, schema = NULL)
 }
 \arguments{
-\item{...}{One of the followings:
+\item{...}{One of the following:
 \itemize{
 \item a list of mixed vectors and Series of equal length
 \item mixed vectors and/or Series of equal length

--- a/tests/testthat/test-as_polars.R
+++ b/tests/testthat/test-as_polars.R
@@ -452,3 +452,16 @@ test_that("as_polars_series for nested type", {
     )
   )
 })
+
+
+test_that("as_polars_df and pl$DataFrame for data.frame has list column", {
+  data = data.frame(a = I(list(data.frame(b = 1L))))
+  expect_true(
+    as_polars_df(data)$equals(
+      pl$DataFrame(data)
+    )
+  )
+  expect_true(
+    as_polars_df(data)$dtypes[[1]] == pl$List(pl$Struct(b = pl$Int32))
+  )
+})


### PR DESCRIPTION
A follow up for #1022

Currently in the main branch, there are two functions for building DataFrame from data.frame, and each one handles list columns differently due to the changes made in #1022.

``` r
data = data.frame(a = I(list(data.frame(b = 1))))
polars::as_polars_df(data)
#> shape: (1, 1)
#> ┌─────────────────┐
#> │ a               │
#> │ ---             │
#> │ list[struct[1]] │
#> ╞═════════════════╡
#> │ [{1.0}]         │
#> └─────────────────┘
polars::pl$DataFrame(data)
#> shape: (1, 1)
#> ┌─────────────────┐
#> │ a               │
#> │ ---             │
#> │ list[list[f64]] │
#> ╞═════════════════╡
#> │ [[1.0]]         │
#> └─────────────────┘
```

<sup>Created on 2024-04-12 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

Since `pl$DataFrame()` may process a variety of arguments and the process to release the `AsIs` class may produce unintended results, simply change the process to pass `as_polars_df()` to convert the data.frame.