### PR TITLE
fix: fix arguments that were erroneously passed outside of `unwrap()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,11 @@
 
 ## polars (development version)
 
+### Bug fixes
+
+- Function to convert Polars to R (`<Series>$to_r()` etc.) no longer fail with
+  the "NA in coercion to boolean" error in R 4.5 (#1337).
+
 ## Polars R Package 0.22.1
 
 This is a small hot-fix release to fix the build error on R-multiverse.

--- a/R/series__series.R
+++ b/R/series__series.R
@@ -544,13 +544,13 @@ Series_to_r = \(int64_conversion = polars_options()$int64_conversion) {
 #' @rdname Series_to_r
 #' @inheritParams DataFrame_to_data_frame
 Series_to_vector = \(int64_conversion = polars_options()$int64_conversion) {
-  unlist(unwrap(.pr$Series$to_r(self, int64_conversion)), "in $to_vector():")
+  unlist(unwrap(.pr$Series$to_r(self, int64_conversion), "in $to_vector():"))
 }
 
 #' @rdname Series_to_r
 #' @inheritParams DataFrame_to_data_frame
 Series_to_list = \(int64_conversion = polars_options()$int64_conversion) {
-  as.list(unwrap(.pr$Series$to_r(self, int64_conversion)), "in $to_list():")
+  as.list(unwrap(.pr$Series$to_r(self, int64_conversion), "in $to_list():"))
 }
 
 #' Count the occurrences of unique values


### PR DESCRIPTION
It appears that `unlist()` is failing on R 4.5 due to incorrectly positioned arguments.