### PR TITLE
ci(test-r): Should not build rust lib twice in R CMD check

### DIFF
--- a/.github/workflows/test-r.yml
+++ b/.github/workflows/test-r.yml
@@ -114,6 +114,7 @@ jobs:
 
       - uses: r-lib/actions/check-r-package@v2
         env:
+          LIBR_POLARS_BUILD: "false"
           NOT_CRAN: "false"
         with:
           upload-snapshots: true


### PR DESCRIPTION
Missed in #1585.

During the R CMD check process, it had become necessary to perform a source build in order to build the vignettes.