### PR TITLE
ci(dependabot): Should not update tikv-jemallocator to 0.6.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,10 @@ updates:
       strum:
         patterns:
           - "strum*"
+    ignore:
+      - dependency-name: tikv-jemallocator
+        versions:
+          - "0.6.1"
 
   - package-ecosystem: devcontainers
     directory: /


### PR DESCRIPTION
Related to #1651 and #1656