### PR TITLE
chore: Bump polars to py-1.35.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,7 +53,7 @@ VignetteBuilder:
 Config/Needs/dev: devtools, lifecycle, readr, glue, RcppTOML, smvr
 Config/Needs/lint: fs, lintr
 Config/Needs/website: etiennebacher/altdoc, future.apply
-Config/polars/lib-version: 1.5.1-rc.1
+Config/polars/lib-version: 1.6.0-rc.1
 Config/testthat/edition: 3
 Config/testthat/parallel: true
 Config/testthat/start-first: lazyframe-frame, *-s3-base, polars_options,

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -2248,7 +2248,7 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-polars"
-version = "1.5.1-rc.1"
+version = "1.6.0-rc.1"
 dependencies = [
  "ciborium",
  "either",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r-polars"
-version = "1.5.1-rc.1"
+version = "1.6.0-rc.1"
 edition = "2024"
 rust-version = "1.89.0"
 publish = false


### PR DESCRIPTION
https://github.com/pola-rs/polars/releases/tag/py-1.35.2

There a few important bug fixes  (at least important enough to make a patch version). I put our version to 1.5.1 because I imagine we could do a patch release too, what do you think @eitsupi ?