### PR TITLE
build(taskfile): fix redundant Rust recompilation in build/test tasks

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -155,7 +155,7 @@ tasks:
     generates:
       - man/*.Rd
     status:
-      - Rscript -e 'if (desc::desc_get("RoxygenNote") < packageVersion("roxygen2")) quit(status = 1)'
+      - Rscript -e 'if (desc::desc_get("Config/roxygen2/version") < packageVersion("roxygen2")) quit(status = 1)'
     deps:
       - build-rust
       - build-standalone-files

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -269,6 +269,7 @@ tasks:
     env:
       LIBR_POLARS_BUILD: "false"
       LIBR_POLARS_PATH: "{{.RUST_RELEASE_LIB}}"
+      TARGET: "{{.RUST_TARGET}}"
     sources:
       - DESCRIPTION
       - "{{.R_SOURCE}}"


### PR DESCRIPTION
## Summary

- Fix broken `status` check in `build-documents` task: `RoxygenNote` field no longer exists in DESCRIPTION since roxygen2 8.0.0; the correct field is `Config/roxygen2/version`
- Pass `TARGET` env var to `install-package` task so Makevars uses the correct target-triple path during `R CMD INSTALL`

## Background

Running `task test-all` or `task install-package` repeatedly was triggering unnecessary Rust recompilation. Two issues were found:

1. The `status` check in `build-documents` referenced `desc::desc_get("RoxygenNote")`, which returns `NA` since roxygen2 8.0.0 renamed this field to `Config/roxygen2/version`. The `NA < packageVersion(...)` comparison threw an error, causing the status check to always return non-zero, and `build-documents` (and its dep `build-rust`) to always rerun.

2. Without `TARGET` set in `install-package`, the `configure` script generates Makevars with an empty `TARGET`, placing the library at `target//release/` instead of the target-triple path expected by `build-rust`'s `generates` fingerprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)