### PR TITLE
docs: Add warning about maintenance mode in README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -27,6 +27,23 @@ knitr::opts_chunk$set(
 [![Docs dev version](https://img.shields.io/badge/docs-dev-blue.svg)](https://pola-rs.github.io/r-polars)
 <!-- badges: end -->
 
+---
+
+IMPORTANT: 
+
+This package is now in maintenance mode, meaning that important bugs will be 
+fixed if possible but we won't adding new features in the next few weeks / months.
+
+The focus of future development is on a completely rewritten version (`neopolars`)
+that currently exists in the `next` branch. 
+
+The package in that branch will become the new `polars` package once the rewrite
+is complete (so the installation method will not change).
+
+Check https://github.com/pola-rs/r-polars/issues/1152 for more info.
+
+---
+
 The **polars** package for R gives users access to [a lightning
 fast](https://duckdblabs.github.io/db-benchmark/) Data Frame library written in
 Rust. [Polars](https://www.pola.rs/)' embarrassingly parallel execution, cache

--- a/README.Rmd
+++ b/README.Rmd
@@ -29,13 +29,13 @@ knitr::opts_chunk$set(
 
 ---
 
-IMPORTANT: 
+IMPORTANT:
 
-This package is now in maintenance mode, meaning that important bugs will be 
+This package is now in maintenance mode, meaning that important bugs will be
 fixed if possible but we won't adding new features in the next few weeks / months.
 
 The focus of future development is on a completely rewritten version (`neopolars`)
-that currently exists in the `next` branch. 
+that currently exists in the `next` branch.
 
 The package in that branch will become the new `polars` package once the rewrite
 is complete (so the installation method will not change).

--- a/README.md
+++ b/README.md
@@ -17,6 +17,24 @@ R-CMD-check](https://github.com/pola-rs/r-polars/actions/workflows/check.yaml/ba
 version](https://img.shields.io/badge/docs-dev-blue.svg)](https://pola-rs.github.io/r-polars)
 <!-- badges: end -->
 
+------------------------------------------------------------------------
+
+IMPORTANT:
+
+This package is now in maintenance mode, meaning that important bugs
+will be fixed if possible but we won’t adding new features in the next
+few weeks / months.
+
+The focus of future development is on a completely rewritten version
+(`neopolars`) that currently exists in the `next` branch.
+
+The package in that branch will become the new `polars` package once the
+rewrite is complete (so the installation method will not change).
+
+Check <https://github.com/pola-rs/r-polars/issues/1152> for more info.
+
+------------------------------------------------------------------------
+
 The **polars** package for R gives users access to [a lightning
 fast](https://duckdblabs.github.io/db-benchmark/) Data Frame library
 written in Rust. [Polars](https://www.pola.rs/)’ embarrassingly parallel


### PR DESCRIPTION
Might be a bit late but I just realized that the warning message was only displayed in the changelog and releases page, and I doubt many people check those.

So even if it's for a few weeks only, I'd like to show that the package is not abandoned.