### PR TITLE
ci(test-r): Reduce test matrix and fix space issue

### DIFF
--- a/.github/workflows/test-r.yml
+++ b/.github/workflows/test-r.yml
@@ -154,6 +154,7 @@ jobs:
           du -hsc /opt/hostedtoolcache/*
           sudo rm -rf /opt/hostedtoolcache/CodeQL || true
           sudo rm -rf /opt/hostedtoolcache/go || true
+          sudo rm -rf /opt/hostedtoolcache/Python || true
 
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
macos-15-intel and ubuntu-24.04-arm are tested on R-universe, and I don't think there is much need to test these here.