### PR TITLE
chore: switch the maintainer of this package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,8 +5,8 @@ Depends: R (>= 4.2)
 Imports: utils, codetools, methods
 Authors@R:
   c(person("Ritchie", "Vink", , "ritchie46@gmail.com", role = c("aut")),
-    person("Soren", "Welling", , "sorhawell@gmail.com", role = c("aut", "cre")),
-    person("Tatsuya", "Shima", , "ts1s1andn@gmail.com", role = c("aut")),
+    person("Soren", "Welling", , "sorhawell@gmail.com", role = c("aut")),
+    person("Tatsuya", "Shima", , "ts1s1andn@gmail.com", role = c("aut", "cre")),
     person("Etienne", "Bacher", , "etienne.bacher@protonmail.com", role = c("aut"), comment = c(ORCID = "0000-0002-9271-5075")))
 Description: Lightning-fast 'DataFrame' library written in 'Rust'. Convert R data
   to 'Polars' data and vice versa. Perform fast, lazy, larger-than-memory and

--- a/man/polars-package.Rd
+++ b/man/polars-package.Rd
@@ -18,12 +18,12 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Soren Welling \email{sorhawell@gmail.com}
+\strong{Maintainer}: Tatsuya Shima \email{ts1s1andn@gmail.com}
 
 Authors:
 \itemize{
   \item Ritchie Vink \email{ritchie46@gmail.com}
-  \item Tatsuya Shima \email{ts1s1andn@gmail.com}
+  \item Soren Welling \email{sorhawell@gmail.com}
   \item Etienne Bacher \email{etienne.bacher@protonmail.com} (\href{https://orcid.org/0000-0002-9271-5075}{ORCID})
 }
 


### PR DESCRIPTION
I expect the next release to be the last release of this package and would like to clarify support responsibilities by crediting me as the maintainer instead of @sorhawell who is no longer active.
(Just for the record, this was the case in the polars package on CRAN, but I have revert to the original because we gave up on the CRAN release.)
https://github.com/cran/polars/blob/a4763e6c99a7985d3272691535769d0fd529faf5/DESCRIPTION#L6-L10

Related to #1152 and #1336