### PR TITLE
Temporarily disable examples for `$name$map()`

### DIFF
--- a/R/expr__name.R
+++ b/R/expr__name.R
@@ -56,17 +56,17 @@ ExprName_keep = function() {
 #' @param fun an R function which takes a string as input and return a string
 #' @return Expr
 #'
-#' @examplesIf FALSE
-#' df = pl$DataFrame(var1 = 1:3, var2 = "a")
-#'
-#' df$select(
-#'   pl$col("*")$name$map(\(x) paste0("new_", x))
-#' )
-#'
-#' # $alias() is not taken into account by $name$map()
-#' df$select(
-#'   pl$col("var1")$alias("foobar")$name$map(\(x) paste0("new_", x))
-#' )
+#' @examples
+#' # df = pl$DataFrame(var1 = 1:3, var2 = "a")
+#' #
+#' #  df$select(
+#' #    pl$col("*")$name$map(\(x) paste0("new_", x))
+#' #  )
+#' #
+#' #  # $alias() is not taken into account by $name$map()
+#' #  df$select(
+#' #    pl$col("var1")$alias("foobar")$name$map(\(x) paste0("new_", x))
+#' #  )
 ExprName_map = function(fun) {
   if (
     !polars_options()$no_messages &&

--- a/man/ExprName_map.Rd
+++ b/man/ExprName_map.Rd
@@ -16,16 +16,14 @@ Expr
 Rename the output of an expression by mapping a function over the root name.
 }
 \examples{
-\dontshow{if (FALSE) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
-df = pl$DataFrame(var1 = 1:3, var2 = "a")
-
-df$select(
-  pl$col("*")$name$map(\(x) paste0("new_", x))
-)
-
-# $alias() is not taken into account by $name$map()
-df$select(
-  pl$col("var1")$alias("foobar")$name$map(\(x) paste0("new_", x))
-)
-\dontshow{\}) # examplesIf}
+# df = pl$DataFrame(var1 = 1:3, var2 = "a")
+#
+#  df$select(
+#    pl$col("*")$name$map(\(x) paste0("new_", x))
+#  )
+#
+#  # $alias() is not taken into account by $name$map()
+#  df$select(
+#    pl$col("var1")$alias("foobar")$name$map(\(x) paste0("new_", x))
+#  )
 }


### PR DESCRIPTION
I'd like to find a solution for `$name$map()`, I'm not sure `$rename()` would do the same thing but I need to think more about this. In the meantime I disable its examples since they fail on CI and prevent the website to be updated. This failure is weird since I had put `@examplesIf FALSE` in a previous PR so it shouldn't be evaluated, but apparently it still is.