### PR TITLE
ci: stop using `filter_rcmdcheck.R` to simplify maintenance

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -115,15 +115,6 @@ jobs:
       - uses: r-lib/actions/check-r-package@v2
         env:
           LIBR_POLARS_BUILD: "false"
-        with:
-          upload-snapshots: false
-          error-on: '"never"' #errors are filtered by rules below
-
-      - name: raise remaining rcmdcheck errors
-        run: |
-         print(getwd());
-         source("./inst/misc/filter_rcmdcheck.R");
-        shell: Rscript {0}
 
       - name: upload artifact
         if: matrix.config.full-features


### PR DESCRIPTION
There is no active development on this package, so there is no need to be aware of new NOTEs anymore.

Context: https://github.com/pola-rs/r-polars/issues/80#issuecomment-1475223652