### PR TITLE
Better handling of hive partitions in `$scan_parquet()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,8 @@
   and `TRUE` for the newest one (less compatible). It can also take an integer
   determining a specific compatibility level when more are added in the future.
   For now, `future = FALSE` can be replaced by `compat_level = FALSE` (#1183).
+- In `$scan_parquet()` and `$read_parquet()`, the default value of
+  `hive_partitioning` is now `NULL` (#1189).
 
 ### New features
 
@@ -35,8 +37,10 @@
 - `$scan_parquet()`, `$scan_ipc()` and `$read_parquet()` have a new argument
   `include_file_paths` to automatically add a column containing the path to the
   source file(s) (#1183).
-- `$scan_ipc` can read a hive-partitioned directory with its new arguments
+- `$scan_ipc()` can read a hive-partitioned directory with its new arguments
   `hive_partitioning`, `hive_schema`, and `try_parse_hive_dates` (#1183).
+- `$scan_parquet()` and `$read_parquet()` gain two new arguments for more control
+  on importing hive partitions: `hive_schema` and `try_parse_hive_dates` (#1189).
 
 ### Other changes
 

--- a/R/extendr-wrappers.R
+++ b/R/extendr-wrappers.R
@@ -98,7 +98,7 @@ import_arrow_ipc <- function(path, n_rows, cache, rechunk, row_name, row_index, 
 
 new_from_ndjson <- function(path, infer_schema_length, batch_size, n_rows, low_memory, rechunk, row_index_name, row_index_offset, ignore_errors) .Call(wrap__new_from_ndjson, path, infer_schema_length, batch_size, n_rows, low_memory, rechunk, row_index_name, row_index_offset, ignore_errors)
 
-new_from_parquet <- function(path, n_rows, cache, parallel, rechunk, row_name, row_index, storage_options, use_statistics, low_memory, hive_partitioning, glob, include_file_paths) .Call(wrap__new_from_parquet, path, n_rows, cache, parallel, rechunk, row_name, row_index, storage_options, use_statistics, low_memory, hive_partitioning, glob, include_file_paths)
+new_from_parquet <- function(path, n_rows, cache, parallel, rechunk, row_name, row_index, storage_options, use_statistics, low_memory, hive_partitioning, hive_schema, try_parse_hive_dates, glob, include_file_paths) .Call(wrap__new_from_parquet, path, n_rows, cache, parallel, rechunk, row_name, row_index, storage_options, use_statistics, low_memory, hive_partitioning, hive_schema, try_parse_hive_dates, glob, include_file_paths)
 
 test_rpolarserr <- function() .Call(wrap__test_rpolarserr)
 

--- a/R/io_parquet.R
+++ b/R/io_parquet.R
@@ -51,8 +51,15 @@
 #'   `storage_options` argument.
 #'
 #' @examplesIf requireNamespace("arrow", quietly = TRUE) && arrow::arrow_with_dataset() && arrow::arrow_with_parquet()
-#' temp_dir = tempfile()
+#' # Write a Parquet file than we can then import as DataFrame
+#' temp_file = tempfile(fileext = ".parquet")
+#' pl$DataFrame(mtcars)$write_parquet(temp_file)
+#'
+#' pl$scan_parquet(temp_file)$collect()
+#' invisible(file.remove(temp_file))
+#'
 #' # Write a hive-style partitioned parquet dataset
+#' temp_dir = tempdir()
 #' arrow::write_dataset(
 #'   mtcars,
 #'   temp_dir,
@@ -62,10 +69,12 @@
 #' )
 #' list.files(temp_dir, recursive = TRUE)
 #'
-#' # Read the dataset
-#' pl$scan_parquet(
-#'   file.path(temp_dir, "**/*.parquet")
-#' )$collect()
+#' # If the path is a folder, Polars automatically tries to detect partitions
+#' # and includes them in the output
+#' pl$scan_parquet(temp_dir)$collect()
+#'
+#' # We can also impose a schema to the partition
+#' pl$scan_parquet(temp_dir, hive_schema = list(cyl = pl$String, gear = pl$Int32))$collect()
 pl_scan_parquet = function(
     source,
     ...,
@@ -78,7 +87,9 @@ pl_scan_parquet = function(
       "row_groups",
       "none"
     ),
-    hive_partitioning = TRUE,
+    hive_partitioning = NULL,
+    hive_schema = NULL,
+    try_parse_hive_dates = TRUE,
     glob = TRUE,
     rechunk = FALSE,
     low_memory = FALSE,
@@ -97,6 +108,8 @@ pl_scan_parquet = function(
     low_memory = low_memory,
     use_statistics = use_statistics,
     hive_partitioning = hive_partitioning,
+    hive_schema = hive_schema,
+    try_parse_hive_dates = try_parse_hive_dates,
     storage_options = storage_options,
     glob = glob,
     include_file_paths = include_file_paths
@@ -109,8 +122,15 @@ pl_scan_parquet = function(
 #' @inherit pl_read_csv return
 #' @inherit pl_scan_parquet params details
 #' @examplesIf requireNamespace("arrow", quietly = TRUE) && arrow::arrow_with_dataset() && arrow::arrow_with_parquet()
-#' temp_dir = tempfile()
-#' # Write a hive-style partitioned parquet dataset
+#' # Write a Parquet file than we can then import as DataFrame
+#' temp_file = tempfile(fileext = ".parquet")
+#' pl$DataFrame(mtcars)$write_parquet(temp_file)
+#'
+#' pl$read_parquet(temp_file)
+#' invisible(file.remove(temp_file))
+#'
+#' # Write a hive-style partitioned Parquet dataset
+#' temp_dir = tempdir()
 #' arrow::write_dataset(
 #'   mtcars,
 #'   temp_dir,
@@ -120,10 +140,12 @@ pl_scan_parquet = function(
 #' )
 #' list.files(temp_dir, recursive = TRUE)
 #'
-#' # Read the dataset
-#' pl$read_parquet(
-#'   file.path(temp_dir, "**/*.parquet")
-#' )
+#' # If the path is a folder, Polars automatically tries to detect partitions
+#' # and includes them in the output
+#' pl$read_parquet(temp_dir)
+#'
+#' # We can also impose a schema to the partition
+#' pl$read_parquet(temp_dir, hive_schema = list(cyl = pl$String, gear = pl$Int32))
 pl_read_parquet = function(
     source,
     ...,
@@ -136,7 +158,9 @@ pl_read_parquet = function(
       "row_groups",
       "none"
     ),
-    hive_partitioning = TRUE,
+    hive_partitioning = NULL,
+    hive_schema = NULL,
+    try_parse_hive_dates = TRUE,
     glob = TRUE,
     rechunk = TRUE,
     low_memory = FALSE,

--- a/R/io_parquet.R
+++ b/R/io_parquet.R
@@ -50,31 +50,21 @@
 #'   a valid service account. Be sure to always include a service account in the
 #'   `storage_options` argument.
 #'
-#' @examplesIf requireNamespace("arrow", quietly = TRUE) && arrow::arrow_with_dataset() && arrow::arrow_with_parquet()
+#' @examplesIf requireNamespace("withr", quietly = TRUE)
 #' # Write a Parquet file than we can then import as DataFrame
-#' temp_file = tempfile(fileext = ".parquet")
+#' temp_file = withr::local_tempfile(fileext = ".parquet")
 #' pl$DataFrame(mtcars)$write_parquet(temp_file)
 #'
 #' pl$scan_parquet(temp_file)$collect()
-#' invisible(file.remove(temp_file))
 #'
 #' # Write a hive-style partitioned parquet dataset
-#' temp_dir = tempdir()
-#' arrow::write_dataset(
-#'   mtcars,
-#'   temp_dir,
-#'   partitioning = c("cyl", "gear"),
-#'   format = "parquet",
-#'   hive_style = TRUE
-#' )
+#' temp_dir = withr::local_tempdir()
+#' pl$DataFrame(mtcars)$write_parquet(temp_dir, partition_by = c("cyl", "gear"))
 #' list.files(temp_dir, recursive = TRUE)
 #'
 #' # If the path is a folder, Polars automatically tries to detect partitions
 #' # and includes them in the output
 #' pl$scan_parquet(temp_dir)$collect()
-#'
-#' # We can also impose a schema to the partition
-#' pl$scan_parquet(temp_dir, hive_schema = list(cyl = pl$String, gear = pl$Int32))$collect()
 pl_scan_parquet = function(
     source,
     ...,
@@ -121,31 +111,21 @@ pl_scan_parquet = function(
 #' @rdname IO_read_parquet
 #' @inherit pl_read_csv return
 #' @inherit pl_scan_parquet params details
-#' @examplesIf requireNamespace("arrow", quietly = TRUE) && arrow::arrow_with_dataset() && arrow::arrow_with_parquet()
+#' @examplesIf requireNamespace("withr", quietly = TRUE)
 #' # Write a Parquet file than we can then import as DataFrame
-#' temp_file = tempfile(fileext = ".parquet")
+#' temp_file = withr::local_tempfile(fileext = ".parquet")
 #' pl$DataFrame(mtcars)$write_parquet(temp_file)
 #'
 #' pl$read_parquet(temp_file)
-#' invisible(file.remove(temp_file))
 #'
-#' # Write a hive-style partitioned Parquet dataset
-#' temp_dir = tempdir()
-#' arrow::write_dataset(
-#'   mtcars,
-#'   temp_dir,
-#'   partitioning = c("cyl", "gear"),
-#'   format = "parquet",
-#'   hive_style = TRUE
-#' )
+#' # Write a hive-style partitioned parquet dataset
+#' temp_dir = withr::local_tempdir()
+#' pl$DataFrame(mtcars)$write_parquet(temp_dir, partition_by = c("cyl", "gear"))
 #' list.files(temp_dir, recursive = TRUE)
 #'
 #' # If the path is a folder, Polars automatically tries to detect partitions
 #' # and includes them in the output
 #' pl$read_parquet(temp_dir)
-#'
-#' # We can also impose a schema to the partition
-#' pl$read_parquet(temp_dir, hive_schema = list(cyl = pl$String, gear = pl$Int32))
 pl_read_parquet = function(
     source,
     ...,

--- a/man/IO_read_parquet.Rd
+++ b/man/IO_read_parquet.Rd
@@ -11,7 +11,9 @@ pl_read_parquet(
   row_index_name = NULL,
   row_index_offset = 0L,
   parallel = c("auto", "columns", "row_groups", "none"),
-  hive_partitioning = TRUE,
+  hive_partitioning = NULL,
+  hive_schema = NULL,
+  try_parse_hive_dates = TRUE,
   glob = TRUE,
   rechunk = TRUE,
   low_memory = FALSE,
@@ -42,6 +44,14 @@ try to determine the optimal direction. Can be \code{"auto"}, \code{"columns"},
 \item{hive_partitioning}{Infer statistics and schema from Hive partitioned URL
 and use them to prune reads. If \code{NULL} (default), it is automatically
 enabled when a single directory is passed, and otherwise disabled.}
+
+\item{hive_schema}{A list containing the column names and data types of the
+columns by which the data is partitioned, e.g.
+\code{list(a = pl$String, b = pl$Float32)}. If \code{NULL} (default), the schema of
+the Hive partitions is inferred.}
+
+\item{try_parse_hive_dates}{Whether to try parsing hive values as date/datetime
+types.}
 
 \item{glob}{Expand path given via globbing rules.}
 
@@ -105,8 +115,15 @@ a valid service account. Be sure to always include a service account in the
 }
 \examples{
 \dontshow{if (requireNamespace("arrow", quietly = TRUE) && arrow::arrow_with_dataset() && arrow::arrow_with_parquet()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
-temp_dir = tempfile()
-# Write a hive-style partitioned parquet dataset
+# Write a Parquet file than we can then import as DataFrame
+temp_file = tempfile(fileext = ".parquet")
+pl$DataFrame(mtcars)$write_parquet(temp_file)
+
+pl$read_parquet(temp_file)
+invisible(file.remove(temp_file))
+
+# Write a hive-style partitioned Parquet dataset
+temp_dir = tempdir()
 arrow::write_dataset(
   mtcars,
   temp_dir,
@@ -116,9 +133,11 @@ arrow::write_dataset(
 )
 list.files(temp_dir, recursive = TRUE)
 
-# Read the dataset
-pl$read_parquet(
-  file.path(temp_dir, "**/*.parquet")
-)
+# If the path is a folder, Polars automatically tries to detect partitions
+# and includes them in the output
+pl$read_parquet(temp_dir)
+
+# We can also impose a schema to the partition
+pl$read_parquet(temp_dir, hive_schema = list(cyl = pl$String, gear = pl$Int32))
 \dontshow{\}) # examplesIf}
 }

--- a/man/IO_read_parquet.Rd
+++ b/man/IO_read_parquet.Rd
@@ -114,30 +114,20 @@ a valid service account. Be sure to always include a service account in the
 }
 }
 \examples{
-\dontshow{if (requireNamespace("arrow", quietly = TRUE) && arrow::arrow_with_dataset() && arrow::arrow_with_parquet()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 # Write a Parquet file than we can then import as DataFrame
-temp_file = tempfile(fileext = ".parquet")
+temp_file = withr::local_tempfile(fileext = ".parquet")
 pl$DataFrame(mtcars)$write_parquet(temp_file)
 
 pl$read_parquet(temp_file)
-invisible(file.remove(temp_file))
 
-# Write a hive-style partitioned Parquet dataset
-temp_dir = tempdir()
-arrow::write_dataset(
-  mtcars,
-  temp_dir,
-  partitioning = c("cyl", "gear"),
-  format = "parquet",
-  hive_style = TRUE
-)
+# Write a hive-style partitioned parquet dataset
+temp_dir = withr::local_tempdir()
+pl$DataFrame(mtcars)$write_parquet(temp_dir, partition_by = c("cyl", "gear"))
 list.files(temp_dir, recursive = TRUE)
 
 # If the path is a folder, Polars automatically tries to detect partitions
 # and includes them in the output
 pl$read_parquet(temp_dir)
-
-# We can also impose a schema to the partition
-pl$read_parquet(temp_dir, hive_schema = list(cyl = pl$String, gear = pl$Int32))
 \dontshow{\}) # examplesIf}
 }

--- a/man/IO_scan_parquet.Rd
+++ b/man/IO_scan_parquet.Rd
@@ -11,7 +11,9 @@ pl_scan_parquet(
   row_index_name = NULL,
   row_index_offset = 0L,
   parallel = c("auto", "columns", "row_groups", "none"),
-  hive_partitioning = TRUE,
+  hive_partitioning = NULL,
+  hive_schema = NULL,
+  try_parse_hive_dates = TRUE,
   glob = TRUE,
   rechunk = FALSE,
   low_memory = FALSE,
@@ -42,6 +44,14 @@ try to determine the optimal direction. Can be \code{"auto"}, \code{"columns"},
 \item{hive_partitioning}{Infer statistics and schema from Hive partitioned URL
 and use them to prune reads. If \code{NULL} (default), it is automatically
 enabled when a single directory is passed, and otherwise disabled.}
+
+\item{hive_schema}{A list containing the column names and data types of the
+columns by which the data is partitioned, e.g.
+\code{list(a = pl$String, b = pl$Float32)}. If \code{NULL} (default), the schema of
+the Hive partitions is inferred.}
+
+\item{try_parse_hive_dates}{Whether to try parsing hive values as date/datetime
+types.}
 
 \item{glob}{Expand path given via globbing rules.}
 
@@ -105,8 +115,15 @@ a valid service account. Be sure to always include a service account in the
 }
 \examples{
 \dontshow{if (requireNamespace("arrow", quietly = TRUE) && arrow::arrow_with_dataset() && arrow::arrow_with_parquet()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
-temp_dir = tempfile()
+# Write a Parquet file than we can then import as DataFrame
+temp_file = tempfile(fileext = ".parquet")
+pl$DataFrame(mtcars)$write_parquet(temp_file)
+
+pl$scan_parquet(temp_file)$collect()
+invisible(file.remove(temp_file))
+
 # Write a hive-style partitioned parquet dataset
+temp_dir = tempdir()
 arrow::write_dataset(
   mtcars,
   temp_dir,
@@ -116,9 +133,11 @@ arrow::write_dataset(
 )
 list.files(temp_dir, recursive = TRUE)
 
-# Read the dataset
-pl$scan_parquet(
-  file.path(temp_dir, "**/*.parquet")
-)$collect()
+# If the path is a folder, Polars automatically tries to detect partitions
+# and includes them in the output
+pl$scan_parquet(temp_dir)$collect()
+
+# We can also impose a schema to the partition
+pl$scan_parquet(temp_dir, hive_schema = list(cyl = pl$String, gear = pl$Int32))$collect()
 \dontshow{\}) # examplesIf}
 }

--- a/man/IO_scan_parquet.Rd
+++ b/man/IO_scan_parquet.Rd
@@ -114,30 +114,20 @@ a valid service account. Be sure to always include a service account in the
 }
 }
 \examples{
-\dontshow{if (requireNamespace("arrow", quietly = TRUE) && arrow::arrow_with_dataset() && arrow::arrow_with_parquet()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 # Write a Parquet file than we can then import as DataFrame
-temp_file = tempfile(fileext = ".parquet")
+temp_file = withr::local_tempfile(fileext = ".parquet")
 pl$DataFrame(mtcars)$write_parquet(temp_file)
 
 pl$scan_parquet(temp_file)$collect()
-invisible(file.remove(temp_file))
 
 # Write a hive-style partitioned parquet dataset
-temp_dir = tempdir()
-arrow::write_dataset(
-  mtcars,
-  temp_dir,
-  partitioning = c("cyl", "gear"),
-  format = "parquet",
-  hive_style = TRUE
-)
+temp_dir = withr::local_tempdir()
+pl$DataFrame(mtcars)$write_parquet(temp_dir, partition_by = c("cyl", "gear"))
 list.files(temp_dir, recursive = TRUE)
 
 # If the path is a folder, Polars automatically tries to detect partitions
 # and includes them in the output
 pl$scan_parquet(temp_dir)$collect()
-
-# We can also impose a schema to the partition
-pl$scan_parquet(temp_dir, hive_schema = list(cyl = pl$String, gear = pl$Int32))$collect()
 \dontshow{\}) # examplesIf}
 }

--- a/tests/testthat/test-parquet.R
+++ b/tests/testthat/test-parquet.R
@@ -113,18 +113,18 @@ test_that("try_parse_hive_dates works", {
     test,
     temp_dir,
     partitioning = "dt",
-    format = "arrow",
+    format = "parquet",
     hive_style = TRUE
   )
 
   # default is to parse dates
   expect_identical(
-    pl$scan_ipc(temp_dir)$select("dt")$collect()$to_list(),
+    pl$scan_parquet(temp_dir)$select("dt")$collect()$to_list(),
     list(dt = as.Date(c("2020-01-01", "2020-01-01", "2020-01-02")))
   )
 
   expect_identical(
-    pl$scan_ipc(temp_dir, try_parse_hive_dates = FALSE)$select("dt")$collect()$to_list(),
+    pl$scan_parquet(temp_dir, try_parse_hive_dates = FALSE)$select("dt")$collect()$to_list(),
     list(dt = c("2020-01-01", "2020-01-01", "2020-01-02"))
   )
 })


### PR DESCRIPTION
Add two arguments already in `$scan_ipc()` for better handling of hive partitions. There are some bugs upstream (see tests commented out) but we can already add support for those. 