### PR TITLE
Point to canonical URL for R-multiverse

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -59,7 +59,7 @@ The recommended way to install this package is via R-multiverse:
 
 ```r
 Sys.setenv(NOT_CRAN = "true")
-install.packages("polars", repos = "https://r-multiverse.r-universe.dev")
+install.packages("polars", repos = "https://community.r-multiverse.org")
 ```
 
 [The "Install" vignette](https://pola-rs.github.io/r-polars/vignettes/install.html) (`vignette("install", "polars")`)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The recommended way to install this package is via R-multiverse:
 
 ``` r
 Sys.setenv(NOT_CRAN = "true")
-install.packages("polars", repos = "https://r-multiverse.r-universe.dev")
+install.packages("polars", repos = "https://community.r-multiverse.org")
 ```
 
 [The “Install”

--- a/vignettes/install.Rmd
+++ b/vignettes/install.Rmd
@@ -31,7 +31,7 @@ Installing the latest release version.
 
 ```r
 Sys.setenv(NOT_CRAN = "true") # Enable installation with pre-built Rust library binary, or enable Rust caching
-install.packages("polars", repos = "https://r-multiverse.r-universe.dev")
+install.packages("polars", repos = "https://community.r-multiverse.org")
 ```
 
 - On supported platforms, binary R package will be installed.
@@ -111,7 +111,7 @@ For example (on Bash):
 ```sh
 export LIBR_POLARS_BUILD="false"
 export LIBR_POLARS_PATH="/tmp/libr_polars.a"
-Rscript -e 'install.packages("polars", repos = "https://r-multiverse.r-universe.dev", type = "source")'
+Rscript -e 'install.packages("polars", repos = "https://community.r-multiverse.org", type = "source")'
 ```
 
 ### Rust build time options


### PR DESCRIPTION
@eitsupi sorry I didn't notice until you'd merged #1159.

For the installation instructions, the URL to use should be <https://community.r-multiverse.org>.

I've amended it for you in the places you had changed.