### PR TITLE
fix: fix csv download issue on windows

### DIFF
--- a/R/io_csv.R
+++ b/R/io_csv.R
@@ -224,7 +224,7 @@ check_is_link = function(path, reuse_downloaded, raise_error = FALSE) {
         cache_temp_file[[actual_url]] = tempfile()
       }
       if (isFALSE(reuse_downloaded) || isFALSE(file.exists(cache_temp_file[[actual_url]]))) {
-        download.file(url = actual_url, destfile = cache_temp_file[[actual_url]])
+        download.file(url = actual_url, destfile = cache_temp_file[[actual_url]], mode = "wb")
         message(paste("tmp file placed in \n", cache_temp_file[[actual_url]]))
       }
 


### PR DESCRIPTION
Fix #1288

The help of `download.file` says:

> Code written to download binary files must use mode = "wb" (or "ab"), but the problems incurred by a text transfer will only be seen on Windows.