### PR TITLE
feat: Implement argument `mkdir` in `<DataFrame>$write_parquet()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,10 @@ They still work the same way on series.
 - `<expr>$str$to_decimal()`'s `inference_length` (#1507).
 - `<expr>$str$to_decimal()`'s new `scale` argument must be specified (#1507).
 
+### New features
+
+- New argument `mkdir` in `<DataFrame>$write_parquet()` (#1525).
+
 ## polars 1.2.1
 
 This is an update that corresponds to Python Polars 1.32.3.

--- a/R/output-parquet.R
+++ b/R/output-parquet.R
@@ -186,13 +186,13 @@ dataframe__write_parquet <- function(
   partition_by = NULL,
   partition_chunk_size_bytes = 4294967296,
   storage_options = NULL,
-  retries = 2
+  retries = 2,
+  mkdir = FALSE
 ) {
   wrap({
     check_dots_empty0(...)
 
     target <- file
-    mkdir <- FALSE
 
     if (!is.null(partition_by)) {
       if (!is_string(file)) {

--- a/man/dataframe__write_parquet.Rd
+++ b/man/dataframe__write_parquet.Rd
@@ -15,7 +15,8 @@ dataframe__write_parquet(
   partition_by = NULL,
   partition_chunk_size_bytes = 4294967296,
   storage_options = NULL,
-  retries = 2
+  retries = 2,
+  mkdir = FALSE
 )
 }
 \arguments{
@@ -90,6 +91,8 @@ If \code{storage_options} is not provided, Polars will try to infer the
 information from environment variables.}
 
 \item{retries}{Number of retries if accessing a cloud instance fails.}
+
+\item{mkdir}{Recursively create all the directories in the path.}
 }
 \value{
 \code{NULL} invisibly.

--- a/tests/testthat/test-output-parquet.R
+++ b/tests/testthat/test-output-parquet.R
@@ -173,3 +173,22 @@ test_that("polars and arrow create the same hive partition", {
     dirname(list.files(temp_dir_polars, recursive = TRUE))
   )
 })
+
+test_that("argument `mkdir` works", {
+  tmpf <- file.path(withr::local_tempdir(), "out", "foo.parquet")
+  on.exit(unlink(tmpf))
+  df_exp <- as_polars_df(mtcars)
+
+  expect_error(
+    df_exp$write_parquet(tmpf),
+    "No such file or directory"
+  )
+
+  df_exp$write_parquet(tmpf, mkdir = TRUE)
+
+  expect_equal(
+    pl$read_parquet(tmpf),
+    mtcars,
+    ignore_attr = TRUE
+  )
+})


### PR DESCRIPTION
This is part of polars 1.33.0 but I didn't want to include it in #1523 since it doesn't touch the Rust part.