### PR TITLE
Bump rust-polars to unreleased version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -116,7 +116,7 @@ Collate:
     'sql.R'
     'vctrs.R'
     'zzz.R'
-Config/rextendr/version: 0.3.1
+Config/rextendr/version: 0.3.1.9000
 VignetteBuilder: knitr
 Config/polars/LibVersion: 0.41.1
 Config/polars/RustToolchainVersion: nightly-2024-07-26

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -116,7 +116,7 @@ Collate:
     'sql.R'
     'vctrs.R'
     'zzz.R'
-Config/rextendr/version: 0.3.1.9000
+Config/rextendr/version: 0.3.1
 VignetteBuilder: knitr
 Config/polars/LibVersion: 0.41.1
 Config/polars/RustToolchainVersion: nightly-2024-07-26

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 ### Breaking changes
 
-- Updated rust-polars to 0.42.0 (#1183).
+- Updated rust-polars to unreleased 2024-08-20, after 0.42.0 (#1183).
 - `$describe_plan()` and `$describe_optimized_plan()` are removed. Use
   respectively `$explain(optimized = FALSE)` and `$explain()` instead (#1182).
 - The parameter `inherit_optimization` is removed from all functions that had it

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -1684,7 +1684,7 @@ dependencies = [
 [[package]]
 name = "polars"
 version = "0.42.0"
-source = "git+https://github.com/pola-rs/polars.git?rev=7686025ac7738607f2d4f6887e9a1313b7c8b1e2#7686025ac7738607f2d4f6887e9a1313b7c8b1e2"
+source = "git+https://github.com/pola-rs/polars.git?rev=67551b6594c581731f0e9ca814ff7c39377bd324#67551b6594c581731f0e9ca814ff7c39377bd324"
 dependencies = [
  "getrandom",
  "polars-arrow",
@@ -1704,7 +1704,7 @@ dependencies = [
 [[package]]
 name = "polars-arrow"
 version = "0.42.0"
-source = "git+https://github.com/pola-rs/polars.git?rev=7686025ac7738607f2d4f6887e9a1313b7c8b1e2#7686025ac7738607f2d4f6887e9a1313b7c8b1e2"
+source = "git+https://github.com/pola-rs/polars.git?rev=67551b6594c581731f0e9ca814ff7c39377bd324#67551b6594c581731f0e9ca814ff7c39377bd324"
 dependencies = [
  "ahash",
  "atoi",
@@ -1751,7 +1751,7 @@ dependencies = [
 [[package]]
 name = "polars-compute"
 version = "0.42.0"
-source = "git+https://github.com/pola-rs/polars.git?rev=7686025ac7738607f2d4f6887e9a1313b7c8b1e2#7686025ac7738607f2d4f6887e9a1313b7c8b1e2"
+source = "git+https://github.com/pola-rs/polars.git?rev=67551b6594c581731f0e9ca814ff7c39377bd324#67551b6594c581731f0e9ca814ff7c39377bd324"
 dependencies = [
  "bytemuck",
  "either",
@@ -1766,7 +1766,7 @@ dependencies = [
 [[package]]
 name = "polars-core"
 version = "0.42.0"
-source = "git+https://github.com/pola-rs/polars.git?rev=7686025ac7738607f2d4f6887e9a1313b7c8b1e2#7686025ac7738607f2d4f6887e9a1313b7c8b1e2"
+source = "git+https://github.com/pola-rs/polars.git?rev=67551b6594c581731f0e9ca814ff7c39377bd324#67551b6594c581731f0e9ca814ff7c39377bd324"
 dependencies = [
  "ahash",
  "bitflags",
@@ -1800,7 +1800,7 @@ dependencies = [
 [[package]]
 name = "polars-error"
 version = "0.42.0"
-source = "git+https://github.com/pola-rs/polars.git?rev=7686025ac7738607f2d4f6887e9a1313b7c8b1e2#7686025ac7738607f2d4f6887e9a1313b7c8b1e2"
+source = "git+https://github.com/pola-rs/polars.git?rev=67551b6594c581731f0e9ca814ff7c39377bd324#67551b6594c581731f0e9ca814ff7c39377bd324"
 dependencies = [
  "avro-schema",
  "object_store",
@@ -1813,7 +1813,7 @@ dependencies = [
 [[package]]
 name = "polars-expr"
 version = "0.42.0"
-source = "git+https://github.com/pola-rs/polars.git?rev=7686025ac7738607f2d4f6887e9a1313b7c8b1e2#7686025ac7738607f2d4f6887e9a1313b7c8b1e2"
+source = "git+https://github.com/pola-rs/polars.git?rev=67551b6594c581731f0e9ca814ff7c39377bd324#67551b6594c581731f0e9ca814ff7c39377bd324"
 dependencies = [
  "ahash",
  "bitflags",
@@ -1832,7 +1832,7 @@ dependencies = [
 [[package]]
 name = "polars-io"
 version = "0.42.0"
-source = "git+https://github.com/pola-rs/polars.git?rev=7686025ac7738607f2d4f6887e9a1313b7c8b1e2#7686025ac7738607f2d4f6887e9a1313b7c8b1e2"
+source = "git+https://github.com/pola-rs/polars.git?rev=67551b6594c581731f0e9ca814ff7c39377bd324#67551b6594c581731f0e9ca814ff7c39377bd324"
 dependencies = [
  "ahash",
  "async-trait",
@@ -1879,7 +1879,7 @@ dependencies = [
 [[package]]
 name = "polars-json"
 version = "0.42.0"
-source = "git+https://github.com/pola-rs/polars.git?rev=7686025ac7738607f2d4f6887e9a1313b7c8b1e2#7686025ac7738607f2d4f6887e9a1313b7c8b1e2"
+source = "git+https://github.com/pola-rs/polars.git?rev=67551b6594c581731f0e9ca814ff7c39377bd324#67551b6594c581731f0e9ca814ff7c39377bd324"
 dependencies = [
  "ahash",
  "chrono",
@@ -1900,7 +1900,7 @@ dependencies = [
 [[package]]
 name = "polars-lazy"
 version = "0.42.0"
-source = "git+https://github.com/pola-rs/polars.git?rev=7686025ac7738607f2d4f6887e9a1313b7c8b1e2#7686025ac7738607f2d4f6887e9a1313b7c8b1e2"
+source = "git+https://github.com/pola-rs/polars.git?rev=67551b6594c581731f0e9ca814ff7c39377bd324#67551b6594c581731f0e9ca814ff7c39377bd324"
 dependencies = [
  "ahash",
  "bitflags",
@@ -1927,7 +1927,7 @@ dependencies = [
 [[package]]
 name = "polars-mem-engine"
 version = "0.42.0"
-source = "git+https://github.com/pola-rs/polars.git?rev=7686025ac7738607f2d4f6887e9a1313b7c8b1e2#7686025ac7738607f2d4f6887e9a1313b7c8b1e2"
+source = "git+https://github.com/pola-rs/polars.git?rev=67551b6594c581731f0e9ca814ff7c39377bd324#67551b6594c581731f0e9ca814ff7c39377bd324"
 dependencies = [
  "futures",
  "memmap2",
@@ -1948,7 +1948,7 @@ dependencies = [
 [[package]]
 name = "polars-ops"
 version = "0.42.0"
-source = "git+https://github.com/pola-rs/polars.git?rev=7686025ac7738607f2d4f6887e9a1313b7c8b1e2#7686025ac7738607f2d4f6887e9a1313b7c8b1e2"
+source = "git+https://github.com/pola-rs/polars.git?rev=67551b6594c581731f0e9ca814ff7c39377bd324#67551b6594c581731f0e9ca814ff7c39377bd324"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -1984,7 +1984,7 @@ dependencies = [
 [[package]]
 name = "polars-parquet"
 version = "0.42.0"
-source = "git+https://github.com/pola-rs/polars.git?rev=7686025ac7738607f2d4f6887e9a1313b7c8b1e2#7686025ac7738607f2d4f6887e9a1313b7c8b1e2"
+source = "git+https://github.com/pola-rs/polars.git?rev=67551b6594c581731f0e9ca814ff7c39377bd324#67551b6594c581731f0e9ca814ff7c39377bd324"
 dependencies = [
  "ahash",
  "async-stream",
@@ -2011,7 +2011,7 @@ dependencies = [
 [[package]]
 name = "polars-pipe"
 version = "0.42.0"
-source = "git+https://github.com/pola-rs/polars.git?rev=7686025ac7738607f2d4f6887e9a1313b7c8b1e2#7686025ac7738607f2d4f6887e9a1313b7c8b1e2"
+source = "git+https://github.com/pola-rs/polars.git?rev=67551b6594c581731f0e9ca814ff7c39377bd324#67551b6594c581731f0e9ca814ff7c39377bd324"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-queue",
@@ -2038,7 +2038,7 @@ dependencies = [
 [[package]]
 name = "polars-plan"
 version = "0.42.0"
-source = "git+https://github.com/pola-rs/polars.git?rev=7686025ac7738607f2d4f6887e9a1313b7c8b1e2#7686025ac7738607f2d4f6887e9a1313b7c8b1e2"
+source = "git+https://github.com/pola-rs/polars.git?rev=67551b6594c581731f0e9ca814ff7c39377bd324#67551b6594c581731f0e9ca814ff7c39377bd324"
 dependencies = [
  "ahash",
  "bitflags",
@@ -2071,7 +2071,7 @@ dependencies = [
 [[package]]
 name = "polars-row"
 version = "0.42.0"
-source = "git+https://github.com/pola-rs/polars.git?rev=7686025ac7738607f2d4f6887e9a1313b7c8b1e2#7686025ac7738607f2d4f6887e9a1313b7c8b1e2"
+source = "git+https://github.com/pola-rs/polars.git?rev=67551b6594c581731f0e9ca814ff7c39377bd324#67551b6594c581731f0e9ca814ff7c39377bd324"
 dependencies = [
  "bytemuck",
  "polars-arrow",
@@ -2082,7 +2082,7 @@ dependencies = [
 [[package]]
 name = "polars-sql"
 version = "0.42.0"
-source = "git+https://github.com/pola-rs/polars.git?rev=7686025ac7738607f2d4f6887e9a1313b7c8b1e2#7686025ac7738607f2d4f6887e9a1313b7c8b1e2"
+source = "git+https://github.com/pola-rs/polars.git?rev=67551b6594c581731f0e9ca814ff7c39377bd324#67551b6594c581731f0e9ca814ff7c39377bd324"
 dependencies = [
  "hex",
  "once_cell",
@@ -2102,7 +2102,7 @@ dependencies = [
 [[package]]
 name = "polars-time"
 version = "0.42.0"
-source = "git+https://github.com/pola-rs/polars.git?rev=7686025ac7738607f2d4f6887e9a1313b7c8b1e2#7686025ac7738607f2d4f6887e9a1313b7c8b1e2"
+source = "git+https://github.com/pola-rs/polars.git?rev=67551b6594c581731f0e9ca814ff7c39377bd324#67551b6594c581731f0e9ca814ff7c39377bd324"
 dependencies = [
  "atoi",
  "bytemuck",
@@ -2123,7 +2123,7 @@ dependencies = [
 [[package]]
 name = "polars-utils"
 version = "0.42.0"
-source = "git+https://github.com/pola-rs/polars.git?rev=7686025ac7738607f2d4f6887e9a1313b7c8b1e2#7686025ac7738607f2d4f6887e9a1313b7c8b1e2"
+source = "git+https://github.com/pola-rs/polars.git?rev=67551b6594c581731f0e9ca814ff7c39377bd324#67551b6594c581731f0e9ca814ff7c39377bd324"
 dependencies = [
  "ahash",
  "bytemuck",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -50,8 +50,8 @@ serde_json = "*"
 smartstring = "1.0.1"
 state = "0.6.0"
 thiserror = "1.0.63"
-polars-core = { git = "https://github.com/pola-rs/polars.git", rev = "7686025ac7738607f2d4f6887e9a1313b7c8b1e2", default-features = false }
-polars-lazy = { git = "https://github.com/pola-rs/polars.git", rev = "7686025ac7738607f2d4f6887e9a1313b7c8b1e2", default-features = false }
+polars-core = { git = "https://github.com/pola-rs/polars.git", rev = "67551b6594c581731f0e9ca814ff7c39377bd324", default-features = false }
+polars-lazy = { git = "https://github.com/pola-rs/polars.git", rev = "67551b6594c581731f0e9ca814ff7c39377bd324", default-features = false }
 either = "1"
 
 [dependencies.polars]
@@ -159,4 +159,4 @@ features = [
   "zip_with",
 ]
 git = "https://github.com/pola-rs/polars.git"
-rev = "7686025ac7738607f2d4f6887e9a1313b7c8b1e2"
+rev = "67551b6594c581731f0e9ca814ff7c39377bd324"

--- a/src/rust/src/lazy/dataframe.rs
+++ b/src/rust/src/lazy/dataframe.rs
@@ -542,7 +542,7 @@ impl RPolarsLazyFrame {
     fn schema(&mut self) -> RResult<Pairlist> {
         let schema = self
             .0
-            .schema()
+            .collect_schema()
             .map_err(crate::rpolarserr::polars_to_rpolars_err)?;
         let pairs = schema.iter().collect::<Vec<_>>().into_iter();
         Ok(Pairlist::from_pairs(

--- a/src/rust/src/rdataframe/mod.rs
+++ b/src/rust/src/rdataframe/mod.rs
@@ -47,7 +47,7 @@ impl OwnedDataFrameIterator {
             data_type,
             idx: 0,
             n_chunks: df.n_chunks(),
-            compat_level: compat_level,
+            compat_level,
         }
     }
 }

--- a/tests/testthat/test-parquet.R
+++ b/tests/testthat/test-parquet.R
@@ -81,19 +81,18 @@ test_that("scanning from hive partition works", {
   )
 })
 
-# TODO: https://github.com/pola-rs/polars/issues/18219
-# test_that("scan_parquet can include file path", {
-#   skip_if_not_installed("withr")
-#   temp_dir = withr::local_tempdir()
-#   pl$DataFrame(mtcars)$write_parquet(temp_dir, partition_by = c("cyl", "gear"))
-#
-#   # There are 8 partitions so 8 file paths
-#   expect_identical(
-#     pl$scan_parquet(temp_dir, include_file_paths = "file_paths")$collect()$unique("file_paths") |>
-#       dim(),
-#     c(8L, 12L)
-#   )
-# })
+test_that("scan_parquet can include file path", {
+  skip_if_not_installed("withr")
+  temp_dir = withr::local_tempdir()
+  pl$DataFrame(mtcars)$write_parquet(temp_dir, partition_by = c("cyl", "gear"))
+
+  # There are 8 partitions so 8 file paths
+  expect_identical(
+    pl$scan_parquet(temp_dir, include_file_paths = "file_paths")$collect()$unique("file_paths") |>
+      dim(),
+    c(8L, 12L)
+  )
+})
 
 
 test_that("write_parquet works", {


### PR DESCRIPTION
This fixes an annoying bug in `$scan_parquet()` (see uncommented test) and there were just a few commits since 0.42.0