### PR TITLE
ci(release-lib): avoid installing wrong binary from p3m

### DIFF
--- a/.github/workflows/release-lib.yml
+++ b/.github/workflows/release-lib.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Set up R
         uses: r-lib/actions/setup-r@v2
         with:
-          use-public-rspm: matorix.os != 'ubuntu-22.04-arm' # TODO: remove this line after r-lib/actions#1083
+          use-public-rspm: ${{ matrix.os != 'ubuntu-22.04-arm' }} # TODO: remove this line after r-lib/actions#1083
           Ncpus: 2
 
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/release-lib.yml
+++ b/.github/workflows/release-lib.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Set up R
         uses: r-lib/actions/setup-r@v2
         with:
-          use-public-rspm: true
+          use-public-rspm: matorix.os != 'ubuntu-22.04-arm' # TODO: remove this line after r-lib/actions#1083
           Ncpus: 2
 
       - uses: r-lib/actions/setup-r-dependencies@v2


### PR DESCRIPTION
Context: r-lib/actions#1083