### PR TITLE
fix: remove STATLIB immediately after immediate build

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -115,6 +115,7 @@ jobs:
       - uses: r-lib/actions/check-r-package@v2
         env:
           LIBR_POLARS_BUILD: "false"
+          NOT_CRAN: "false"
 
       - name: upload artifact
         if: matrix.config.full-features

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -8,7 +8,8 @@ LIBDIR = $(TARGET_DIR)/$(TARGET)/$(LIBR_POLARS_PROFILE)
 STATLIB = $(LIBDIR)/$(LIBNAME)
 PKG_LIBS = -L$(LIBDIR) -lr_polars @ADDITIONAL_PKG_LIBS_FLAG@
 
-all: C_clean
+.PHONY: all
+all: cleanup
 
 $(SHLIB): $(STATLIB)
 
@@ -28,12 +29,12 @@ $(STATLIB):
 		cargo build --lib --manifest-path="$(CURDIR)/rust/Cargo.toml" --target-dir "$(TARGET_DIR)" --target="$(TARGET)" \
 			--profile="$(LIBR_POLARS_PROFILE)" --features="$(LIBR_POLARS_FEATURES)"
 
-	if [ "true" != "true" ]; then \
-		rm -Rf "$(CARGOTMP)" "$(LIBDIR)/build"; \
+.PHONY: cleanup
+cleanup: $(SHLIB)
+	if [ "$(NOT_CRAN)" != "true" ]; then \
+		rm -Rf "$(STATLIB)"; \
 	fi
 
-C_clean:
-	rm -Rf "$(SHLIB)" "$(STATLIB)" "$(OBJECTS)"
-
+.PHONY: clean
 clean:
 	rm -Rf "$(SHLIB)" "$(STATLIB)" "$(OBJECTS)" "$(TARGET_DIR)"

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -15,7 +15,7 @@ $(SHLIB): $(STATLIB)
 
 CARGOTMP = $(CURDIR)/.cargo
 
-$(STATLIB):
+$(STATLIB): remove-prev
 	if [ -f "$(CURDIR)/../tools/$(LIBNAME)" ]; then \
 		mkdir -p "$(LIBDIR)" ; \
 		mv "$(CURDIR)/../tools/$(LIBNAME)" "$(STATLIB)" ; \
@@ -28,6 +28,11 @@ $(STATLIB):
 		export PATH="$(PATH):$(HOME)/.cargo/bin" && \
 		cargo build --lib --manifest-path="$(CURDIR)/rust/Cargo.toml" --target-dir "$(TARGET_DIR)" --target="$(TARGET)" \
 			--profile="$(LIBR_POLARS_PROFILE)" --features="$(LIBR_POLARS_FEATURES)"
+
+.PHONY: remove-prev
+# Remove previous build artifacts
+remove-prev:
+	rm -f "$(STATLIB)"
 
 .PHONY: cleanup
 cleanup: $(SHLIB)

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -19,7 +19,7 @@ $(SHLIB): $(STATLIB)
 
 CARGOTMP = $(CURDIR)/.cargo
 
-$(STATLIB):
+$(STATLIB): remove-prev
 	# `rustc` adds `-lgcc_eh` flags to the compiler, but Rtools' GCC doesn't have
 	# `libgcc_eh` due to the compilation settings. So, in order to please the
 	# compiler, we need to add empty `libgcc_eh` to the library search paths.
@@ -42,6 +42,11 @@ $(STATLIB):
 		export LIBRARY_PATH="$${LIBRARY_PATH};$(TARGET_DIR)/libgcc_mock" && \
 		cargo build --lib --manifest-path="$(CURDIR)/rust/Cargo.toml" --target-dir "$(TARGET_DIR)" --target="$(TARGET)" \
 			--profile="$(LIBR_POLARS_PROFILE)" --features="$(LIBR_POLARS_FEATURES)"
+
+.PHONY: remove-prev
+# Remove previous build artifacts
+remove-prev:
+	rm -f "$(STATLIB)"
 
 .PHONY: cleanup
 cleanup: $(SHLIB)

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -12,7 +12,8 @@ PKG_LIBS = -L$(LIBDIR) -lr_polars -lws2_32 -lncrypt -lcrypt32 -ladvapi32 -lusere
 # need to overwrite it via configuration.
 CARGO_LINKER = x86_64-w64-mingw32.static.posix-gcc.exe
 
-all: C_clean
+.PHONY: all
+all: cleanup
 
 $(SHLIB): $(STATLIB)
 
@@ -42,12 +43,12 @@ $(STATLIB):
 		cargo build --lib --manifest-path="$(CURDIR)/rust/Cargo.toml" --target-dir "$(TARGET_DIR)" --target="$(TARGET)" \
 			--profile="$(LIBR_POLARS_PROFILE)" --features="$(LIBR_POLARS_FEATURES)"
 
-	if [ "true" != "true" ]; then \
-		rm -Rf "$(CARGOTMP)" "$(LIBDIR)/build"; \
+.PHONY: cleanup
+cleanup: $(SHLIB)
+	if [ "$(NOT_CRAN)" != "true" ]; then \
+		rm -Rf "$(STATLIB)"; \
 	fi
 
-C_clean:
-	rm -Rf "$(SHLIB)" "$(STATLIB)" "$(OBJECTS)"
-
+.PHONY: clean
 clean:
 	rm -Rf "$(SHLIB)" "$(STATLIB)" "$(OBJECTS)" "$(TARGET_DIR)"


### PR DESCRIPTION
Context: yutannihilation/savvy#355

It is required by R 4.5.0's R CMD check.