### PR TITLE
ci: exclude R devel on windows from binary library check step

### DIFF
--- a/.github/workflows/release-lib.yaml
+++ b/.github/workflows/release-lib.yaml
@@ -131,6 +131,8 @@ jobs:
             r: devel
           - os: macos-14
             r: oldrel-1
+          - os: windows-latest
+            r: devel
 
     permissions:
       contents: read


### PR DESCRIPTION
Currently, just after the release of R 4.4.0, R devel on Windows seems to fail to install `stringi`.
This is preventing the release, so I will skip this check.