### PR TITLE
ci(build-docs): Replace the `release` trigger to the `push.tag` trigger with tag name filter

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -18,6 +18,8 @@ on:
       - NAMESPACE
       - README.md
       - NEWS.md
+    tags:
+      - v*
   pull_request:
     branches:
       - main
@@ -35,9 +37,6 @@ on:
       - NAMESPACE
       - README.md
       - NEWS.md
-  release:
-    types:
-      - released
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
It might make sense to also create releases of the binary lib to use GitHub's new immutable release feature, and if we do something like this, we don't want this workflow to be triggered on every release.