### PR TITLE
allow the crate to be build as rust library

### DIFF
--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.77.0"
 publish = false
 
 [lib]
-crate-type = ['staticlib']
+crate-type = ['staticlib', 'rlib']
 
 [features]
 default = ["sql"]


### PR DESCRIPTION
this enables git import of `r-polars` in other rust based R libraries

`Cargo.toml`
```toml
[package]
name = "test-import"
version = "0.1.0"
edition = "2021"

[lib]
crate-type = ["rlib", "staticlib"]

[dependencies]
r-polars = { git = "https://github.com/ju6ge/r-polars", branch = "feature/enable-rust-git-import" }
extendr-api = { git = "https://github.com/extendr/extendr", rev = "1895bfc8ee22347665900caa0e48da4f0b13232f" }
```
`lib.rs`
```rust
use r_polars::rdataframe::RPolarsDataFrame;
use extendr_api::prelude::*;

#[extendr]
/// @export
pub fn export_dataframe() -> RPolarsDataFrame {
    RPolarsDataFrame::default()
}

extendr_module! {
    mod polars_export;
    fn export_dataframe;
}

```