### PR TITLE
chore: Use tikv-jemallocator 0.6.0 instead of 0.6.1

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -3027,9 +3027,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.6.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -172,10 +172,13 @@ features = [
 mimalloc = { version = "0.1", default-features = false }
 
 [target.'cfg(all(target_family = "unix", not(target_os = "macos"), not(target_os = "emscripten"), not(allocator = "mimalloc")))'.dependencies]
-tikv-jemallocator = { version = "0.6", features = [
+# tikv-jemallocator 0.6.1 cannot be built on some situations
+# https://github.com/tikv/jemallocator/issues/92
+# TODO: remove version pinning after the issue is resolved
+tikv-jemallocator = { version = "=0.6.0", features = [
     "disable_initial_exec_tls",
     "background_threads",
 ] }
 
 [target.'cfg(all(target_family = "unix", target_os = "macos", not(allocator = "mimalloc")))'.dependencies]
-tikv-jemallocator = { version = "0.6", features = ["disable_initial_exec_tls"] }
+tikv-jemallocator = { version = "=0.6.0", features = ["disable_initial_exec_tls"] }


### PR DESCRIPTION
Ref: tikv/jemallocator#92
Related to #98

I found that 0.6.1 can't be built on conda-forge CI (https://github.com/conda-forge/staged-recipes/pull/31488#issuecomment-3536263029), and Python Polars uses 0.6.0.

IIUC, this is due to the environment variables set at build time, so if there are no problems with the current build, we will not be affected.