### PR TITLE
docs: Qualify topic `factor` explicitly with a package name

### DIFF
--- a/R/series-to_r_vector.R
+++ b/R/series-to_r_vector.R
@@ -14,7 +14,7 @@
 #' - Float32, Float64: [double].
 #' - Decimal: [double].
 #' - String: [character].
-#' - Categorical: [factor].
+#' - Categorical: [factor][base::factor].
 #' - Date: [Date] or [data.table::IDate][data.table::IDateTime],
 #'   depending on the `date` argument.
 #' - Time: [hms::hms] or [data.table::ITime][data.table::IDateTime],

--- a/man/series__to_r_vector.Rd
+++ b/man/series__to_r_vector.Rd
@@ -131,7 +131,7 @@ depending on the \code{int64} argument.
 \item Float32, Float64: \link{double}.
 \item Decimal: \link{double}.
 \item String: \link{character}.
-\item Categorical: \link{factor}.
+\item Categorical: \link[base:factor]{factor}.
 \item Date: \link{Date} or \link[data.table:IDateTime]{data.table::IDate},
 depending on the \code{date} argument.
 \item Time: \link[hms:hms]{hms::hms} or \link[data.table:IDateTime]{data.table::ITime},


### PR DESCRIPTION
To avoid warnings like this:

```
✖ series-to_r_vector.R:7: @details Topic "factor" is available in multiple packages: bit64 and base..
ℹ Qualify topic explicitly with a package name when linking to it.
```