### PR TITLE
Add a base R `check_empty_dots()`

### DIFF
--- a/R/expr__expr.R
+++ b/R/expr__expr.R
@@ -1417,6 +1417,7 @@ Expr_sort = function(..., descending = FALSE, nulls_last = FALSE) {
 #' @examples
 #' pl$DataFrame(a = c(6, 1, 0, NA, Inf, NaN))$select(pl$col("a")$top_k(5))
 Expr_top_k = function(k, ..., nulls_last = FALSE, maintain_order = FALSE, multithreaded = TRUE) {
+  check_dots_empty(...)
   if (!is.numeric(k) || k < 0) stop("k must be numeric and positive, prefereably integerish")
   .pr$Expr$top_k(self, k, nulls_last = nulls_last, maintain_order = maintain_order, multithreaded = multithreaded) |>
     unwrap("in $top_k():")

--- a/R/utils.R
+++ b/R/utils.R
@@ -678,3 +678,15 @@ is_named = function(x) {
   }
   TRUE
 }
+
+get_dots <- function(...) {
+  eval(substitute(alist(...)))
+}
+
+check_dots_empty <- function(...) {
+  dots <- get_dots(...)
+  if (length(dots) > 0) {
+    Err_plain("`...` must be empty. Problematic values:", toString(dots)) |>
+      unwrap()
+  }
+}


### PR DESCRIPTION
Related to #942 

It seems unnecessary to me to import `rlang` to check for empty dots. Also `rlang::check_empty_dots()` is very expensive on my machine, about 200ms, but I didn't find why (if it's due to `rlang` update, RStudio, etc.). I'm not completely against having `rlang` but if we can have easy base R alternatives I don't think it's worth importing it.

This PR is just an example of what it would look like, for example with `$top_k()`:

```r
pl$DataFrame(a = c(6, 1, 0, NA, Inf, NaN))$select(pl$col("a")$top_k(5, nulls_last = TRUE, FALSE, 1))
```
```
Error: Execution halted with the following contexts
   0: In R: in $select()
   0: During function call [pl$DataFrame(a = c(6, 1, 0, NA, Inf, NaN))$select(pl$col("a")$top_k(5, 
          nulls_last = TRUE, FALSE, 1))]
   1: `...` must be empty. Problematic values: FALSE, 1
```