### PR TITLE
fix: replace `knitr:::escape_html` by `xfun::html_escape`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,8 @@ Suggests:
     tibble,
     tools,
     vctrs,
-    withr
+    withr,
+    xfun (>= 0.48)
 Config/Needs/website:
     altdoc,
     future.apply,

--- a/R/pkg-knitr.R
+++ b/R/pkg-knitr.R
@@ -49,7 +49,13 @@ to_html_table = function(x, max_cols = 75, max_rows = 40) {
     stop("Please install the `knitr` package to use `to_html_table`.")
   }
 
-  escape_html = getFromNamespace("escape_html", "knitr")
+  # escape_html will be removed from knitr (> 1.49)
+  if (exists("html_escape", where = asNamespace("xfun"), mode = "function")) {
+    escape_html = xfun::html_escape
+  } else {
+    escape_html = getFromNamespace("escape_html", "knitr")
+  }
+
   omit_chr = "&hellip;"
 
   .dim = dim(x)


### PR DESCRIPTION
Related to #1283

`knitr:::escape_html` was replaced by `xfun::html_escape`
See mgondan/mathml#18