### PR TITLE
fix:  Warn for existing mirai daemons when loaded

### DIFF
--- a/R/integration-mirai.R
+++ b/R/integration-mirai.R
@@ -5,6 +5,25 @@ register_mirai_serial <- function() {
   # If the mirai package is not installed, `asNamespace("mirai")` will throw an error,
   # so this function should only be called when the mirai package is loaded.
   if (exists("register_serial", envir = asNamespace("mirai"), mode = "function")) {
+    # If the daemons are already set, registering serialization configs
+    # will not affect existing daemons. So warn to the user.
+    # Safety: mirai::daemons_set is added in mirai 2.3.0,
+    # the same version that introduced the `register_serial` function.
+    if (mirai::daemons_set()) {
+      warn(
+        format_warning(
+          c(
+            `!` = sprintf(
+              "Auto registered %s serialization configs by %s does not affect existing daemons.",
+              format_pkg("mirai"),
+              format_pkg("polars")
+            ),
+            i = "To apply the configs, recreating daemons is needed."
+          )
+        )
+      )
+    }
+
     mirai::register_serial(
       c("polars_data_frame", "polars_lazy_frame", "polars_series"),
       sfunc = list(\(x) x$serialize(), \(x) x$serialize(), \(x) x$serialize()),


### PR DESCRIPTION
Related to https://github.com/pola-rs/r-polars/issues/1440#issuecomment-3112254174

It will raise a warning before the weird errors occur.

``` r
mirai::daemons(1)
#> [1] 1

series <- polars::as_polars_series(1)$cast(polars::pl$Int128)
#> Warning: ! Auto registered mirai serialization configs by polars does not affect
#>   existing daemons.
#> ℹ To apply the configs, recreating daemons is needed.

list(series) |>
  mirai::mirai_map(\(x) x * 2L) |>
  _[][[1]]
#> 'miraiError' chr Error in x$len(): Evaluation failed in `$len()`.
```

<sup>Created on 2025-07-24 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

If polars is loaded before the daemons are created, nothing will happen.

``` r
series <- polars::as_polars_series(1)$cast(polars::pl$Int128)

mirai::daemons(1)
#> [1] 1

list(series) |>
  mirai::mirai_map(\(x) x * 2L) |>
  _[][[1]]
#> shape: (1, 1)
#> ┌──────┐
#> │      │
#> │ ---  │
#> │ i128 │
#> ╞══════╡
#> │ 2    │
#> └──────┘
```

<sup>Created on 2025-07-24 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

``` r
mirai::daemons(1)
#> [1] 1
mirai::daemons(0)
#> [1] 0

series <- polars::as_polars_series(1)$cast(polars::pl$Int128)

mirai::daemons(1)
#> [1] 1

list(series) |>
  mirai::mirai_map(\(x) x * 2L) |>
  _[][[1]]
#> shape: (1, 1)
#> ┌──────┐
#> │      │
#> │ ---  │
#> │ i128 │
#> ╞══════╡
#> │ 2    │
#> └──────┘
```

<sup>Created on 2025-07-24 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

@shikokuchuo Could you take a look at this?
Maybe it would be better to add such functionality to `register_serial`.