### PR TITLE
docs: Mention that partitioning functions also work with `write_*()`

### DIFF
--- a/R/output-partition.R
+++ b/R/output-partition.R
@@ -37,10 +37,10 @@
 #'   Defaults to approximately 4GB when `key` is specified without `max_rows_per_file`;
 #'   otherwise unlimited.
 #' @param by `r lifecycle::badge("deprecated")`
-#'   Something can be coerced to a list of [expressions][polars_expr].
+#'   Something that can be coerced to a list of [expressions][polars_expr].
 #'   Used to partition by. Use the `key` property of `pl$PartitionBy` instead.
 #' @param per_partition_sort_by `r lifecycle::badge("deprecated")`
-#'   Something can be coerced to a list of [expressions][polars_expr], or `NULL` (default).
+#'   Something that can be coerced to a list of [expressions][polars_expr], or `NULL` (default).
 #'   Used to sort over within each partition.
 #'   Use the `per_partition_sort_by` property of `pl$PartitionBy` instead.
 #' @param max_size `r lifecycle::badge("deprecated")`

--- a/man/polars_partitioning_scheme.Rd
+++ b/man/polars_partitioning_scheme.Rd
@@ -60,11 +60,11 @@ Defaults to approximately 4GB when \code{key} is specified without \code{max_row
 otherwise unlimited.}
 
 \item{by}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
-Something can be coerced to a list of \link[=polars_expr]{expressions}.
+Something that can be coerced to a list of \link[=polars_expr]{expressions}.
 Used to partition by. Use the \code{key} property of \code{pl$PartitionBy} instead.}
 
 \item{per_partition_sort_by}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
-Something can be coerced to a list of \link[=polars_expr]{expressions}, or \code{NULL} (default).
+Something that can be coerced to a list of \link[=polars_expr]{expressions}, or \code{NULL} (default).
 Used to sort over within each partition.
 Use the \code{per_partition_sort_by} property of \code{pl$PartitionBy} instead.}
 


### PR DESCRIPTION
``` r
library(polars)

as_polars_df(mtcars)$write_parquet(
  pl$PartitionBy(
    ".",
    key = c("cyl", "am"),
    include_key = FALSE
  )
)
fs::dir_tree()
#> .
#> ├── cyl=4.0
#> │   ├── am=0.0
#> │   │   └── 00000000.parquet
#> │   └── am=1.0
#> │       └── 00000000.parquet
#> ├── cyl=6.0
#> │   ├── am=0.0
#> │   │   └── 00000000.parquet
#> │   └── am=1.0
#> │       └── 00000000.parquet
#> ├── cyl=8.0
#> │   ├── am=0.0
#> │   │   └── 00000000.parquet
#> │   └── am=1.0
#> │       └── 00000000.parquet
#> ├── lucid-carp_reprex.R
#> ├── lucid-carp_reprex.spin.R
#> └── lucid-carp_reprex.spin.Rmd
```
