### PR TITLE
ci: pin rust-cache to latest commit to fix cdylib/rlib caching

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -115,7 +115,9 @@ jobs:
 
       - uses: rui314/setup-mold@v1
 
-      - uses: Swatinem/rust-cache@v2
+      # TODO: Switch back to @v2 once a new version is released that includes the fixes for
+      # cdylib/rlib crate caching (Swatinem/rust-cache#317, Swatinem/rust-cache#320).
+      - uses: Swatinem/rust-cache@baf1a810e98b6a3001d0d7234864ed75a17c42fb
         if: env.LIBR_POLARS_BUILD == 'true'
         with:
           workspaces: "src/rust -> target"

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -44,7 +44,9 @@ jobs:
 
       - uses: rui314/setup-mold@v1
 
-      - uses: Swatinem/rust-cache@v2
+      # TODO: Switch back to @v2 once a new version is released that includes the fixes for
+      # cdylib/rlib crate caching (Swatinem/rust-cache#317, Swatinem/rust-cache#320).
+      - uses: Swatinem/rust-cache@baf1a810e98b6a3001d0d7234864ed75a17c42fb
         with:
           workspaces: "src/rust -> target"
 

--- a/.github/workflows/lint-r.yml
+++ b/.github/workflows/lint-r.yml
@@ -88,7 +88,9 @@ jobs:
 
       - uses: rui314/setup-mold@v1
 
-      - uses: Swatinem/rust-cache@v2
+      # TODO: Switch back to @v2 once a new version is released that includes the fixes for
+      # cdylib/rlib crate caching (Swatinem/rust-cache#317, Swatinem/rust-cache#320).
+      - uses: Swatinem/rust-cache@baf1a810e98b6a3001d0d7234864ed75a17c42fb
         if: env.LIBR_POLARS_BUILD == 'true'
         with:
           workspaces: "src/rust -> target"

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -43,7 +43,9 @@ jobs:
       - uses: rui314/setup-mold@v1
 
       - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
+        # TODO: Switch back to @v2 once a new version is released that includes the fixes for
+        # cdylib/rlib crate caching (Swatinem/rust-cache#317, Swatinem/rust-cache#320).
+        uses: Swatinem/rust-cache@baf1a810e98b6a3001d0d7234864ed75a17c42fb
         with:
           workspaces: "src/rust -> target"
 

--- a/.github/workflows/release-lib.yml
+++ b/.github/workflows/release-lib.yml
@@ -61,7 +61,9 @@ jobs:
 
       - uses: rui314/setup-mold@v1
 
-      - uses: Swatinem/rust-cache@v2
+      # TODO: Switch back to @v2 once a new version is released that includes the fixes for
+      # cdylib/rlib crate caching (Swatinem/rust-cache#317, Swatinem/rust-cache#320).
+      - uses: Swatinem/rust-cache@baf1a810e98b6a3001d0d7234864ed75a17c42fb
         with:
           workspaces: "src/rust -> target"
           shared-key: ${{ matrix.target }}-dist-release

--- a/.github/workflows/test-r.yml
+++ b/.github/workflows/test-r.yml
@@ -97,7 +97,9 @@ jobs:
 
       - uses: rui314/setup-mold@v1
 
-      - uses: Swatinem/rust-cache@v2
+      # TODO: Switch back to @v2 once a new version is released that includes the fixes for
+      # cdylib/rlib crate caching (Swatinem/rust-cache#317, Swatinem/rust-cache#320).
+      - uses: Swatinem/rust-cache@baf1a810e98b6a3001d0d7234864ed75a17c42fb
         if: env.LIBR_POLARS_BUILD == 'true'
         with:
           workspaces: "src/rust -> target"
@@ -196,7 +198,9 @@ jobs:
 
       - uses: rui314/setup-mold@v1
 
-      - uses: Swatinem/rust-cache@v2
+      # TODO: Switch back to @v2 once a new version is released that includes the fixes for
+      # cdylib/rlib crate caching (Swatinem/rust-cache#317, Swatinem/rust-cache#320).
+      - uses: Swatinem/rust-cache@baf1a810e98b6a3001d0d7234864ed75a17c42fb
         with:
           workspaces: "src/rust -> target"
           # On Windows, DEBUG build seems buggy <https://github.com/eitsupi/neo-r-polars/issues/218>


### PR DESCRIPTION
## Summary

- Pin `Swatinem/rust-cache` from `@v2` to the latest commit (`baf1a810`) to fix cache misses for `jsonpath_lib_polars_vendor`
- `rust-cache` was not restoring the compiled artifacts for crates whose library target kind is `cdylib` or `rlib` (not `lib`), causing unnecessary recompilation on every CI run
- Fixes were merged upstream in Swatinem/rust-cache#317 and Swatinem/rust-cache#320, but no new release has been cut yet
- Added TODO comments to switch back to `@v2` once the new release is available
