### PR TITLE
ci(release-lib): use ubuntu-24.04-arm runner for aarch64-unknown-linux-musl

### DIFF
--- a/.github/workflows/release-lib.yml
+++ b/.github/workflows/release-lib.yml
@@ -31,7 +31,7 @@ jobs:
             target: x86_64-unknown-linux-musl
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
-          - os: ubuntu-22.04-arm
+          - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
           - os: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu


### PR DESCRIPTION
The 22.04 runner seems unable to complete the build, so I'll try the 24.04 runner. If that doesn't work, we'll have no choice but to exclude the arm64 musl build from the release.
https://github.com/pola-rs/r-polars/actions/runs/30681205454/job/91333266191