### PR TITLE
test: Add missing `skip_if_not_installed()`

### DIFF
--- a/tests/testthat/test-expr-binary.R
+++ b/tests/testthat/test-expr-binary.R
@@ -69,6 +69,7 @@ test_that("bin$size()", {
 })
 
 test_that("bin$reinterpret()", {
+  skip_if_not_installed("blob")
   df <- pl$DataFrame(x = blob::as_blob(c(5L, 35L)))
 
   expect_equal(


### PR DESCRIPTION
Followup of https://github.com/pola-rs/r-polars/pull/1664#discussion_r2553716178.

I merged #1664 too soon, I actually noticed that the `testthat` blog post says:

> **On CRAN**, [test_that()](https://testthat.r-lib.org/reference/test_that.html) will automatically skip if a package is not installed, which means that you no longer need to check if suggested packages are installed in your tests.

but locally this fails:

```r
test_that("foo", {
	# aamatch not installed on my machine  
	aamatch::artless(1)
})
```

There's no point in having this pass on CRAN if it fails locally.