### PR TITLE
ci(release-lib): fix arm64 musl linux binary builds

### DIFF
--- a/.github/scripts/zig-aarch64-musl-cc.sh
+++ b/.github/scripts/zig-aarch64-musl-cc.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# zig-cc wrapper that bridges the cc crate's Rust-style target triple to Zig.
+#
+# The cc crate (used by ring, jemalloc-sys, etc.) passes the target triple as
+# `--target=aarch64-unknown-linux-musl`. Zig rejects the `-unknown-` vendor
+# component and requires its own format `aarch64-linux-musl`. This wrapper
+# rewrites the triple before exec'ing `zig cc`.
+set -eu
+
+newargs=""
+for arg in "$@"; do
+  # Skip a stray leading `cc` subcommand; cc-rs invokes the wrapper with the
+  # flags only, but some callers pass `cc` explicitly.
+  case "$arg" in
+    cc)
+      continue
+      ;;
+  esac
+  case "$arg" in
+    --target=aarch64-unknown-linux-musl)
+      arg="--target=aarch64-linux-musl"
+      ;;
+  esac
+  # Quote each arg so paths with spaces survive the final eval.
+  newargs="$newargs '$(printf '%s' "$arg" | sed "s/'/'\\\\''/g")'"
+done
+
+eval "exec zig cc $newargs"

--- a/.github/scripts/zig-aarch64-musl-cc.sh
+++ b/.github/scripts/zig-aarch64-musl-cc.sh
@@ -9,20 +9,20 @@ set -eu
 
 newargs=""
 for arg in "$@"; do
-  # Skip a stray leading `cc` subcommand; cc-rs invokes the wrapper with the
-  # flags only, but some callers pass `cc` explicitly.
-  case "$arg" in
-    cc)
-      continue
-      ;;
-  esac
-  case "$arg" in
-    --target=aarch64-unknown-linux-musl)
-      arg="--target=aarch64-linux-musl"
-      ;;
-  esac
-  # Quote each arg so paths with spaces survive the final eval.
-  newargs="$newargs '$(printf '%s' "$arg" | sed "s/'/'\\\\''/g")'"
+	# Skip a stray leading `cc` subcommand; cc-rs invokes the wrapper with the
+	# flags only, but some callers pass `cc` explicitly.
+	case "$arg" in
+	cc)
+		continue
+		;;
+	esac
+	case "$arg" in
+	--target=aarch64-unknown-linux-musl)
+		arg="--target=aarch64-linux-musl"
+		;;
+	esac
+	# Quote each arg so paths with spaces survive the final eval.
+	newargs="$newargs '$(printf '%s' "$arg" | sed "s/'/'\\\\''/g")'"
 done
 
 eval "exec zig cc $newargs"

--- a/.github/workflows/release-lib.yml
+++ b/.github/workflows/release-lib.yml
@@ -32,8 +32,6 @@ jobs:
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
           - os: ubuntu-22.04-arm
-            target: aarch64-unknown-linux-musl
-          - os: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
           - os: macos-latest
             target: x86_64-apple-darwin
@@ -71,13 +69,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y musl-tools
-
-      - name: pref for aarch64-unknown-linux-musl
-        if: matrix.target == 'aarch64-unknown-linux-musl'
-        # Ref <https://github.com/rust-lang/stacker/issues/80>
-        run: |
-          echo 'CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc' >>"$GITHUB_ENV"
-          echo 'CC=aarch64-linux-gnu-gcc' >>"$GITHUB_ENV"
 
       - name: limit rust build jobs on aarch64 linux
         if: runner.os == 'Linux' && runner.arch == 'ARM64'
@@ -148,6 +139,75 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: libs-${{ matrix.target }}
+          path: ${{ env.ARTIFACT_NAME }}
+
+  # Build the aarch64 musl static library natively inside an Alpine (musl)
+  # ARM64 container on GitHub's native ARM64 runner. This is required because
+  # cross-compiling the musl target with a glibc C toolchain (the previous
+  # `CC=aarch64-linux-gnu-gcc` workaround) leaked glibc fortification symbols
+  # like `__fprintf_chk` into the library, which are missing on musl and broke
+  # loading on Alpine (#1760). A native musl toolchain cannot leak glibc
+  # symbols and avoids the jemalloc C-atomics detection failure that `musl-gcc`
+  # on the Ubuntu host runner triggers.
+  build-aarch64-musl:
+    runs-on: ubuntu-24.04-arm
+    container:
+      image: alpine:3.22
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: install system deps
+        run: |
+          # R and R-dev live in Alpine's community repository
+          apk add --no-cache --repository "https://dl-cdn.alpinelinux.org/alpine/v3.22/community" \
+            bash curl gcc jq make musl-dev pkg-config R R-dev tar
+
+      - name: install Rust toolchain
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+          echo "$HOME/.cargo/bin" >>"$GITHUB_PATH"
+          TOOLCHAIN="$(sed -n 's/^channel = "\(.*\)"/\1/p' src/rust/rust-toolchain.toml)"
+          rustup toolchain install "${TOOLCHAIN}" --profile minimal
+          rustup target add aarch64-unknown-linux-musl --toolchain "${TOOLCHAIN}"
+          rustup default "${TOOLCHAIN}"
+
+      - name: install R pkgbuild
+        run: |
+          Rscript -e 'options(repos = c(CRAN = "https://cloud.r-project.org")); install.packages("pkgbuild")'
+
+      # Serialize rustc: the ARM runner runs out of memory while polars-plan and
+      # polars-expr compile at the same time.
+      - name: limit rust build jobs on aarch64 linux
+        run: |
+          echo 'CARGO_BUILD_JOBS=1' >>"$GITHUB_ENV"
+          echo 'CARGO_PROFILE_DIST_RELEASE_LTO=thin' >>"$GITHUB_ENV"
+
+      - name: build lib
+        env:
+          NOT_CRAN: "true"
+          TARGET: aarch64-unknown-linux-musl
+          LIBR_POLARS_BUILD: "true"
+          LIBR_POLARS_FEATURES: nightly
+          LIBR_POLARS_PROFILE: dist-release
+        run: |
+          # savvy needs R_INCLUDE_DIR at build time
+          export R_INCLUDE_DIR="$(Rscript -e 'cat(normalizePath(R.home("include")))')"
+          LIB_VERSION="$(cargo metadata --format-version=1 --no-deps --manifest-path src/rust/Cargo.toml | jq --raw-output '.packages[0].version')"
+          echo "LIB_VERSION=${LIB_VERSION}" >>"$GITHUB_ENV"
+          Rscript -e 'pkgbuild::compile_dll(debug = FALSE)'
+
+          ARTIFACT_NAME="${LIB_NAME}-${LIB_VERSION}-${TARGET}.tar.gz"
+          tar -czf "${ARTIFACT_NAME}" -C "src/rust/target/${TARGET}/${LIBR_POLARS_PROFILE}" "${LIB_NAME}.a"
+          echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >>"$GITHUB_ENV"
+
+      - name: upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: libs-aarch64-unknown-linux-musl
           path: ${{ env.ARTIFACT_NAME }}
 
   test:
@@ -241,6 +301,7 @@ jobs:
   release:
     needs:
       - build
+      - build-aarch64-musl
       - test
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/release-lib.yml
+++ b/.github/workflows/release-lib.yml
@@ -91,15 +91,20 @@ jobs:
 
       - name: pref for aarch64-unknown-linux-musl
         if: matrix.target == 'aarch64-unknown-linux-musl'
-        # Use Zig's cross-compiler (zig cc) as the C compiler and linker for
-        # the musl target. Unlike the previous CC=aarch64-linux-gnu-gcc
-        # workaround, zig cc targets musl directly, so jemalloc's C is compiled
+        # Use Zig's cross-compiler as the C compiler and linker for the musl
+        # target. Unlike the previous CC=aarch64-linux-gnu-gcc workaround, zig
+        # cc targets musl directly, so C (jemalloc, ring, ...) is compiled
         # against musl headers and never leaks glibc fortification symbols like
         # __fprintf_chk (fixes #1760). It also provides working atomics, unlike
         # the Ubuntu musl-gcc wrapper.
+        #
+        # We point at the wrapper script rather than `zig cc` directly because
+        # Zig rejects the Rust-style target triple (`aarch64-unknown-linux-musl`)
+        # that the cc crate passes; the wrapper rewrites it to Zig's own format
+        # (`aarch64-linux-musl`) before invoking `zig cc`.
         run: |
-          echo 'CC_aarch64_unknown_linux_musl=zig cc' >>"$GITHUB_ENV"
-          echo 'CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=zig cc' >>"$GITHUB_ENV"
+          echo 'CC_aarch64_unknown_linux_musl=$GITHUB_WORKSPACE/.github/scripts/zig-aarch64-musl-cc.sh' >>"$GITHUB_ENV"
+          echo 'CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=$GITHUB_WORKSPACE/.github/scripts/zig-aarch64-musl-cc.sh' >>"$GITHUB_ENV"
 
       - name: limit rust build jobs on aarch64 linux
         if: runner.os == 'Linux' && runner.arch == 'ARM64'

--- a/.github/workflows/release-lib.yml
+++ b/.github/workflows/release-lib.yml
@@ -84,7 +84,9 @@ jobs:
             -o /tmp/zig.tar.xz
           echo 'ea4b09bfb22ec6f6c6ceac57ab63efb6b46e17ab08d21f69f3a48b38e1534f17  /tmp/zig.tar.xz' | sha256sum -c -
           tar -xJf /tmp/zig.tar.xz -C "$HOME/.zig" --strip-components=1
+          # GITHUB_PATH only applies to later steps, so export for this step
           echo "$HOME/.zig" >>"$GITHUB_PATH"
+          export PATH="$HOME/.zig:$PATH"
           zig version
 
       - name: pref for aarch64-unknown-linux-musl

--- a/.github/workflows/release-lib.yml
+++ b/.github/workflows/release-lib.yml
@@ -76,7 +76,7 @@ jobs:
         if: matrix.target == 'aarch64-unknown-linux-musl'
         uses: mlugg/setup-zig@v1
         with:
-          version: 0.14.0
+          version: 0.16.0
 
       - name: pref for aarch64-unknown-linux-musl
         if: matrix.target == 'aarch64-unknown-linux-musl'

--- a/.github/workflows/release-lib.yml
+++ b/.github/workflows/release-lib.yml
@@ -103,8 +103,8 @@ jobs:
         # that the cc crate passes; the wrapper rewrites it to Zig's own format
         # (`aarch64-linux-musl`) before invoking `zig cc`.
         run: |
-          echo 'CC_aarch64_unknown_linux_musl=$GITHUB_WORKSPACE/.github/scripts/zig-aarch64-musl-cc.sh' >>"$GITHUB_ENV"
-          echo 'CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=$GITHUB_WORKSPACE/.github/scripts/zig-aarch64-musl-cc.sh' >>"$GITHUB_ENV"
+          echo "CC_aarch64_unknown_linux_musl=$GITHUB_WORKSPACE/.github/scripts/zig-aarch64-musl-cc.sh" >>"$GITHUB_ENV"
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=$GITHUB_WORKSPACE/.github/scripts/zig-aarch64-musl-cc.sh" >>"$GITHUB_ENV"
 
       - name: limit rust build jobs on aarch64 linux
         if: runner.os == 'Linux' && runner.arch == 'ARM64'

--- a/.github/workflows/release-lib.yml
+++ b/.github/workflows/release-lib.yml
@@ -32,6 +32,8 @@ jobs:
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
           - os: ubuntu-22.04-arm
+            target: aarch64-unknown-linux-musl
+          - os: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
           - os: macos-latest
             target: x86_64-apple-darwin
@@ -69,6 +71,24 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y musl-tools
+
+      - name: setup Zig (C toolchain for musl cross-compilation)
+        if: matrix.target == 'aarch64-unknown-linux-musl'
+        uses: mlugg/setup-zig@v1
+        with:
+          version: 0.14.0
+
+      - name: pref for aarch64-unknown-linux-musl
+        if: matrix.target == 'aarch64-unknown-linux-musl'
+        # Use Zig's cross-compiler (zig cc) as the C compiler and linker for
+        # the musl target. Unlike the previous CC=aarch64-linux-gnu-gcc
+        # workaround, zig cc targets musl directly, so jemalloc's C is compiled
+        # against musl headers and never leaks glibc fortification symbols like
+        # __fprintf_chk (fixes #1760). It also provides working atomics, unlike
+        # the Ubuntu musl-gcc wrapper.
+        run: |
+          echo 'CC_aarch64_unknown_linux_musl=zig cc' >>"$GITHUB_ENV"
+          echo 'CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=zig cc' >>"$GITHUB_ENV"
 
       - name: limit rust build jobs on aarch64 linux
         if: runner.os == 'Linux' && runner.arch == 'ARM64'
@@ -139,75 +159,6 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: libs-${{ matrix.target }}
-          path: ${{ env.ARTIFACT_NAME }}
-
-  # Build the aarch64 musl static library natively inside an Alpine (musl)
-  # ARM64 container on GitHub's native ARM64 runner. This is required because
-  # cross-compiling the musl target with a glibc C toolchain (the previous
-  # `CC=aarch64-linux-gnu-gcc` workaround) leaked glibc fortification symbols
-  # like `__fprintf_chk` into the library, which are missing on musl and broke
-  # loading on Alpine (#1760). A native musl toolchain cannot leak glibc
-  # symbols and avoids the jemalloc C-atomics detection failure that `musl-gcc`
-  # on the Ubuntu host runner triggers.
-  build-aarch64-musl:
-    runs-on: ubuntu-24.04-arm
-    container:
-      image: alpine:3.24
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: install system deps
-        run: |
-          # R and R-dev live in Alpine's community repository
-          apk add --no-cache --repository "https://dl-cdn.alpinelinux.org/alpine/v3.24/community" \
-            bash curl gcc jq make musl-dev pkg-config R R-dev tar
-
-      - name: install Rust toolchain
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
-          echo "$HOME/.cargo/bin" >>"$GITHUB_PATH"
-          TOOLCHAIN="$(sed -n 's/^channel = "\(.*\)"/\1/p' src/rust/rust-toolchain.toml)"
-          rustup toolchain install "${TOOLCHAIN}" --profile minimal
-          rustup target add aarch64-unknown-linux-musl --toolchain "${TOOLCHAIN}"
-          rustup default "${TOOLCHAIN}"
-
-      - name: install R pkgbuild
-        run: |
-          Rscript -e 'options(repos = c(CRAN = "https://cloud.r-project.org")); install.packages("pkgbuild")'
-
-      # Serialize rustc: the ARM runner runs out of memory while polars-plan and
-      # polars-expr compile at the same time.
-      - name: limit rust build jobs on aarch64 linux
-        run: |
-          echo 'CARGO_BUILD_JOBS=1' >>"$GITHUB_ENV"
-          echo 'CARGO_PROFILE_DIST_RELEASE_LTO=thin' >>"$GITHUB_ENV"
-
-      - name: build lib
-        env:
-          NOT_CRAN: "true"
-          TARGET: aarch64-unknown-linux-musl
-          LIBR_POLARS_BUILD: "true"
-          LIBR_POLARS_FEATURES: nightly
-          LIBR_POLARS_PROFILE: dist-release
-        run: |
-          # savvy needs R_INCLUDE_DIR at build time
-          export R_INCLUDE_DIR="$(Rscript -e 'cat(normalizePath(R.home("include")))')"
-          LIB_VERSION="$(cargo metadata --format-version=1 --no-deps --manifest-path src/rust/Cargo.toml | jq --raw-output '.packages[0].version')"
-          echo "LIB_VERSION=${LIB_VERSION}" >>"$GITHUB_ENV"
-          Rscript -e 'pkgbuild::compile_dll(debug = FALSE)'
-
-          ARTIFACT_NAME="${LIB_NAME}-${LIB_VERSION}-${TARGET}.tar.gz"
-          tar -czf "${ARTIFACT_NAME}" -C "src/rust/target/${TARGET}/${LIBR_POLARS_PROFILE}" "${LIB_NAME}.a"
-          echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >>"$GITHUB_ENV"
-
-      - name: upload artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: libs-aarch64-unknown-linux-musl
           path: ${{ env.ARTIFACT_NAME }}
 
   test:
@@ -301,7 +252,6 @@ jobs:
   release:
     needs:
       - build
-      - build-aarch64-musl
       - test
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/release-lib.yml
+++ b/.github/workflows/release-lib.yml
@@ -152,7 +152,7 @@ jobs:
   build-aarch64-musl:
     runs-on: ubuntu-24.04-arm
     container:
-      image: alpine:3.22
+      image: alpine:3.24
     permissions:
       contents: read
       packages: write
@@ -163,7 +163,7 @@ jobs:
       - name: install system deps
         run: |
           # R and R-dev live in Alpine's community repository
-          apk add --no-cache --repository "https://dl-cdn.alpinelinux.org/alpine/v3.22/community" \
+          apk add --no-cache --repository "https://dl-cdn.alpinelinux.org/alpine/v3.24/community" \
             bash curl gcc jq make musl-dev pkg-config R R-dev tar
 
       - name: install Rust toolchain

--- a/.github/workflows/release-lib.yml
+++ b/.github/workflows/release-lib.yml
@@ -74,9 +74,18 @@ jobs:
 
       - name: setup Zig (C toolchain for musl cross-compilation)
         if: matrix.target == 'aarch64-unknown-linux-musl'
-        uses: mlugg/setup-zig@v1
-        with:
-          version: 0.16.0
+        run: |
+          # This runner is native ARM64, so install the aarch64-linux Zig build
+          # directly instead of relying on an action (the action's post-cleanup
+          # step fails to find `zig` on PATH).
+          mkdir -p "$HOME/.zig"
+          curl -fsSL \
+            https://ziglang.org/download/0.16.0/zig-aarch64-linux-0.16.0.tar.xz \
+            -o /tmp/zig.tar.xz
+          echo 'ea4b09bfb22ec6f6c6ceac57ab63efb6b46e17ab08d21f69f3a48b38e1534f17  /tmp/zig.tar.xz' | sha256sum -c -
+          tar -xJf /tmp/zig.tar.xz -C "$HOME/.zig" --strip-components=1
+          echo "$HOME/.zig" >>"$GITHUB_PATH"
+          zig version
 
       - name: pref for aarch64-unknown-linux-musl
         if: matrix.target == 'aarch64-unknown-linux-musl'


### PR DESCRIPTION
## Summary

Fixes https://github.com/pola-rs/r-polars/issues/1760

Builds the `aarch64-unknown-linux-musl` target's Rust code with `rustc` targeting musl, and cross-compiles its C components (jemalloc, ring, ...) with Zig (`zig cc`), which compiles C against musl with a working atomics implementation, so jemalloc builds without leaking glibc fortification symbols such as `__fprintf_chk`.

## What changed

- `.github/workflows/release-lib.yml`: Replaced the `CC=aarch64-linux-gnu-gcc` workaround with a `setup Zig` step that downloads the official Zig 0.16.0 `aarch64-linux` build with sha256 verification, and sets `CC_aarch64_unknown_linux_musl` / `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER` to the Zig wrapper for the `aarch64-unknown-linux-musl` target.
- `.github/scripts/zig-aarch64-musl-cc.sh`: Added a wrapper that rewrites the cc crate's Rust-style target triple (`--target=aarch64-unknown-linux-musl`) to Zig's own format (`--target=aarch64-linux-musl`) before executing `zig cc`, because Zig rejects the Rust triple with `UnknownOperatingSystem`.

## Behaviour change

The `aarch64-unknown-linux-musl` static library is now built with rustc targeting musl, and its C components (jemalloc, ring, ...) are compiled by Zig (`zig cc`) against musl libc instead of a glibc C compiler. As a result, glibc fortification symbols such as `__fprintf_chk` are no longer embedded, and the package should load correctly on Alpine/musl linux machines. `jemalloc` is retained as the prefereed memory allocator in polars.

```sh
build lib step
  └─ cargo build --target=aarch64-unknown-linux-musl
       └─ cc crate compiles ring/jemalloc/zstd C
            └─ invokes CC_aarch64_unknown_linux_musl  (= wrapper script)
                 └─ wrapper rewrites --target=aarch64-unknown-linux-musl → aarch64-linux-musl
                      └─ exec zig cc ...  (compiles C against musl)
```

- Before: C sources were compiled by glibc `aarch64-linux-gnu-gcc` → glibc symbols leaked in.
- Now: C sources are compiled by Zig (`zig cc`) against musl → no glibc symbols.

The added wrapper is a C compiler for the C-only crates; it injects nothing into the Rust build or the Rust-produced machine code.

## Notes

- The `aarch64-unknown-linux-gnu` matrix build passes; the `aarch64-unknown-linux-musl` target still needs a green run on the native ARM64 runner to confirm Zig cross-compiled the C components (jemalloc, ring, ...) correctly.
- GitHub Actions runs `uses:`-style actions as Node.js JavaScript actions, and its runtime refuses to execute them inside an Alpine container on an ARM64 runner:

```sh
Error: JavaScript Actions in Alpine containers are only supported on x64 Linux runners. Detected Linux Arm64
```

That is a documented limitation of the Actions runtime, not something a config tweak fixes.

---
AI assistance notice: assisted with deepseek-v4-flash-0731 in pi agent setup ( https://codefloe.com/philipp-baumann/agentic-tooling-and-configs )