### PR TITLE
ci(release-lib): reduce ARM Linux build memory pressure in release-lib

### DIFF
--- a/.github/workflows/release-lib.yml
+++ b/.github/workflows/release-lib.yml
@@ -79,6 +79,14 @@ jobs:
           echo 'CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc' >>"$GITHUB_ENV"
           echo 'CC=aarch64-linux-gnu-gcc' >>"$GITHUB_ENV"
 
+      - name: limit rust build jobs on aarch64 linux
+        if: startsWith(matrix.target, 'aarch64-unknown-linux-')
+        run: |
+          # First step: reduce parallel rustc processes only on ARM Linux targets.
+          echo 'CARGO_BUILD_JOBS=2' >>"$GITHUB_ENV"
+          # Reduce LTO memory pressure on ARM Linux while keeping release optimizations.
+          echo 'CARGO_PROFILE_DIST_RELEASE_LTO=thin' >>"$GITHUB_ENV"
+
       - name: Set up R
         uses: r-lib/actions/setup-r@v2
         with:


### PR DESCRIPTION
## Summary
- limit Rust build parallelism on ARM Linux targets (`aarch64-unknown-linux-*`)
- override `dist-release` LTO to `thin` only for ARM Linux in CI
- keep scope limited to `.github/workflows/release-lib.yml`

## Why
- mitigate hosted runner instability (`runner lost communication`) during ARM library builds
- reduce peak memory pressure during Rust build/link steps while keeping release optimizations

## Notes
- targets affected: `aarch64-unknown-linux-gnu`, `aarch64-unknown-linux-musl`
- changes are CI-only and platform-scoped
