### PR TITLE
ci: update rust-cache for Windows path validation fix

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -117,7 +117,7 @@ jobs:
 
       # TODO: Switch back to @v2 once a new version is released that includes the fixes for
       # cdylib/rlib crate caching (Swatinem/rust-cache#317, Swatinem/rust-cache#320).
-      - uses: Swatinem/rust-cache@baf1a810e98b6a3001d0d7234864ed75a17c42fb
+      - uses: Swatinem/rust-cache@b57030f2122925cb90e22399eed75c2c3be0a46f
         if: env.LIBR_POLARS_BUILD == 'true'
         with:
           workspaces: "src/rust -> target"

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -46,7 +46,7 @@ jobs:
 
       # TODO: Switch back to @v2 once a new version is released that includes the fixes for
       # cdylib/rlib crate caching (Swatinem/rust-cache#317, Swatinem/rust-cache#320).
-      - uses: Swatinem/rust-cache@baf1a810e98b6a3001d0d7234864ed75a17c42fb
+      - uses: Swatinem/rust-cache@b57030f2122925cb90e22399eed75c2c3be0a46f
         with:
           workspaces: "src/rust -> target"
 

--- a/.github/workflows/lint-r.yml
+++ b/.github/workflows/lint-r.yml
@@ -90,7 +90,7 @@ jobs:
 
       # TODO: Switch back to @v2 once a new version is released that includes the fixes for
       # cdylib/rlib crate caching (Swatinem/rust-cache#317, Swatinem/rust-cache#320).
-      - uses: Swatinem/rust-cache@baf1a810e98b6a3001d0d7234864ed75a17c42fb
+      - uses: Swatinem/rust-cache@b57030f2122925cb90e22399eed75c2c3be0a46f
         if: env.LIBR_POLARS_BUILD == 'true'
         with:
           workspaces: "src/rust -> target"

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Cache Rust
         # TODO: Switch back to @v2 once a new version is released that includes the fixes for
         # cdylib/rlib crate caching (Swatinem/rust-cache#317, Swatinem/rust-cache#320).
-        uses: Swatinem/rust-cache@baf1a810e98b6a3001d0d7234864ed75a17c42fb
+        uses: Swatinem/rust-cache@b57030f2122925cb90e22399eed75c2c3be0a46f
         with:
           workspaces: "src/rust -> target"
 

--- a/.github/workflows/release-lib.yml
+++ b/.github/workflows/release-lib.yml
@@ -63,7 +63,7 @@ jobs:
 
       # TODO: Switch back to @v2 once a new version is released that includes the fixes for
       # cdylib/rlib crate caching (Swatinem/rust-cache#317, Swatinem/rust-cache#320).
-      - uses: Swatinem/rust-cache@baf1a810e98b6a3001d0d7234864ed75a17c42fb
+      - uses: Swatinem/rust-cache@b57030f2122925cb90e22399eed75c2c3be0a46f
         with:
           workspaces: "src/rust -> target"
           shared-key: ${{ matrix.target }}-dist-release

--- a/.github/workflows/test-r.yml
+++ b/.github/workflows/test-r.yml
@@ -99,7 +99,7 @@ jobs:
 
       # TODO: Switch back to @v2 once a new version is released that includes the fixes for
       # cdylib/rlib crate caching (Swatinem/rust-cache#317, Swatinem/rust-cache#320).
-      - uses: Swatinem/rust-cache@baf1a810e98b6a3001d0d7234864ed75a17c42fb
+      - uses: Swatinem/rust-cache@b57030f2122925cb90e22399eed75c2c3be0a46f
         if: env.LIBR_POLARS_BUILD == 'true'
         with:
           workspaces: "src/rust -> target"
@@ -200,7 +200,7 @@ jobs:
 
       # TODO: Switch back to @v2 once a new version is released that includes the fixes for
       # cdylib/rlib crate caching (Swatinem/rust-cache#317, Swatinem/rust-cache#320).
-      - uses: Swatinem/rust-cache@baf1a810e98b6a3001d0d7234864ed75a17c42fb
+      - uses: Swatinem/rust-cache@b57030f2122925cb90e22399eed75c2c3be0a46f
         with:
           workspaces: "src/rust -> target"
           # On Windows, DEBUG build seems buggy <https://github.com/eitsupi/neo-r-polars/issues/218>


### PR DESCRIPTION
## Summary

- update all `Swatinem/rust-cache` references to the commit from Swatinem/rust-cache#355
- retain the previously pinned cdylib/rlib caching fixes
- validate the Windows cache path fix in r-polars, which uses Cargo paths on `C:` and a workspace target on `D:`

## Context

The previous rust-cache commit fails during the Windows post step with:

```text
Error: Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```

Swatinem/rust-cache#355 reproduces the failure and fixes the Rollup bundle to share the ESM-compatible `@actions/glob` dependency with the GitHub cache provider. Its save/restore integration tests pass on Linux, macOS, and Windows.

## Test plan

- [x] workflow validation passes
- [x] Windows rust-cache post step saves without a path validation error
- [ ] subsequent Windows run restores the saved cache