### PR TITLE
Minor improvement in error messages

### DIFF
--- a/R/dotdotdot.R
+++ b/R/dotdotdot.R
@@ -68,8 +68,7 @@ unpack_bool_expr_result = function(...) {
       if (!is.null(names(l))) {
         Err_plain(
           "Detected a named input.",
-          "This usually means that you've used `=` instead of `==`.",
-          "Some names seen:", head(names(l))
+          "This usually means that you've used `=` instead of `==`."
         )
       } else {
         l |>

--- a/R/error__rpolarserr.R
+++ b/R/error__rpolarserr.R
@@ -56,7 +56,7 @@ bad_robj = function(r) {
 }
 
 Err_plain = function(...) {
-  Err(.pr$Err$new()$plain(paste0(..., collapse = " ")))
+  Err(.pr$Err$new()$plain(paste(..., sep = " ", collapse = " ")))
 }
 
 # short hand for extracting an error context in unit testing, will raise error if not an RPolarsErr

--- a/R/error__rpolarserr.R
+++ b/R/error__rpolarserr.R
@@ -56,7 +56,7 @@ bad_robj = function(r) {
 }
 
 Err_plain = function(...) {
-  Err(.pr$Err$new()$plain(paste(..., sep = " ", collapse = " ")))
+  Err(.pr$Err$new()$plain(paste(..., collapse = " ")))
 }
 
 # short hand for extracting an error context in unit testing, will raise error if not an RPolarsErr


### PR DESCRIPTION
Fix spacing when several strings in `Err_plain()`. Also, I don't understand what the "Some names seen" message means and I don't think it makes the error message better so I suggest we remove it.

Old:
```r
> pl$when(a = 1)
Error: Execution halted with the following contexts
   0: In R: in pl$when():
   0: During function call [pl$when(a = 1)]
   1: Detected a named input.This usually means that you've used `=` instead of `==`.Some names seen:a
```
New:
```r
> pl$when(a = 1)
Error: Execution halted with the following contexts
   0: In R: in pl$when():
   0: During function call [pl$when(a = 1)]
   1: Detected a named input. This usually means that you've used `=` instead of `==`.
```