### PR TITLE
fix: avoid GC inside `<DataFrame>$get_columns()`

### DIFF
--- a/src/rust/src/dataframe/general.rs
+++ b/src/rust/src/dataframe/general.rs
@@ -43,11 +43,12 @@ impl PlRDataFrame {
             .collect();
         let mut list = OwnedListSexp::new(cols.len(), true)?;
         for (i, col) in cols.iter().enumerate() {
-            let _ = list.set_name_and_value(
-                i,
-                col.name(),
-                Sexp::try_from(PlRSeries::from(col.clone()))?,
-            );
+            // Set names first to avoid https://github.com/pola-rs/r-polars/issues/1411
+            list.set_name(i, col.name())?;
+            let series = Sexp::try_from(PlRSeries::from(col.clone()))?;
+            unsafe {
+                list.set_value_unchecked(i, series.0);
+            }
         }
         Ok(list.into())
     }


### PR DESCRIPTION
Fix #1411

I verified its effectiveness by running the following code multiple times in the latest release and this branch.

```r
library(polars)
df <- pl$DataFrame(
  a = 1:3,
  b = 4:6,
  c = 7:9
)

gctorture(TRUE)
cols <- df$get_columns()
gctorture(FALSE)

cols[[1]]$to_r_vector()
cols[[2]]$to_r_vector()
cols[[3]]$to_r_vector()
#> [1] 1 2 3
#> [1] 4 5 6
#> [1] 7 8 9
```