### PR TITLE
ci(test-r): ensure use R 4.5.0 or later for R CMD check, and clean up

### DIFF
--- a/.github/workflows/test-r.yml
+++ b/.github/workflows/test-r.yml
@@ -56,7 +56,7 @@ jobs:
           - ubuntu-latest
         r:
           - devel
-          - "4.3"
+          - "4.5"
     steps:
       - uses: actions/checkout@v7
 
@@ -76,9 +76,6 @@ jobs:
           http-user-agent: ${{ runner.os == 'Windows' && 'release' || '' }}
           use-public-rspm: true
           Ncpus: "2"
-          # To install the edge version of nanoarrow
-          # TODO: remove this after nanoarrow 0.8.0 release
-          extra-repositories: https://apache.r-universe.dev/nanoarrow
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
@@ -176,9 +173,6 @@ jobs:
           http-user-agent: ${{ runner.os == 'Windows' && 'release' || '' }}
           use-public-rspm: true
           Ncpus: "2"
-          # To install the edge version of nanoarrow
-          # TODO: remove this after nanoarrow 0.8.0 release
-          extra-repositories: https://apache.r-universe.dev/nanoarrow
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:


### PR DESCRIPTION
Follow up for #1847, the R CMD check job should not use R 4.3.

And remove the stale configs.