### PR TITLE
perf: Only call as_polars_selector.character once inside `parse_into_selector`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,11 @@ This is an update that corresponds to Python Polars 1.32.2.
 - New function `pl$concat_arr()` (#1490).
 - New functions `pl$linear_space()` and `pl$linear_spaces()` (#1487).
 
+### Performance
+
+- The performance of converting character vectors to selectors has been improved,
+  resolving performance issues when specifying column names with a large number of strings.
+
 ## polars 1.1.0
 
 This is an update that corresponds to Python Polars 1.32.0, which includes significant internal changes.

--- a/tests/testthat/_snaps/utils-parse-expr.md
+++ b/tests/testthat/_snaps/utils-parse-expr.md
@@ -37,6 +37,14 @@
 ---
 
     Code
+      parse_into_selector(NA_character_)
+    Condition
+      Error:
+      ! `...` can only contain single strings or polars selectors.
+
+---
+
+    Code
       parse_into_selector(integer())
     Condition
       Error:

--- a/tests/testthat/test-utils-parse-expr.R
+++ b/tests/testthat/test-utils-parse-expr.R
@@ -28,6 +28,7 @@ test_that("parse_into_selector works", {
     cs$empty()
   )
   expect_snapshot(parse_into_selector(NULL), error = TRUE)
+  expect_snapshot(parse_into_selector(NA_character_), error = TRUE)
   expect_equal(
     parse_into_selector(character()),
     cs$by_name(require_all = TRUE)


### PR DESCRIPTION
#1481 only fixed the case that dots only contains characters.
So if the dots contains other objects, the performance is not good.

This PR fix the situation by filtering all characters.

```r
bench::mark(
  p_i_s_with_splicing = polars:::parse_into_selector(!!!letters, cs$by_index(1)),
  p_i_s_without_splicing = polars:::parse_into_selector(letters, cs$by_index(1)),
  as_selector = polars:::as_polars_selector(letters) | cs$by_index(1),
  relative = TRUE
)
```

Before:

```r
#> # A tibble: 3 × 13
#>   expression               min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result     memory               time             gc                
#>   <bch:expr>             <dbl>  <dbl>     <dbl>     <dbl>    <dbl> <int> <dbl>   <bch:tm> <list>     <list>               <list>           <list>            
#> 1 p_i_s_with_splicing    19.4   18.8        1        34.0     1.47    20     7      340ms <plrs_slc> <Rprofmem [635 × 3]> <bench_tm [27]>  <tibble [27 × 3]> 
#> 2 p_i_s_without_splicing  1.07   1.09      16.1       1       1.09   432     7      457ms <plrs_slc> <Rprofmem [22 × 3]>  <bench_tm [439]> <tibble [439 × 3]>
#> 3 as_selector             1      1         17.8       1       1      447     6      428ms <plrs_slc> <Rprofmem [22 × 3]>  <bench_tm [453]> <tibble [453 × 3]>
```

After:

```r
#> # A tibble: 3 × 13
#>   expression               min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result     memory               time             gc                
#>   <bch:expr>             <dbl>  <dbl>     <dbl>     <dbl>    <dbl> <int> <dbl>   <bch:tm> <list>     <list>               <list>           <list>            
#> 1 p_i_s_with_splicing     1.15   1.25      1         4.35     1      434     6      466ms <plrs_slc> <Rprofmem [59 × 3]>  <bench_tm [440]> <tibble [440 × 3]>
#> 2 p_i_s_without_splicing  1.09   1.26      1.01     12.6      1.00   435     6      465ms <plrs_slc> <Rprofmem [364 × 3]> <bench_tm [441]> <tibble [441 × 3]>
#> 3 as_selector             1      1         1.28      1        1.19   546     7      458ms <plrs_slc> <Rprofmem [22 × 3]>  <bench_tm [553]> <tibble [553 × 3]>
```