### PR TITLE
fix: Swap format_arg/format_fn order in scan_parquet deprecation message

### DIFF
--- a/R/input-parquet-functions.R
+++ b/R/input-parquet-functions.R
@@ -94,8 +94,8 @@ pl__scan_parquet <- function(
       c(
         `!` = sprintf(
           "The argument %s of %s is deprecated.",
-          format_fn("scan_parquet"),
-          format_arg("allow_missing_columns")
+          format_arg("allow_missing_columns"),
+          format_fn("scan_parquet")
         ),
         i = sprintf(
           "Use the argument %s instead and pass one of %s.",


### PR DESCRIPTION
## Summary
- Fix sprintf argument order in `scan_parquet` `allow_missing_columns` deprecation warning
- Was producing "The argument `scan_parquet()` of `allow_missing_columns` is deprecated." instead of "The argument `allow_missing_columns` of `scan_parquet()` is deprecated."

## Test plan
- [ ] Verify the deprecation warning message reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)