### PR TITLE
build(taskfile): Use release build for development

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -53,7 +53,8 @@ export DEBUG=true  # for debug builds, false for release builds
 **Option 1: Using Task (Recommended)**
 
 - `task test-all` -- Runs full test suite with proper environment
-- `task test-source` -- Runs all tests for source code
+- `task test-file FILE=tests/testthat/test-foo.R` -- Runs one test file
+- `task test-filter FILTER=foo` -- Runs test files matching a regular expression
 
 **Option 2: Manual Commands**
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -600,8 +600,15 @@ Alternatively, you can run the steps individually:
 task build-lib-sums    # update DESCRIPTION lib-version and checksum metadata
 task build-documents   # regenerate Rd files and auto-generated R files
 task test-all          # run the full test suite
+task test-file FILE=tests/testthat/test-dataframe-frame.R
+task test-filter FILTER=dataframe
 task build-readme      # rebuild README
 ```
+
+The test tasks build and install the package, then run tests against the installed
+package. Installation reuses the release Rust library produced while building the
+documentation, so it does not compile the Rust library a second time. Use `test-file`
+for a single test file and `test-filter` to select test files by a regular expression.
 
 Categorize test failures into:
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -21,6 +21,9 @@ vars:
   VIGNETTES: vignettes/**/*.Rmd
   RUST_SOURCE: src/rust/src/**/*.rs
   RUST_TOOLCHAIN_CONFIG: src/rust/rust-toolchain.toml
+  RUST_TARGET:
+    sh: "rustc -vV | sed -n 's/^host: //p'"
+  RUST_RELEASE_LIB: src/rust/target/{{.RUST_TARGET}}/release/libr_polars.a
   MAKEVARS_IN: src/Makevars{{if eq OS "windows"}}.win{{end}}.in
 
   R_FUNC_LOAD_REQUIRED_PKGS:
@@ -76,11 +79,12 @@ tasks:
       - "{{.RUST_TOOLCHAIN_CONFIG}}"
     generates:
       - R/000-wrappers.R
+      - "{{.RUST_RELEASE_LIB}}"
     deps:
       - format-rust
     cmds:
       - savvy-cli update .
-      - Rscript -e 'pkgbuild::compile_dll()'
+      - Rscript -e 'pkgbuild::compile_dll(debug = FALSE)'
 
   build-standalone-files:
     desc: Update "standalone" R files by `usethis::use_standalone()`
@@ -173,10 +177,10 @@ tasks:
   test-all:
     desc: Run all tests.
     cmds:
-      - task: test-source
+      - task: test-installed
 
-  test-source:
-    desc: Run all tests for source.
+  test-installed:
+    desc: Run all tests against the installed package.
     internal: true
     deps:
       - install-package
@@ -193,6 +197,41 @@ tasks:
       - Rscript -e
         'testthat::test_dir(
           "tests/testthat",
+          package = "polars",
+          load_package = "installed"
+        )'
+
+  test-file:
+    desc: Run one test file against the installed package.
+    requires:
+      vars:
+        - FILE
+    env:
+      TEST_FILE: "{{.FILE}}"
+    deps:
+      - install-package
+    cmds:
+      - Rscript -e
+        'testthat::test_file(
+          Sys.getenv("TEST_FILE"),
+          package = "polars",
+          load_package = "installed"
+        )'
+
+  test-filter:
+    desc: Run filtered tests against the installed package.
+    requires:
+      vars:
+        - FILTER
+    env:
+      TEST_FILTER: "{{.FILTER}}"
+    deps:
+      - install-package
+    cmds:
+      - Rscript -e
+        'testthat::test_dir(
+          "tests/testthat",
+          filter = Sys.getenv("TEST_FILTER"),
           package = "polars",
           load_package = "installed"
         )'
@@ -219,6 +258,9 @@ tasks:
 
   install-package:
     desc: Install the R package.
+    env:
+      LIBR_POLARS_BUILD: "false"
+      LIBR_POLARS_PATH: "{{.RUST_RELEASE_LIB}}"
     sources:
       - DESCRIPTION
       - "{{.R_SOURCE}}"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -23,10 +23,10 @@ vars:
   RUST_TOOLCHAIN_CONFIG: src/rust/rust-toolchain.toml
   RUST_TARGET:
     sh: >-
-      echo ${TARGET:-
+      echo "${TARGET:-
       {{- if eq OS "windows"}}$(Rscript tools/get-win-triple.R)
       {{- else}}$(rustc -vV | sed -n "s/^host: //p")
-      {{- end}}}
+      {{- end}}}"
   RUST_RELEASE_LIB: src/rust/target/{{.RUST_TARGET}}/release/libr_polars.a
   MAKEVARS_IN: src/Makevars{{if eq OS "windows"}}.win{{end}}.in
 
@@ -199,9 +199,7 @@ tasks:
       - "{{.RUST_TOOLCHAIN_CONFIG}}"
     cmds:
       - Rscript -e
-        'testthat::test_dir(
-          "tests/testthat",
-          package = "polars",
+        'testthat::test_local(
           load_package = "installed"
         )'
 
@@ -233,10 +231,8 @@ tasks:
       - install-package
     cmds:
       - Rscript -e
-        'testthat::test_dir(
-          "tests/testthat",
+        'testthat::test_local(
           filter = Sys.getenv("TEST_FILTER"),
-          package = "polars",
           load_package = "installed"
         )'
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -22,7 +22,7 @@ vars:
   RUST_SOURCE: src/rust/src/**/*.rs
   RUST_TOOLCHAIN_CONFIG: src/rust/rust-toolchain.toml
   RUST_TARGET:
-    sh: "rustc -vV | sed -n 's/^host: //p'"
+    sh: '{{if eq OS "windows"}}Rscript tools/get-win-triple.R{{else}}rustc -vV | sed -n "s/^host: //p"{{end}}'
   RUST_RELEASE_LIB: src/rust/target/{{.RUST_TARGET}}/release/libr_polars.a
   MAKEVARS_IN: src/Makevars{{if eq OS "windows"}}.win{{end}}.in
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -22,7 +22,11 @@ vars:
   RUST_SOURCE: src/rust/src/**/*.rs
   RUST_TOOLCHAIN_CONFIG: src/rust/rust-toolchain.toml
   RUST_TARGET:
-    sh: '{{if eq OS "windows"}}Rscript tools/get-win-triple.R{{else}}rustc -vV | sed -n "s/^host: //p"{{end}}'
+    sh: >-
+      echo ${TARGET:-
+      {{- if eq OS "windows"}}$(Rscript tools/get-win-triple.R)
+      {{- else}}$(rustc -vV | sed -n "s/^host: //p")
+      {{- end}}}
   RUST_RELEASE_LIB: src/rust/target/{{.RUST_TARGET}}/release/libr_polars.a
   MAKEVARS_IN: src/Makevars{{if eq OS "windows"}}.win{{end}}.in
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,7 +4,7 @@ env:
   NOT_CRAN: "true"
   LIBR_POLARS_BUILD: "true"
   LIBR_POLARS_FEATURES: "nightly"
-  DEBUG: "true"
+  LIBR_POLARS_PROFILE: "release"
   VIRTUAL_ENV: "{{.VENV_DIR}}"
 
 vars:
@@ -178,6 +178,8 @@ tasks:
   test-source:
     desc: Run all tests for source.
     internal: true
+    deps:
+      - install-package
     sources:
       - tests/**/*
       - "{{.R_SOURCE}}"
@@ -188,7 +190,12 @@ tasks:
       - "{{.RUST_SOURCE}}"
       - "{{.RUST_TOOLCHAIN_CONFIG}}"
     cmds:
-      - Rscript -e 'devtools::test()'
+      - Rscript -e
+        'testthat::test_dir(
+          "tests/testthat",
+          package = "polars",
+          load_package = "installed"
+        )'
 
   build-readme:
     desc: Build README.md


### PR DESCRIPTION
The size of the binaries generated by debug builds has ballooned to over 5GB, putting a strain on local storage, slowing down link speed, and increasing the likelihood of link failures.
Here, we will abandon debug builds and update the Taskfile to always use release builds.