### PR TITLE
ci: update rust-cache for target-triple cleanup fix

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -117,7 +117,7 @@ jobs:
 
       # TODO: Switch back to @v2 once a new version is released that includes the fixes for
       # cdylib/rlib crate caching (Swatinem/rust-cache#317, Swatinem/rust-cache#320).
-      - uses: Swatinem/rust-cache@b57030f2122925cb90e22399eed75c2c3be0a46f
+      - uses: Swatinem/rust-cache@0aa9ab6c7bd3ac99d3eeed430a1f3e3d0fd5ba59
         if: env.LIBR_POLARS_BUILD == 'true'
         with:
           workspaces: "src/rust -> target"

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -46,7 +46,7 @@ jobs:
 
       # TODO: Switch back to @v2 once a new version is released that includes the fixes for
       # cdylib/rlib crate caching (Swatinem/rust-cache#317, Swatinem/rust-cache#320).
-      - uses: Swatinem/rust-cache@b57030f2122925cb90e22399eed75c2c3be0a46f
+      - uses: Swatinem/rust-cache@0aa9ab6c7bd3ac99d3eeed430a1f3e3d0fd5ba59
         with:
           workspaces: "src/rust -> target"
 

--- a/.github/workflows/lint-r.yml
+++ b/.github/workflows/lint-r.yml
@@ -90,7 +90,7 @@ jobs:
 
       # TODO: Switch back to @v2 once a new version is released that includes the fixes for
       # cdylib/rlib crate caching (Swatinem/rust-cache#317, Swatinem/rust-cache#320).
-      - uses: Swatinem/rust-cache@b57030f2122925cb90e22399eed75c2c3be0a46f
+      - uses: Swatinem/rust-cache@0aa9ab6c7bd3ac99d3eeed430a1f3e3d0fd5ba59
         if: env.LIBR_POLARS_BUILD == 'true'
         with:
           workspaces: "src/rust -> target"

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Cache Rust
         # TODO: Switch back to @v2 once a new version is released that includes the fixes for
         # cdylib/rlib crate caching (Swatinem/rust-cache#317, Swatinem/rust-cache#320).
-        uses: Swatinem/rust-cache@b57030f2122925cb90e22399eed75c2c3be0a46f
+        uses: Swatinem/rust-cache@0aa9ab6c7bd3ac99d3eeed430a1f3e3d0fd5ba59
         with:
           workspaces: "src/rust -> target"
 

--- a/.github/workflows/release-lib.yml
+++ b/.github/workflows/release-lib.yml
@@ -63,7 +63,7 @@ jobs:
 
       # TODO: Switch back to @v2 once a new version is released that includes the fixes for
       # cdylib/rlib crate caching (Swatinem/rust-cache#317, Swatinem/rust-cache#320).
-      - uses: Swatinem/rust-cache@b57030f2122925cb90e22399eed75c2c3be0a46f
+      - uses: Swatinem/rust-cache@0aa9ab6c7bd3ac99d3eeed430a1f3e3d0fd5ba59
         with:
           workspaces: "src/rust -> target"
           shared-key: ${{ matrix.target }}-dist-release

--- a/.github/workflows/test-r.yml
+++ b/.github/workflows/test-r.yml
@@ -99,7 +99,7 @@ jobs:
 
       # TODO: Switch back to @v2 once a new version is released that includes the fixes for
       # cdylib/rlib crate caching (Swatinem/rust-cache#317, Swatinem/rust-cache#320).
-      - uses: Swatinem/rust-cache@b57030f2122925cb90e22399eed75c2c3be0a46f
+      - uses: Swatinem/rust-cache@0aa9ab6c7bd3ac99d3eeed430a1f3e3d0fd5ba59
         if: env.LIBR_POLARS_BUILD == 'true'
         with:
           workspaces: "src/rust -> target"
@@ -200,7 +200,7 @@ jobs:
 
       # TODO: Switch back to @v2 once a new version is released that includes the fixes for
       # cdylib/rlib crate caching (Swatinem/rust-cache#317, Swatinem/rust-cache#320).
-      - uses: Swatinem/rust-cache@b57030f2122925cb90e22399eed75c2c3be0a46f
+      - uses: Swatinem/rust-cache@0aa9ab6c7bd3ac99d3eeed430a1f3e3d0fd5ba59
         with:
           workspaces: "src/rust -> target"
           # On Windows, DEBUG build seems buggy <https://github.com/eitsupi/neo-r-polars/issues/218>


### PR DESCRIPTION
## Summary

- pin Swatinem/rust-cache to the latest commit from Swatinem/rust-cache#356
- preserve Cargo artifacts under target-specific profile directories
- update every rust-cache use consistently

## Context

The previous cleanup logic treated target/<triple> as a Cargo profile directory and removed nested debug or release artifacts before saving the cache. Swatinem/rust-cache#356 fixes profile detection and adds cross-platform save/restore coverage.

## Validation

- Swatinem/rust-cache#356 CI passes on Linux, macOS, and Windows
- git diff --check