### PR TITLE
fix: r concurrent handler

### DIFF
--- a/R/extendr-wrappers.R
+++ b/R/extendr-wrappers.R
@@ -84,6 +84,8 @@ test_wrong_call_pl_lit <- function(robj) .Call(wrap__test_wrong_call_pl_lit, rob
 
 test_robj_to_rchoice <- function(robj) .Call(wrap__test_robj_to_rchoice, robj)
 
+test_threadcom_stack_size <- function() .Call(wrap__test_threadcom_stack_size)
+
 concat_lf <- function(l, rechunk, parallel, to_supertypes) .Call(wrap__concat_lf, l, rechunk, parallel, to_supertypes)
 
 concat_lf_diagonal <- function(l, rechunk, parallel, to_supertypes) .Call(wrap__concat_lf_diagonal, l, rechunk, parallel, to_supertypes)

--- a/man/DataFrame_class.Rd
+++ b/man/DataFrame_class.Rd
@@ -115,7 +115,7 @@ withr::with_timezone(
     )
   \}
 )
-#> <error: in to_r: ComputeError(ErrString("datetime '2020-03-08 02:00:00' is non-existent in time zone 'America/New_York'. You may be able to use `non_existent='null'` to return `null` in this case.")) When calling: devtools::document()>
+#> <error: in to_r: ComputeError(ErrString("datetime '2020-03-08 02:00:00' is non-existent in time zone 'America/New_York'. You may be able to use `non_existent='null'` to return `null` in this case.")) When calling: rextendr::document()>
 
 withr::with_timezone(
   "America/New_York",

--- a/man/DataFrame_to_data_frame.Rd
+++ b/man/DataFrame_to_data_frame.Rd
@@ -58,7 +58,7 @@ withr::with_timezone(
     )
   \}
 )
-#> <error: in to_r: ComputeError(ErrString("datetime '2020-03-08 02:00:00' is non-existent in time zone 'America/New_York'. You may be able to use `non_existent='null'` to return `null` in this case.")) When calling: devtools::document()>
+#> <error: in to_r: ComputeError(ErrString("datetime '2020-03-08 02:00:00' is non-existent in time zone 'America/New_York'. You may be able to use `non_existent='null'` to return `null` in this case.")) When calling: rextendr::document()>
 
 withr::with_timezone(
   "America/New_York",

--- a/man/DataFrame_to_list.Rd
+++ b/man/DataFrame_to_list.Rd
@@ -68,7 +68,7 @@ withr::with_timezone(
     )
   \}
 )
-#> <error: in to_r: ComputeError(ErrString("datetime '2020-03-08 02:00:00' is non-existent in time zone 'America/New_York'. You may be able to use `non_existent='null'` to return `null` in this case.")) When calling: devtools::document()>
+#> <error: in to_r: ComputeError(ErrString("datetime '2020-03-08 02:00:00' is non-existent in time zone 'America/New_York'. You may be able to use `non_existent='null'` to return `null` in this case.")) When calling: rextendr::document()>
 
 withr::with_timezone(
   "America/New_York",

--- a/man/LazyFrame_class.Rd
+++ b/man/LazyFrame_class.Rd
@@ -85,7 +85,7 @@ withr::with_timezone(
     )
   \}
 )
-#> <error: in to_r: ComputeError(ErrString("datetime '2020-03-08 02:00:00' is non-existent in time zone 'America/New_York'. You may be able to use `non_existent='null'` to return `null` in this case.")) When calling: devtools::document()>
+#> <error: in to_r: ComputeError(ErrString("datetime '2020-03-08 02:00:00' is non-existent in time zone 'America/New_York'. You may be able to use `non_existent='null'` to return `null` in this case.")) When calling: rextendr::document()>
 
 withr::with_timezone(
   "America/New_York",

--- a/man/S3_as.data.frame.Rd
+++ b/man/S3_as.data.frame.Rd
@@ -109,7 +109,7 @@ withr::with_timezone(
     )
   \}
 )
-#> <error: in to_r: ComputeError(ErrString("datetime '2020-03-08 02:00:00' is non-existent in time zone 'America/New_York'. You may be able to use `non_existent='null'` to return `null` in this case.")) When calling: devtools::document()>
+#> <error: in to_r: ComputeError(ErrString("datetime '2020-03-08 02:00:00' is non-existent in time zone 'America/New_York'. You may be able to use `non_existent='null'` to return `null` in this case.")) When calling: rextendr::document()>
 
 withr::with_timezone(
   "America/New_York",

--- a/man/S3_as.vector.Rd
+++ b/man/S3_as.vector.Rd
@@ -45,7 +45,7 @@ withr::with_timezone(
     )
   \}
 )
-#> <error: in to_r: ComputeError(ErrString("datetime '2020-03-08 02:00:00' is non-existent in time zone 'America/New_York'. You may be able to use `non_existent='null'` to return `null` in this case.")) When calling: devtools::document()>
+#> <error: in to_r: ComputeError(ErrString("datetime '2020-03-08 02:00:00' is non-existent in time zone 'America/New_York'. You may be able to use `non_existent='null'` to return `null` in this case.")) When calling: rextendr::document()>
 
 withr::with_timezone(
   "America/New_York",

--- a/man/S3_as_arrow_table.Rd
+++ b/man/S3_as_arrow_table.Rd
@@ -4,7 +4,7 @@
 \alias{as_arrow_table.RPolarsDataFrame}
 \title{Create a arrow Table from a Polars object}
 \usage{
-\method{as_arrow_table}{RPolarsDataFrame}(x, ..., compat_level = FALSE)
+as_arrow_table.RPolarsDataFrame(x, ..., compat_level = FALSE)
 }
 \arguments{
 \item{x}{\link[=DataFrame_class]{A Polars DataFrame}}

--- a/man/S3_as_nanoarrow_array_stream.Rd
+++ b/man/S3_as_nanoarrow_array_stream.Rd
@@ -5,9 +5,19 @@
 \alias{as_nanoarrow_array_stream.RPolarsSeries}
 \title{Create a nanoarrow_array_stream from a Polars object}
 \usage{
-\method{as_nanoarrow_array_stream}{RPolarsDataFrame}(x, ..., schema = NULL, compat_level = FALSE)
+as_nanoarrow_array_stream.RPolarsDataFrame(
+  x,
+  ...,
+  schema = NULL,
+  compat_level = FALSE
+)
 
-\method{as_nanoarrow_array_stream}{RPolarsSeries}(x, ..., schema = NULL, compat_level = FALSE)
+as_nanoarrow_array_stream.RPolarsSeries(
+  x,
+  ...,
+  schema = NULL,
+  compat_level = FALSE
+)
 }
 \arguments{
 \item{x}{A polars object}

--- a/man/S3_as_record_batch_reader.Rd
+++ b/man/S3_as_record_batch_reader.Rd
@@ -4,7 +4,7 @@
 \alias{as_record_batch_reader.RPolarsDataFrame}
 \title{Create a arrow RecordBatchReader from a Polars object}
 \usage{
-\method{as_record_batch_reader}{RPolarsDataFrame}(x, ..., compat_level = FALSE)
+as_record_batch_reader.RPolarsDataFrame(x, ..., compat_level = FALSE)
 }
 \arguments{
 \item{x}{\link[=DataFrame_class]{A Polars DataFrame}}

--- a/man/S3_infer_nanoarrow_schema.Rd
+++ b/man/S3_infer_nanoarrow_schema.Rd
@@ -5,9 +5,9 @@
 \alias{infer_nanoarrow_schema.RPolarsSeries}
 \title{Infer nanoarrow schema from a Polars object}
 \usage{
-\method{infer_nanoarrow_schema}{RPolarsDataFrame}(x, ..., compat_level = FALSE)
+infer_nanoarrow_schema.RPolarsDataFrame(x, ..., compat_level = FALSE)
 
-\method{infer_nanoarrow_schema}{RPolarsSeries}(x, ..., compat_level = FALSE)
+infer_nanoarrow_schema.RPolarsSeries(x, ..., compat_level = FALSE)
 }
 \arguments{
 \item{x}{A polars object}

--- a/man/S3_knit_print.Rd
+++ b/man/S3_knit_print.Rd
@@ -4,7 +4,7 @@
 \alias{knit_print.RPolarsDataFrame}
 \title{knit print polars DataFrame}
 \usage{
-\method{knit_print}{RPolarsDataFrame}(x, ...)
+knit_print.RPolarsDataFrame(x, ...)
 }
 \arguments{
 \item{x}{a polars DataFrame to knit_print}

--- a/man/Series_class.Rd
+++ b/man/Series_class.Rd
@@ -142,7 +142,7 @@ withr::with_timezone(
     )
   \}
 )
-#> <error: in to_r: ComputeError(ErrString("datetime '2020-03-08 02:00:00' is non-existent in time zone 'America/New_York'. You may be able to use `non_existent='null'` to return `null` in this case.")) When calling: devtools::document()>
+#> <error: in to_r: ComputeError(ErrString("datetime '2020-03-08 02:00:00' is non-existent in time zone 'America/New_York'. You may be able to use `non_existent='null'` to return `null` in this case.")) When calling: rextendr::document()>
 
 withr::with_timezone(
   "America/New_York",

--- a/man/Series_to_r.Rd
+++ b/man/Series_to_r.Rd
@@ -61,7 +61,7 @@ withr::with_timezone(
     )
   \}
 )
-#> <error: in to_r: ComputeError(ErrString("datetime '2020-03-08 02:00:00' is non-existent in time zone 'America/New_York'. You may be able to use `non_existent='null'` to return `null` in this case.")) When calling: devtools::document()>
+#> <error: in to_r: ComputeError(ErrString("datetime '2020-03-08 02:00:00' is non-existent in time zone 'America/New_York'. You may be able to use `non_existent='null'` to return `null` in this case.")) When calling: rextendr::document()>
 
 withr::with_timezone(
   "America/New_York",

--- a/src/rust/src/lazy/dsl.rs
+++ b/src/rust/src/lazy/dsl.rs
@@ -1980,7 +1980,7 @@ impl RPolarsExpr {
         let par_fn = ParRObj(lambda);
         let f = move |s: pl::Series| {
             let thread_com = ThreadCom::try_from_global(&CONFIG)
-                .expect("polars was thread could not initiate ThreadCommunication to R");
+                .expect("polars thread could not initiate ThreadCom(munication) to R");
             thread_com.send(RFnSignature::FnSeriesToSeries(par_fn.clone(), s));
             let s = thread_com.recv().unwrap_series();
             Ok(Some(s))

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -34,9 +34,14 @@ pub use polars_core;
 pub use smartstring;
 
 use crate::concurrent::{RFnOutput, RFnSignature};
-use crate::utils::extendr_concurrent::{InitCell, ThreadCom};
-type ThreadComStorage = InitCell<std::sync::RwLock<Option<ThreadCom<RFnSignature, RFnOutput>>>>;
-static CONFIG: ThreadComStorage = InitCell::new();
+use crate::utils::extendr_concurrent::ThreadCom;
+type ThreadComStorage = Lazy<std::sync::RwLock<Option<ThreadCom<RFnSignature, RFnOutput>>>>;
+
+use once_cell::sync::Lazy;
+use std::sync::RwLock;
+
+static CONFIG: Lazy<RwLock<Option<ThreadCom<RFnSignature, RFnOutput>>>> =
+    Lazy::new(|| RwLock::new(None));
 pub use crate::rbackground::RBGPOOL;
 
 // Macro to generate exports

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -35,13 +35,15 @@ pub use smartstring;
 
 use crate::concurrent::{RFnOutput, RFnSignature};
 use crate::utils::extendr_concurrent::ThreadCom;
-type ThreadComStorage = Lazy<std::sync::RwLock<Option<ThreadCom<RFnSignature, RFnOutput>>>>;
 
 use once_cell::sync::Lazy;
 use std::sync::RwLock;
 
-static CONFIG: Lazy<RwLock<Option<ThreadCom<RFnSignature, RFnOutput>>>> =
-    Lazy::new(|| RwLock::new(None));
+//TODO  verify reallocation of Vec<ThreadCom> does not mess something up. with_capcity(99)
+// ensure at least no reallication before 99 levels of nested r-polars queries
+// which is quite unlikely.
+static CONFIG: Lazy<RwLock<Vec<ThreadCom<RFnSignature, RFnOutput>>>> =
+    Lazy::new(|| RwLock::new(Vec::with_capacity(99)));
 pub use crate::rbackground::RBGPOOL;
 
 // Macro to generate exports

--- a/src/rust/src/rlib.rs
+++ b/src/rust/src/rlib.rs
@@ -234,6 +234,12 @@ fn test_robj_to_rchoice(robj: Robj) -> RResult<String> {
 }
 
 #[extendr]
+fn test_threadcom_stack_size() -> i32 {
+    // can be used to check if threadcom are cleaned up after use
+    ThreadCom::get_global_threadcom_stack_size(&CONFIG) as i32
+}
+
+#[extendr]
 fn fold(acc: Robj, lambda: Robj, exprs: Robj) -> RResult<RPolarsExpr> {
     let par_fn = ParRObj(lambda);
     let f = move |acc: pl::Series, x: pl::Series| {
@@ -427,4 +433,5 @@ extendr_module! {
     fn test_robj_to_expr;
     fn test_wrong_call_pl_lit;
     fn test_robj_to_rchoice;
+    fn test_threadcom_stack_size;
 }

--- a/src/rust/src/utils/extendr_concurrent.rs
+++ b/src/rust/src/utils/extendr_concurrent.rs
@@ -139,6 +139,14 @@ where
             None => Err("Global ThreadCom is empty".to_string()),
         }
     }
+
+    // only for testing
+    pub fn get_global_threadcom_stack_size(conf: &Lazy<RwLock<Vec<ThreadCom<S, R>>>>) -> usize {
+        let global = conf
+            .read()
+            .expect("Failed to acquire read lock on global ThreadCom");
+        global.len()
+    }
 }
 
 // //debug threads
@@ -202,7 +210,8 @@ where
             let answer = i(s); //handle requst with i closure
             let a = answer.map_err(|err| format!("user function raised an error: {:?} \n", err))?;
 
-            c_tx.send(a).unwrap();
+            c_tx.send(a)
+                .expect("failed to result back to polars thread");
         } else if let Err(recv_err) = any_new_msg {
             #[cfg(feature = "rpolars_debug_print")]
             dbg!(&recv_err);

--- a/tests/testthat/_snaps/pkg-knitr.new.md
+++ b/tests/testthat/_snaps/pkg-knitr.new.md
@@ -16,6 +16,10 @@
       as_polars_df(df)
       ```
       
+      ```
+      ## Warning in raw_block(x, "html", ...): raw_block() requires Pandoc >= 2.0.0
+      ```
+      
       ```{=html}
       <div><style>
       .dataframe > thead > tr > th,
@@ -45,6 +49,10 @@
       as_polars_df(df)
       ```
       
+      ```
+      ## Warning in raw_block(x, "html", ...): raw_block() requires Pandoc >= 2.0.0
+      ```
+      
       ```{=html}
       <div><style>
       .dataframe > thead > tr > th,
@@ -55,69 +63,6 @@
       </style>
       <small>shape: (3, 2)</small><table border="1" class="dataframe"><thead><tr><th>a</th><th>b</th></tr><tr><td>i32</td><td>str</td></tr></thead><tbody><tr><td>1</td><td>"a"</td></tr><tr><td>2</td><td>"b"</td></tr><tr><td>3</td><td>"c"</td></tr></tbody></table></div>
       ```
-
----
-
-    Code
-      .knit_file("dataframe.Rmd", use = "rmarkdown")
-    Output
-      
-      ``` r
-      df = data.frame(a = 1:3, b = letters[1:3])
-      as_polars_df(df)
-      ```
-      
-      <div><style>
-      .dataframe > thead > tr > th,
-      .dataframe > tbody > tr > td {
-        text-align: right;
-        white-space: pre-wrap;
-      }
-      </style>
-      <small>shape: (3, 2)</small><table border="1" class="dataframe"><thead><tr><th>a</th><th>b</th></tr><tr><td>i32</td><td>str</td></tr></thead><tbody><tr><td>1</td><td>"a"</td></tr><tr><td>2</td><td>"b"</td></tr><tr><td>3</td><td>"c"</td></tr></tbody></table></div>
-
----
-
-    Code
-      .knit_file("dataframe.Rmd", use = "rmarkdown")
-    Output
-      
-      ``` r
-      df = data.frame(a = 1:3, b = letters[1:3])
-      as_polars_df(df)
-      ```
-      
-          ## shape: (3, 2)
-          ## ┌─────┬─────┐
-          ## │ a   ┆ b   │
-          ## │ --- ┆ --- │
-          ## │ i32 ┆ str │
-          ## ╞═════╪═════╡
-          ## │ 1   ┆ a   │
-          ## │ 2   ┆ b   │
-          ## │ 3   ┆ c   │
-          ## └─────┴─────┘
-
----
-
-    Code
-      .knit_file("flights.Rmd")
-    Output
-      
-      ``` r
-      nycflights13::flights |>
-        to_html_table(5, 5) |>
-        writeLines()
-      ```
-      
-      <div><style>
-      .dataframe > thead > tr > th,
-      .dataframe > tbody > tr > td {
-        text-align: right;
-        white-space: pre-wrap;
-      }
-      </style>
-      <small>shape: (336_776, 19)</small><table border="1" class="dataframe"><thead><tr><th>year</th><th>month</th><th>&hellip;</th><th>minute</th><th>time_hour</th></tr><tr><td>int</td><td>int</td><td>&hellip;</td><td>dbl</td><td>dttm</td></tr></thead><tbody><tr><td>2013</td><td>1</td><td>&hellip;</td><td>15</td><td>2013-01-01 05:00:00</td></tr><tr><td>2013</td><td>1</td><td>&hellip;</td><td>29</td><td>2013-01-01 05:00:00</td></tr><tr><td>2013</td><td>9</td><td>&hellip;</td><td>59</td><td>2013-09-30 11:00:00</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>2013</td><td>9</td><td>&hellip;</td><td>59</td><td>2013-09-30 11:00:00</td></tr><tr><td>2013</td><td>9</td><td>&hellip;</td><td>40</td><td>2013-09-30 08:00:00</td></tr></tbody></table></div>
 
 # to_html_table
 

--- a/tests/testthat/test-concurrent.R
+++ b/tests/testthat/test-concurrent.R
@@ -1,0 +1,61 @@
+# library(polars)
+# library(testthat)
+# polars_code_completion_activate()
+
+
+test_that("concurrent recover on error", {
+  # cause an error
+  expect_error({
+    df = as_polars_df(iris)$
+      select(
+      pl$col("Sepal.Length")$
+        map_batches(\(s) stop("this is a test error"))
+    )
+  })
+
+  # causing an error in one map_batches do not block the concurrent handler
+  # in R session thereafter
+
+  # can achieve unity
+  df = as_polars_df(iris)$
+    select(
+    pl$col("Sepal.Length")$
+      map_batches(\(s) s)
+  )
+  expect_identical(
+    df$to_data_frame(),
+    iris[, 1, drop = FALSE]
+  )
+})
+
+test_that("nested r-polars queries works", {
+  # cause an error
+  # s = as_polars_df(iris)$to_series(0)
+
+  # compute two columns with map batches, which will be handled in two
+  # threads by polars. Each thread will call R, and each thread call R
+  # and create a new sub rpolars-query and there by putting a new
+  # concurrent handler on the handler-stack. When sub-query completes it will
+  # pop the handler stack and allow other previous handler to continue.
+  # TODO implement some diagnostic rust function and verify these claims.
+
+  # happy path test of above claim
+  df = as_polars_df(iris)$
+    select(
+    pl$col("Sepal.Length")$
+      map_batches(\(s) {
+      # make a new rpolars query within a query
+      pl$DataFrame(s)$lazy()$collect()$to_series(0) * 2
+    }),
+    pl$col("Sepal.Width")$
+      map_batches(\(s) {
+      # make another nested rpolars query within a query
+      pl$DataFrame(s * 2)$lazy()$collect()$to_series(0)
+    })
+  )
+
+  expect_identical(
+    df$to_data_frame(),
+    iris[, 1:2, drop = FALSE] * 2
+  )
+})

--- a/tests/testthat/test-concurrent.R
+++ b/tests/testthat/test-concurrent.R
@@ -1,10 +1,9 @@
-# library(polars)
-# library(testthat)
-# polars_code_completion_activate()
+test_that("R handler recovers from an error", {
 
+  # Get previous thradcom stacksize, for comparison. Should not increase.
+  threadcom_stack_size_before = polars:::test_threadcom_stack_size()
 
-test_that("concurrent recover on error", {
-  # cause an error
+  # Cause an error in user function. This must be cleaned up.
   expect_error({
     df = as_polars_df(iris)$
       select(
@@ -13,10 +12,14 @@ test_that("concurrent recover on error", {
     )
   })
 
-  # causing an error in one map_batches do not block the concurrent handler
-  # in R session thereafter
+  # Check R handler threadcom stack size is restored
+  expect_identical(
+    polars:::test_threadcom_stack_size(),
+    threadcom_stack_size_before
+  )
 
-  # can achieve unity
+  # Causing an error in one map_batches does block the concurrent handler
+  # in R session thereafter
   df = as_polars_df(iris)$
     select(
     pl$col("Sepal.Length")$
@@ -28,34 +31,79 @@ test_that("concurrent recover on error", {
   )
 })
 
-test_that("nested r-polars queries works", {
-  # cause an error
-  # s = as_polars_df(iris)$to_series(0)
+test_that("nested r-polars queries with nested errors works", {
 
-  # compute two columns with map batches, which will be handled in two
-  # threads by polars. Each thread will call R, and each thread call R
-  # and create a new sub rpolars-query and there by putting a new
-  # concurrent handler on the handler-stack. When sub-query completes it will
-  # pop the handler stack and allow other previous handler to continue.
-  # TODO implement some diagnostic rust function and verify these claims.
+  # Get previous thradcom stacksize, for comparison. Should not increase.
+  threadcom_stack_size_before = polars:::test_threadcom_stack_size()
 
   # happy path test of above claim
   df = as_polars_df(iris)$
     select(
-    pl$col("Sepal.Length")$
-      map_batches(\(s) {
-      # make a new rpolars query within a query
-      pl$DataFrame(s)$lazy()$collect()$to_series(0) * 2
-    }),
-    pl$col("Sepal.Width")$
-      map_batches(\(s) {
-      # make another nested rpolars query within a query
-      pl$DataFrame(s * 2)$lazy()$collect()$to_series(0)
-    })
-  )
+      pl$col("Sepal.Length")$
+        map_batches(\(s) {
+        # make a new rpolars subquery within a query
+        pl$DataFrame(s)$lazy()$collect()$to_series(0) * 2
+      }),
+      pl$col("Sepal.Width")$
+        map_batches(\(s) {
+
+          # make another sub-query with a polars err
+          pl$DataFrame(s * 2)$
+              lazy()$
+              select(
+                pl$col("this column is not there, will cause polars")
+              )$
+              collect()$
+              to_series(0) |>
+              polars:::result() |>
+              polars:::is_err() |>
+              stopifnot() # ensure there was a polars error
+
+          # just return s * 2
+          s * 2
+      })
+    )
 
   expect_identical(
     df$to_data_frame(),
     iris[, 1:2, drop = FALSE] * 2
   )
+
+
+  expect_identical(
+    polars:::test_threadcom_stack_size(),
+    threadcom_stack_size_before
+  )
 })
+
+test_that("nested r-polars queries with r handling works", {
+  pdf = pl$
+    LazyFrame(a = 1:5)$
+    select(
+    pl$col("a")$
+      map_batches(\(s) {
+      # while locking main R handler, start a new r-polars sub query
+      pl$DataFrame(s * 2)$lazy()$select(
+        # acquire R handler from sub query
+        # must use in_background = TRUE to avoid a dead-lock
+        pl$col("a")$map_batches(\(s) s / 2, in_background = TRUE)$alias("a1"),
+        pl$col("a")$map_elements(\(s) s / 2, in_background = TRUE)$alias("a2")
+      )$collect()$to_series(0)
+    })
+  )$
+    collect()
+
+  expect_identical(
+    pdf$to_data_frame(),
+    data.frame(a = (1:5) * 2 / 2)
+  )
+})
+
+test_that("finally threadcom_stack_size should be zero", {
+  # if failing, something left an old ThreadCom on the stack.
+  expect_identical(
+    polars:::test_threadcom_stack_size(),
+    0L
+  )
+})
+


### PR DESCRIPTION
THIS PR is a DRAFT DO NOT MERGE.

Not fully tested, but promising.

r concurrent handler was reported to crash throughout R session if an R error is raised in an R function embedded in a polars query, reported in  #1253

Annother edge case if starting a new r-polars query within an r user function within an r-polars query did not work well.

Solution:
  - ~~use once_cell (not the actual problem, but still a more safe choice with no undefiend behavior warnings in docs)
  - instead of having a single shared concurrent handler, there is now a stack of concurrent handler. Each sub query will push a handler onto the stack.~~ I was all fine all along
  - if an error occours the handler stack will unwind and clean up leaving no dangling communication channels (ThreadComs)
  
  
  EDIT: It looked up InitCell from the wrong crate :/ the actual docs says it is fine to mutate later
https://docs.rs/state/0.6.0/state/struct.InitCell.html