### PR TITLE
docs: use r-multiverse repo instead of rpolars repo for installing the latest release version

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -20,6 +20,7 @@ knitr::opts_chunk$set(
 # polars
 
 <!-- badges: start -->
+[![R-multiverse status](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fcommunity.r-multiverse.org%2Fapi%2Fpackages%2Fpolars&query=%24.Version&label=r-multiverse)](https://community.r-multiverse.org/polars)
 [![R-universe status badge](https://rpolars.r-universe.dev/badges/polars)](https://rpolars.r-universe.dev)
 [![CRAN status](https://www.r-pkg.org/badges/version/polars)](https://CRAN.R-project.org/package=polars)
 [![Dev R-CMD-check](https://github.com/pola-rs/r-polars/actions/workflows/check.yaml/badge.svg)](https://github.com/pola-rs/r-polars/actions/workflows/check.yaml)
@@ -54,11 +55,11 @@ when updating `polars`.
 
 ## Install
 
-The recommended way to install this package is via R-universe:
+The recommended way to install this package is via R-multiverse:
 
 ```r
 Sys.setenv(NOT_CRAN = "true")
-install.packages("polars", repos = "https://rpolars.r-universe.dev")
+install.packages("polars", repos = "https://r-multiverse.r-universe.dev")
 ```
 
 [The "Install" vignette](https://pola-rs.github.io/r-polars/vignettes/install.html) (`vignette("install", "polars")`)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 <!-- badges: start -->
 
+[![R-multiverse
+status](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fcommunity.r-multiverse.org%2Fapi%2Fpackages%2Fpolars&query=%24.Version&label=r-multiverse)](https://community.r-multiverse.org/polars)
 [![R-universe status
 badge](https://rpolars.r-universe.dev/badges/polars)](https://rpolars.r-universe.dev)
 [![CRAN
@@ -45,11 +47,11 @@ breaking changes at each version. Be sure to check the
 
 ## Install
 
-The recommended way to install this package is via R-universe:
+The recommended way to install this package is via R-multiverse:
 
 ``` r
 Sys.setenv(NOT_CRAN = "true")
-install.packages("polars", repos = "https://rpolars.r-universe.dev")
+install.packages("polars", repos = "https://r-multiverse.r-universe.dev")
 ```
 
 [The “Install”

--- a/vignettes/install.Rmd
+++ b/vignettes/install.Rmd
@@ -31,7 +31,7 @@ Installing the latest release version.
 
 ```r
 Sys.setenv(NOT_CRAN = "true") # Enable installation with pre-built Rust library binary, or enable Rust caching
-install.packages("polars", repos = "https://rpolars.r-universe.dev")
+install.packages("polars", repos = "https://r-multiverse.r-universe.dev")
 ```
 
 - On supported platforms, binary R package will be installed.
@@ -111,7 +111,7 @@ For example (on Bash):
 ```sh
 export LIBR_POLARS_BUILD="false"
 export LIBR_POLARS_PATH="/tmp/libr_polars.a"
-Rscript -e 'install.packages("polars", repos = "https://rpolars.r-universe.dev", type = "source")'
+Rscript -e 'install.packages("polars", repos = "https://r-multiverse.r-universe.dev", type = "source")'
 ```
 
 ### Rust build time options


### PR DESCRIPTION
Close #1151

Related to #1152, I hope to be able to use GitHub pre-releases in the future to install rewritten versions of the polars package from the rpolars repo.
r-multivese is always tied to the latest release, but rpolars repo can be tied to specific git tag, so pre-releases are ignored by r-multivesre and only rpolars can be updated.
(of course, we will need to call for a switch in installation approach on the NEWS file before that can happen).

## Background

@shikokuchuo says that the R-multiverse community universe (<https://community.r-multiverse.org/builds>) is ready for use, but will not be actively promoted until the production universe (<https://production.r-multiverse.org/builds>) is complete.