### PR TITLE
fix: bump extendr and libR-sys to remove non-api calls warnings on R 4.5.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -120,5 +120,5 @@ Collate:
     'zzz.R'
 Config/rextendr/version: 0.3.1
 VignetteBuilder: knitr
-Config/polars/LibVersion: 0.45.0
+Config/polars/LibVersion: 0.45.1
 Config/polars/RustToolchainVersion: nightly-2024-11-28

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -82,6 +82,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "annotate-snippets"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccaf7e9dfbb6ab22c82e473cd1a8a7bd313c19a5b7e40970f3d89ef5a5c9e81e"
+dependencies = [
+ "unicode-width 0.1.14",
+ "yansi-term",
+]
+
+[[package]]
 name = "argminmax"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,6 +223,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "annotate-snippets",
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.90",
+ "which",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,6 +357,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -369,6 +412,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,7 +440,7 @@ dependencies = [
  "crossterm",
  "strum",
  "strum_macros",
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -598,7 +652,7 @@ checksum = "b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c"
 [[package]]
 name = "extendr-api"
 version = "0.6.0"
-source = "git+https://github.com/extendr/extendr?rev=1895bfc8ee22347665900caa0e48da4f0b13232f#1895bfc8ee22347665900caa0e48da4f0b13232f"
+source = "git+https://github.com/rpolars/extendr?rev=24ec0933892fe6d926e3d293b92fc2eeb22b06ad#24ec0933892fe6d926e3d293b92fc2eeb22b06ad"
 dependencies = [
  "extendr-macros",
  "libR-sys",
@@ -610,7 +664,7 @@ dependencies = [
 [[package]]
 name = "extendr-macros"
 version = "0.6.0"
-source = "git+https://github.com/extendr/extendr?rev=1895bfc8ee22347665900caa0e48da4f0b13232f#1895bfc8ee22347665900caa0e48da4f0b13232f"
+source = "git+https://github.com/rpolars/extendr?rev=24ec0933892fe6d926e3d293b92fc2eeb22b06ad#24ec0933892fe6d926e3d293b92fc2eeb22b06ad"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1219,6 +1273,15 @@ checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -1295,10 +1358,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libR-sys"
-version = "0.6.0"
+name = "lazycell"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34aaa68a201f71eab5df5a67d1326add8aaf029434e939353bcab0534919ff1"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
+name = "libR-sys"
+version = "0.7.0"
+source = "git+https://github.com/extendr/libR-sys?rev=975af4e555e4fed58084aef9596a9a71602666be#975af4e555e4fed58084aef9596a9a71602666be"
+dependencies = [
+ "bindgen",
+]
 
 [[package]]
 name = "libc"
@@ -1324,6 +1395,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a52d3a8bfc85f250440e4424db7d857e241a3aebbbe301f3eb606ab15c39acbf"
 dependencies = [
  "rle-decode-fast",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -1474,6 +1555,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1538,6 +1625,16 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "rawpointer",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1618,7 +1715,7 @@ dependencies = [
  "futures",
  "humantime",
  "hyper",
- "itertools",
+ "itertools 0.13.0",
  "md-5",
  "parking_lot",
  "percent-encoding",
@@ -2323,6 +2420,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2360,7 +2467,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.0",
  "rustls",
  "socket2",
  "thiserror",
@@ -2378,7 +2485,7 @@ dependencies = [
  "getrandom",
  "rand",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.0",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -2413,7 +2520,7 @@ dependencies = [
 
 [[package]]
 name = "r-polars"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "either",
  "extendr-api",
@@ -2673,6 +2780,12 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -3353,6 +3466,12 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
@@ -3542,6 +3661,18 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -3877,6 +4008,15 @@ name = "xxhash-rust"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a5cbf750400958819fb6178eaa83bee5cd9c29a26a40cc241df8c70fdd46984"
+
+[[package]]
+name = "yansi-term"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe5c30ade05e61656247b2e334a031dfd0cc466fadef865bdcdea8d537951bf1"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "yoke"

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -82,16 +82,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "annotate-snippets"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccaf7e9dfbb6ab22c82e473cd1a8a7bd313c19a5b7e40970f3d89ef5a5c9e81e"
-dependencies = [
- "unicode-width 0.1.14",
- "yansi-term",
-]
-
-[[package]]
 name = "argminmax"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,30 +213,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "annotate-snippets",
- "bitflags",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.90",
- "which",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,15 +323,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,17 +369,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
-
-[[package]]
 name = "cmake"
 version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,7 +386,7 @@ dependencies = [
  "crossterm",
  "strum",
  "strum_macros",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -651,8 +597,8 @@ checksum = "b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c"
 
 [[package]]
 name = "extendr-api"
-version = "0.6.0"
-source = "git+https://github.com/rpolars/extendr?rev=24ec0933892fe6d926e3d293b92fc2eeb22b06ad#24ec0933892fe6d926e3d293b92fc2eeb22b06ad"
+version = "0.7.0"
+source = "git+https://github.com/rpolars/extendr?rev=53bc326c5cdb4ac8684219d283d0ad21450072c1#53bc326c5cdb4ac8684219d283d0ad21450072c1"
 dependencies = [
  "extendr-macros",
  "libR-sys",
@@ -663,8 +609,8 @@ dependencies = [
 
 [[package]]
 name = "extendr-macros"
-version = "0.6.0"
-source = "git+https://github.com/rpolars/extendr?rev=24ec0933892fe6d926e3d293b92fc2eeb22b06ad#24ec0933892fe6d926e3d293b92fc2eeb22b06ad"
+version = "0.7.0"
+source = "git+https://github.com/rpolars/extendr?rev=53bc326c5cdb4ac8684219d283d0ad21450072c1#53bc326c5cdb4ac8684219d283d0ad21450072c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1273,15 +1219,6 @@ checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -1358,18 +1295,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libR-sys"
-version = "0.7.0"
-source = "git+https://github.com/extendr/libR-sys?rev=975af4e555e4fed58084aef9596a9a71602666be#975af4e555e4fed58084aef9596a9a71602666be"
-dependencies = [
- "bindgen",
-]
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ac9752bc1e83f5a354a62b9e81bd8db4468b1008e29f262441e7f0e91e6bb3"
 
 [[package]]
 name = "libc"
@@ -1395,16 +1324,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a52d3a8bfc85f250440e4424db7d857e241a3aebbbe301f3eb606ab15c39acbf"
 dependencies = [
  "rle-decode-fast",
-]
-
-[[package]]
-name = "libloading"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
-dependencies = [
- "cfg-if",
- "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -1555,12 +1474,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1625,16 +1538,6 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "rawpointer",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -1715,7 +1618,7 @@ dependencies = [
  "futures",
  "humantime",
  "hyper",
- "itertools 0.13.0",
+ "itertools",
  "md-5",
  "parking_lot",
  "percent-encoding",
@@ -2420,16 +2323,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
-dependencies = [
- "proc-macro2",
- "syn 2.0.90",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2467,7 +2360,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.0",
+ "rustc-hash",
  "rustls",
  "socket2",
  "thiserror",
@@ -2485,7 +2378,7 @@ dependencies = [
  "getrandom",
  "rand",
  "ring",
- "rustc-hash 2.1.0",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -2780,12 +2673,6 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -3466,12 +3353,6 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
-name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
@@ -3661,18 +3542,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
 ]
 
 [[package]]
@@ -4008,15 +3877,6 @@ name = "xxhash-rust"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a5cbf750400958819fb6178eaa83bee5cd9c29a26a40cc241df8c70fdd46984"
-
-[[package]]
-name = "yansi-term"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe5c30ade05e61656247b2e334a031dfd0cc466fadef865bdcdea8d537951bf1"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "yoke"

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -36,7 +36,7 @@ opt-level = 3 # was 1 to support 1.66, but since 1.70 is needed anyway it does n
 opt-level = 3
 
 [dependencies]
-extendr-api = { git = "https://github.com/rpolars/extendr", rev = "24ec0933892fe6d926e3d293b92fc2eeb22b06ad", default-features = false, features = [
+extendr-api = { git = "https://github.com/rpolars/extendr", rev = "53bc326c5cdb4ac8684219d283d0ad21450072c1", default-features = false, features = [
   "result_list",
   "serde",
 ] }

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r-polars"
-version = "0.45.0"
+version = "0.45.1"
 edition = "2021"
 rust-version = "1.82.0"
 publish = false
@@ -36,7 +36,7 @@ opt-level = 3 # was 1 to support 1.66, but since 1.70 is needed anyway it does n
 opt-level = 3
 
 [dependencies]
-extendr-api = { git = "https://github.com/extendr/extendr", rev = "1895bfc8ee22347665900caa0e48da4f0b13232f", default-features = false, features = [
+extendr-api = { git = "https://github.com/rpolars/extendr", rev = "24ec0933892fe6d926e3d293b92fc2eeb22b06ad", default-features = false, features = [
   "result_list",
   "serde",
 ] }

--- a/tools/lib-sums.tsv
+++ b/tools/lib-sums.tsv
@@ -1,6 +1,0 @@
-url	sha256sum
-https://github.com/pola-rs/r-polars/releases/download/lib-v0.45.0/libr_polars-0.45.0-aarch64-apple-darwin.tar.gz	bd7b33d8451769bcb9fc463c3061bde3e06db6520833175d5cc16ede26e066bd
-https://github.com/pola-rs/r-polars/releases/download/lib-v0.45.0/libr_polars-0.45.0-aarch64-unknown-linux-gnu.tar.gz	65edd7aa1832379efd851f0c20ebe6bd0f29c515aaac9f3cbe0f94cc6efb194a
-https://github.com/pola-rs/r-polars/releases/download/lib-v0.45.0/libr_polars-0.45.0-x86_64-apple-darwin.tar.gz	464ad4d37d2fc75a575c496fe6f3f406109efa44c20523bae9840270782758d2
-https://github.com/pola-rs/r-polars/releases/download/lib-v0.45.0/libr_polars-0.45.0-x86_64-pc-windows-gnu.tar.gz	00435568a5980f0d2c82f7ef6b3ee1294261aa89efd670f64018153fe7f6fa4a
-https://github.com/pola-rs/r-polars/releases/download/lib-v0.45.0/libr_polars-0.45.0-x86_64-unknown-linux-gnu.tar.gz	52a7ebfce3d02beea4f55d2a049d15a491aa83e269ccb11fabe8b6e0da64854e


### PR DESCRIPTION
Related to #1105

Since the new release of extendr contained some breaking changes that cannot be applied here (#1154, #1164, #1187), I cherry-picked only the relevant commits in the fork (rpolars/extendr#5).

Before:

```log
* checking compiled code ... WARNING
Warning: File ‘polars/libs/polars.so’:
  Found non-API calls to R: ‘BODY’, ‘CLOENV’, ‘DATAPTR’, ‘ENCLOS’,
    ‘ENVFLAGS’, ‘FORMALS’, ‘FRAME’, ‘HASHTAB’, ‘PRCODE’, ‘PRENV’,
    ‘PRSEEN’, ‘PRVALUE’, ‘Rf_allocSExp’, ‘Rf_findVarInFrame3’,
    ‘SET_BODY’, ‘SET_CLOENV’, ‘SET_ENCLOS’, ‘SET_ENVFLAGS’,
    ‘SET_FORMALS’, ‘SET_PRCODE’, ‘SET_PRENV’, ‘SET_PRVALUE’,
    ‘STRING_PTR’, ‘SYMVALUE’, ‘XLENGTH_EX’
These entry points may be removed soon:
‘PRSEEN’, ‘SYMVALUE’
```

This PR:

```log
* checking compiled code ... NOTE
File ‘polars/libs/polars.so’:
  Found non-API calls to R: ‘BODY’, ‘CLOENV’, ‘DATAPTR’, ‘ENCLOS’,
    ‘FORMALS’
```

My goal is to keep this package alive on the R-multiverse Production repository[^1] after the R 4.5 release. (since I don't expect the `next` branch to replace this package in another month, related to #1336)

[^1]: <https://r-multiverse.org/production.html#quality>