### PR TITLE
ci: deploy the API document to GitHub Pages of this repo instead of rpolars/rpolars.github.io

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -49,7 +49,7 @@ env:
 permissions: read-all
 
 jobs:
-  documentation:
+  build:
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -111,6 +111,19 @@ jobs:
         with:
           path: docs
 
+  deploy:
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ (github.event_name != 'pull_request') }}
+    steps:
       - name: Deploy to GitHub Pages
+        id: deployment
         if: ${{ (github.event_name != 'pull_request') }}
         uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -99,34 +99,18 @@ jobs:
         run: |
           task setup-python-tools
 
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
       - name: Build docs
         run: task build-website
 
       - name: upload docs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-pages-artifact@v3
         with:
-          name: docs
           path: docs
 
-      - uses: webfactory/ssh-agent@v0.9.0
-        env:
-          DEPLOY_DOCS: ${{ secrets.DEPLOY_DOCS  }}
-        if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'pola-rs') }}
-        with:
-          ssh-private-key: ${{ secrets.DEPLOY_DOCS }}
-
-        # https://www.mkdocs.org/user-guide/deploying-your-docs/
-      - name: Build site and deploy to GitHub pages
-        env:
-          DEPLOY_DOCS: ${{ secrets.DEPLOY_DOCS  }}
-        if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'pola-rs') }}
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          clean: true
-          branch: main
-          folder: docs
-          repository-name: rpolars/rpolars.github.io
-          ssh-key: true
-          clean-exclude: |
-            .nojekyll
+      - name: Deploy to GitHub Pages
+        if: ${{ (github.event_name != 'pull_request') }}
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Close #932

Once this merged, I will update https://github.com/rpolars/rpolars.github.io to redirect to the new URL.
I would like to update the URLs in the source code afterwards.