### PR TITLE
fix: Avoid using the in-memory engine inside `<dataframe>$write_ipc()`

### DIFF
--- a/R/output-ipc.R
+++ b/R/output-ipc.R
@@ -159,7 +159,8 @@ dataframe__write_ipc <- function(
       retries = retries,
       optimizations = DEFAULT_EAGER_OPT_FLAGS,
       # To avoid the bug of in-memory engine, use streaming engine here
-      # as like Python Polars does.
+      # as Python Polars does.
+      # https://github.com/pola-rs/polars/issues/25487
       engine = "streaming"
     )
   })


### PR DESCRIPTION
Same as pola-rs/polars#25497