### PR TITLE
chore: pre built binaries only support R 4.5.0 or later

### DIFF
--- a/.github/workflows/release-lib.yml
+++ b/.github/workflows/release-lib.yml
@@ -161,14 +161,14 @@ jobs:
           - windows-latest
           - ubuntu-latest
         r:
-          - "4.3"
+          - "4.5"
           - release
           - devel
         exclude:
           - os: macos-latest
             r: devel
           - os: macos-latest
-            r: "4.3"
+            r: "4.5"
         include:
           - os: macos-15-intel
             r: release

--- a/.github/workflows/test-r.yml
+++ b/.github/workflows/test-r.yml
@@ -255,10 +255,10 @@ jobs:
           - ubuntu-latest
         r:
           - release
-          - "4.3"
+          - "4.5"
         exclude:
           - os: macos-latest
-            r: "4.3"
+            r: "4.5"
         include:
           - os: windows-11-arm
             r: release

--- a/tools/prep-lib.R
+++ b/tools/prep-lib.R
@@ -81,6 +81,9 @@ current_os <- which_os()
 current_arch <- which_arch()
 vendor_sys_abi <- which_vendor_sys_abi(current_os, current_arch)
 
+current_r <- sprintf("%s.%s", R.version$major, R.version$minor) |>
+  numeric_version()
+
 target_triple <- if (nzchar(Sys.getenv("TARGET"))) {
   message(sprintf("TARGET is overridden to '%s'", Sys.getenv("TARGET")))
   Sys.getenv("TARGET")
@@ -112,6 +115,10 @@ lib_sum <- lib_data |>
 
 if (!length(lib_sum)) {
   stop("No pre-built binary found at <", target_url, ">", call. = FALSE)
+}
+
+if (current_r < "4.5.0") {
+  stop("Pre-built binaries are only available for R >= 4.5.0.", call. = FALSE)
 }
 
 message("Found pre-built binary at <", target_url, ">.\nDownloading...")


### PR DESCRIPTION
See yutannihilation/savvy#461

Binaries built with the latest version of R (currently 4.6) are no longer compatible with version 4.3.0 to 4.4.x.