### PR TITLE
docs(news): remove misleading expressions to users

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,8 +4,7 @@
 
 ## Polars R Package 0.19.1
 
-- Add the option `-z noexecstack` for compilation on Linux to avoid the error
-  `version GLIBC_2.39' not found` (#1212).
+- This is a maintenance relase. No user facing changes.
 
 ## Polars R Package 0.19.0
 


### PR DESCRIPTION
@etiennebacher As far as etiennebacher/tidypolars#137 is concerned, I don't think the cause of your CI failure is related to the update, so I think the document needs to be changed.