### PR TITLE
ci: drop R devel on windows, add R next (4.5.0 beta for now) on ubuntu to check to pass on R 4.5.0

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -52,9 +52,9 @@ jobs:
       matrix:
         config:
           - { os: macos-14, r: "release" }
-          - { os: windows-latest, r: "devel" }
           - { os: windows-latest, r: "release" }
           - { os: ubuntu-latest, r: "devel", http-user-agent: "release" }
+          - { os: ubuntu-latest, r: "next" }
           - { os: ubuntu-latest, r: "release" }
           - { os: ubuntu-latest, r: "oldrel-1" }
         include:


### PR DESCRIPTION
- Remove R devel on Windows, since checking with R devel on Windows tends to be much slower than checking with R devel on Ubuntu and does not provide additional information.
- The check on R 4.5.0 will be added to the matrix, as it is important to be able to pass the check on R 4.5.0, as it is related to whether or not to enter the production repository of the R-multiverse.