### PR TITLE
ci: fix CI falure on Windows

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -15,6 +15,7 @@ runs:
   using: composite
   steps:
     - name: Should not update rustup
+      shell: bash
       run: rustup set auto-self-update disable
     - name: Update Rust
       if: inputs.rust-nightly != 'true' && env.LIBR_POLARS_FEATURES != 'full_features'

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -14,6 +14,8 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Should not update rustup
+      run: rustup set auto-self-update disable
     - name: Update Rust
       if: inputs.rust-nightly != 'true' && env.LIBR_POLARS_FEATURES != 'full_features'
       shell: bash


### PR DESCRIPTION
Builds on Windows are failing frequently with the following error (For example, in #1083).

```log
info: checking for self-update
info: downloading self-update
task: [setup-rust-toolchain] rustup default nightly-2024-04-15-gnu
warning: tool `rust-analyzer` is already installed, remove it from `C:\Users\runneradmin\.cargo\bin`, then run `rustup update` to have rustup manage this tool.
error: could not remove 'setup' file: 'C:\Users\runneradmin\.cargo\bin/rustup-init.exe': Access is denied. (os error 5)
warning: tool `rustfmt` is already installed, remove it from `C:\Users\runneradmin\.cargo\bin`, then run `rustup update` to have rustup manage this tool.
task: Failed to run task "setup-rust-toolchain": exit status 1
warning: tool `cargo-fmt` is already installed, remove it from `C:\Users\runneradmin\.cargo\bin`, then run `rustup update` to have rustup manage this tool.
Error: Process completed with exit code 201.
```

The self-updating feature of rustup may be related.
See rust-lang/rustup#3709