### PR TITLE
Fix tilde expansion in filenames

### DIFF
--- a/R/dataframe__frame.R
+++ b/R/dataframe__frame.R
@@ -1961,6 +1961,7 @@ DataFrame_write_csv = function(
     float_precision = NULL,
     null_values = "",
     quote_style = "necessary") {
+  file = path.expand(file)
   .pr$DataFrame$write_csv(
     self,
     file, include_bom, include_header, separator, line_terminator, quote,
@@ -1998,6 +1999,7 @@ DataFrame_write_ipc = function(
     compression = c("uncompressed", "zstd", "lz4"),
     ...,
     future = FALSE) {
+  file = path.expand(file)
   if (isTRUE(future)) {
     warning("The `future` parameter of `$write_ipc()` is considered unstable.")
   }
@@ -2034,6 +2036,7 @@ DataFrame_write_parquet = function(
     statistics = FALSE,
     row_group_size = NULL,
     data_pagesize_limit = NULL) {
+  file = path.expand(file)
   .pr$DataFrame$write_parquet(
     self,
     file,
@@ -2073,6 +2076,7 @@ DataFrame_write_json = function(
     ...,
     pretty = FALSE,
     row_oriented = FALSE) {
+  file = path.expand(file)
   .pr$DataFrame$write_json(self, file, pretty, row_oriented) |>
     unwrap("in $write_json():")
 
@@ -2094,6 +2098,7 @@ DataFrame_write_json = function(
 #'
 #' pl$read_ndjson(destination)
 DataFrame_write_ndjson = function(file) {
+  file = path.expand(file)
   .pr$DataFrame$write_ndjson(self, file) |>
     unwrap("in $write_ndjson():")
 

--- a/R/io_csv.R
+++ b/R/io_csv.R
@@ -195,6 +195,7 @@ check_is_link = function(path, reuse_downloaded, raise_error = FALSE) {
   if (is.na(path)) {
     return(NULL)
   }
+  path = path.expand(path)
   if (!file.exists(path)) {
     con = NULL
 

--- a/R/io_ipc.R
+++ b/R/io_ipc.R
@@ -37,6 +37,7 @@ pl_scan_ipc = function(
     row_index_offset = 0L,
     rechunk = FALSE,
     cache = TRUE) {
+  source = path.expand(source)
   import_arrow_ipc(
     source,
     n_rows,

--- a/R/io_parquet.R
+++ b/R/io_parquet.R
@@ -72,6 +72,7 @@ pl_scan_parquet = function(
     storage_options = NULL,
     use_statistics = TRUE,
     cache = TRUE) {
+  source = path.expand(source)
   new_from_parquet(
     path = source,
     n_rows = n_rows,

--- a/R/lazyframe__lazy.R
+++ b/R/lazyframe__lazy.R
@@ -672,6 +672,7 @@ LazyFrame_sink_parquet = function(
     slice_pushdown = TRUE,
     no_optimization = FALSE,
     inherit_optimization = FALSE) {
+  path = path.expand(path)
   if (isTRUE(no_optimization)) {
     predicate_pushdown = FALSE
     projection_pushdown = FALSE
@@ -750,6 +751,7 @@ LazyFrame_sink_ipc = function(
     slice_pushdown = TRUE,
     no_optimization = FALSE,
     inherit_optimization = FALSE) {
+  path = path.expand(path)
   if (isTRUE(no_optimization)) {
     predicate_pushdown = FALSE
     projection_pushdown = FALSE
@@ -832,6 +834,7 @@ LazyFrame_sink_csv = function(
     slice_pushdown = TRUE,
     no_optimization = FALSE,
     inherit_optimization = FALSE) {
+  path = path.expand(path)
   if (isTRUE(no_optimization)) {
     predicate_pushdown = FALSE
     projection_pushdown = FALSE
@@ -909,6 +912,7 @@ LazyFrame_sink_ndjson = function(
     slice_pushdown = TRUE,
     no_optimization = FALSE,
     inherit_optimization = FALSE) {
+  path = path.expand(path)
   if (isTRUE(no_optimization)) {
     predicate_pushdown = FALSE
     projection_pushdown = FALSE


### PR DESCRIPTION
Close #1085

Add path expansion for all `$write_`, `$sink_`, `$read_` and `$scan_` functions. Still draft because I don't know how to test since the `~` expansion will necessarily depend on the file structure of the system on which it runs (I think). @eitsupi any ideas about this?

