### PR TITLE
chore: Bump lib version for new binary lib release

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -2273,7 +2273,7 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-polars"
-version = "1.7.0-rc.1"
+version = "1.7.0-rc.2"
 dependencies = [
  "ciborium",
  "either",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r-polars"
-version = "1.7.0-rc.1"
+version = "1.7.0-rc.2"
 edition = "2024"
 rust-version = "1.89.0"
 publish = false


### PR DESCRIPTION
Related to  #1681

The only difference is the version number, the contents are the same and compatible.