### PR TITLE
ci(test-r): Install dev version of nanoarrow to test reticulate integrations

### DIFF
--- a/.github/workflows/test-r.yml
+++ b/.github/workflows/test-r.yml
@@ -76,6 +76,9 @@ jobs:
           http-user-agent: ${{ runner.os == 'Windows' && 'release' || '' }}
           use-public-rspm: true
           Ncpus: "2"
+          # To install the edge version of nanoarrow
+          # TODO: remove this after nanoarrow 0.8.0 release
+          extra-repositories: https://apache.r-universe.dev/nanoarrow
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:


### PR DESCRIPTION
Ref: r-universe-org/docs#106