### PR TITLE
fix: ensure report rustc version if pre-built binary will be used

### DIFF
--- a/cleanup.win
+++ b/cleanup.win
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-. ./configure
+. ./cleanup

--- a/configure
+++ b/configure
@@ -10,12 +10,8 @@ LIBNAME="libr_polars.a"
 LIBR_POLARS_DEFAULT_PATH="$(pwd)/tools/${LIBNAME}"
 LIBR_POLARS_PATH=${LIBR_POLARS_PATH:-${LIBR_POLARS_DEFAULT_PATH}}
 
-# -z noexecstack added to avoid following error on Ubuntu:
-# /usr/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by /usr/local/lib/R/site-library/polars/libs/polars.so)`
-# https://stackoverflow.com/questions/73435637/how-can-i-fix-usr-bin-ld-warning-trap-o-missing-note-gnu-stack-section-imp/73468271#73468271
-#
 # not used on macOS
-ADDITIONAL_PKG_LIBS_FLAG="-lrt -z noexecstack"
+ADDITIONAL_PKG_LIBS_FLAG="-lrt"
 
 export PATH="$PATH:$HOME/.cargo/bin"
 

--- a/configure
+++ b/configure
@@ -68,6 +68,8 @@ check_bin_lib() {
     echo ""
     echo "---------------------- [LIBRARY BINARY FOUND] ----------------------"
     echo "The library was found at <${LIBR_POLARS_PATH}>. No need to build it."
+    echo ""
+    echo "Note: rustc version: $(rustc -V || echo 'Not found')"
     echo "--------------------------------------------------------------------"
     echo ""
     sed -e "s|@RUST_TARGET@||" -e "s|@ADDITIONAL_PKG_LIBS_FLAG@|${ADDITIONAL_PKG_LIBS_FLAG}|" src/Makevars.in >src/Makevars
@@ -87,6 +89,8 @@ check_bin_lib() {
     echo "The library was not found at <${LIBR_POLARS_PATH}>,"
     echo "but was found at <${LIBR_POLARS_DEFAULT_PATH}>."
     echo "No need to build it."
+    echo ""
+    echo "Note: rustc version: $(rustc -V || echo 'Not found')"
     echo "--------------------------------------------------------------------"
     echo ""
     sed -e "s|@RUST_TARGET@||" -e "s|@ADDITIONAL_PKG_LIBS_FLAG@|${ADDITIONAL_PKG_LIBS_FLAG}|" src/Makevars.in >src/Makevars

--- a/configure
+++ b/configure
@@ -69,7 +69,7 @@ check_bin_lib() {
     echo "---------------------- [LIBRARY BINARY FOUND] ----------------------"
     echo "The library was found at <${LIBR_POLARS_PATH}>. No need to build it."
     echo ""
-    echo "Note: rustc version: $(rustc -V || echo 'Not found')"
+    echo "Note: rustc version: $(command -v rustc >/dev/null && rustc -V || echo 'Not found')"
     echo "--------------------------------------------------------------------"
     echo ""
     sed -e "s|@RUST_TARGET@||" -e "s|@ADDITIONAL_PKG_LIBS_FLAG@|${ADDITIONAL_PKG_LIBS_FLAG}|" src/Makevars.in >src/Makevars
@@ -90,7 +90,7 @@ check_bin_lib() {
     echo "but was found at <${LIBR_POLARS_DEFAULT_PATH}>."
     echo "No need to build it."
     echo ""
-    echo "Note: rustc version: $(rustc -V || echo 'Not found')"
+    echo "Note: rustc version: $(command -v rustc >/dev/null && rustc -V || echo 'Not found')"
     echo "--------------------------------------------------------------------"
     echo ""
     sed -e "s|@RUST_TARGET@||" -e "s|@ADDITIONAL_PKG_LIBS_FLAG@|${ADDITIONAL_PKG_LIBS_FLAG}|" src/Makevars.in >src/Makevars


### PR DESCRIPTION
R CMD check now checks to see if the rustc version is shown in the installation log, so even if rustc is not used, the version must be shown.
https://github.com/r-devel/r-svn/commit/6114d4126434c056b476cbc5db2657536c153d9a

I saw this warning at <https://github.com/eitsupi/r-glaredb/actions/runs/10879498825/job/30184319369>

```log
 ❯ checking Rust compilation ... WARNING
    No rustc version reported prior to compilation
```

In addition, remove the unnecessary flag added by #1212.