### PR TITLE
fix: correct `file_cache_ttl` migration guidance

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,13 @@
 
 ## polars (development version)
 
+### Deprecations
+
+* The deprecated `file_cache_ttl` argument of the CSV, IPC, and NDJSON
+  readers now warns that the file cache is no longer supported and has no
+  direct replacement in Polars 2.0. It is no longer translated into
+  `storage_options`.
+
 ## polars 1.15.0
 
 This is an update that corresponds to Python Polars 1.44.1.
@@ -194,8 +201,10 @@ This is an update that corresponds to Python Polars 1.38.1.
 - The `retries` argument in scan/read and sink/write functions is deprecated (#1726).
   Use `max_retries` in `storage_options` instead.
 - The `file_cache_ttl` argument in `pl$scan_csv()`, `pl$scan_ipc()`, `pl$scan_ndjson()`,
-  and their `read_*` counterparts is deprecated (#1726).
-  Use `file_cache_ttl` in `storage_options` instead.
+  and their `read_*` counterparts is deprecated (#1726). The previous
+  recommendation to use `file_cache_ttl` in `storage_options` has since been
+  superseded: the file cache is no longer supported and has no direct
+  replacement in Polars 2.0.
 - `<expr>$flatten()` is deprecated. Use `<expr>$list$explode()` instead (#1726).
 
 ### New features

--- a/R/input-csv-functions.R
+++ b/R/input-csv-functions.R
@@ -169,22 +169,7 @@ pl__scan_csv <- function(
   }
 
   if (is_present(file_cache_ttl)) {
-    deprecate_warn(
-      c(
-        `!` = sprintf(
-          "The %s argument is deprecated as of %s 1.9.0.",
-          format_arg("file_cache_ttl"),
-          format_pkg("polars")
-        ),
-        i = sprintf(
-          "Specify %s in %s instead.",
-          format_code("file_cache_ttl"),
-          format_arg("storage_options")
-        )
-      )
-    )
-    storage_options <- storage_options %||% character()
-    storage_options[["file_cache_ttl"]] <- as.character(file_cache_ttl)
+    warn_deprecated_file_cache_ttl()
   }
 
   if (isFALSE(infer_schema)) {

--- a/R/input-ipc-functions.R
+++ b/R/input-ipc-functions.R
@@ -37,9 +37,9 @@
 #' @param retries `r lifecycle::badge("deprecated")` Number of retries if
 #'   accessing a cloud instance fails. Specify `max_retries` in
 #'   `storage_options` instead.
-#' @param file_cache_ttl `r lifecycle::badge("deprecated")` Amount of time to
-#'   keep downloaded cloud files since their last access time, in seconds.
-#'   Specify `file_cache_ttl` in `storage_options` instead.
+#' @param file_cache_ttl `r lifecycle::badge("deprecated")` Deprecated and
+#'   ignored. The file cache is no longer supported and has no direct
+#'   replacement in Polars 2.0.
 #' @param hive_partitioning Infer statistics and schema from Hive partitioned
 #' sources and use them to prune reads. If `NULL` (default), it is automatically
 #' enabled when a single directory is passed, and otherwise disabled.
@@ -109,22 +109,7 @@ pl__scan_ipc <- function(
   }
 
   if (is_present(file_cache_ttl)) {
-    deprecate_warn(
-      c(
-        `!` = sprintf(
-          "The %s argument is deprecated as of %s 1.9.0.",
-          format_arg("file_cache_ttl"),
-          format_pkg("polars")
-        ),
-        i = sprintf(
-          "Specify %s in %s instead.",
-          format_code("file_cache_ttl"),
-          format_arg("storage_options")
-        )
-      )
-    )
-    storage_options <- storage_options %||% character()
-    storage_options[["file_cache_ttl"]] <- as.character(file_cache_ttl)
+    warn_deprecated_file_cache_ttl()
   }
 
   if (!is.null(hive_schema)) {

--- a/R/input-json-functions.R
+++ b/R/input-json-functions.R
@@ -57,22 +57,7 @@ pl__scan_ndjson <- function(
   }
 
   if (is_present(file_cache_ttl)) {
-    deprecate_warn(
-      c(
-        `!` = sprintf(
-          "The %s argument is deprecated as of %s 1.9.0.",
-          format_arg("file_cache_ttl"),
-          format_pkg("polars")
-        ),
-        i = sprintf(
-          "Specify %s in %s instead.",
-          format_code("file_cache_ttl"),
-          format_arg("storage_options")
-        )
-      )
-    )
-    storage_options <- storage_options %||% character()
-    storage_options[["file_cache_ttl"]] <- as.character(file_cache_ttl)
+    warn_deprecated_file_cache_ttl()
   }
 
   if (!is.null(schema)) {

--- a/R/utils-deprecation.R
+++ b/R/utils-deprecation.R
@@ -28,3 +28,20 @@ warn_deprecated_rechunk <- function(user_env = caller_env(2)) {
     user_env = user_env
   )
 }
+
+# The file cache was removed upstream and has no replacement in Polars 2.0.
+# Keep accepting this argument in the 1.x migration release, but do not pass it
+# on as a storage option.
+warn_deprecated_file_cache_ttl <- function(user_env = caller_env(2)) {
+  deprecate_warn(
+    c(
+      `!` = sprintf(
+        "The %s argument is deprecated as of %s 1.9.0.",
+        format_arg("file_cache_ttl"),
+        format_pkg("polars")
+      ),
+      i = "The file cache is no longer supported and has no direct replacement in polars 2.0."
+    ),
+    user_env = user_env
+  )
+}

--- a/man/pl__read_csv.Rd
+++ b/man/pl__read_csv.Rd
@@ -159,9 +159,9 @@ information from environment variables.}
 accessing a cloud instance fails. Specify \code{max_retries} in
 \code{storage_options} instead.}
 
-\item{file_cache_ttl}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Amount of time to
-keep downloaded cloud files since their last access time, in seconds.
-Specify \code{file_cache_ttl} in \code{storage_options} instead.}
+\item{file_cache_ttl}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Deprecated and
+ignored. The file cache is no longer supported and has no direct
+replacement in Polars 2.0.}
 
 \item{include_file_paths}{Include the path of the source file(s) as a column
 with this name.}

--- a/man/pl__read_ipc.Rd
+++ b/man/pl__read_ipc.Rd
@@ -61,9 +61,9 @@ information from environment variables.}
 accessing a cloud instance fails. Specify \code{max_retries} in
 \code{storage_options} instead.}
 
-\item{file_cache_ttl}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Amount of time to
-keep downloaded cloud files since their last access time, in seconds.
-Specify \code{file_cache_ttl} in \code{storage_options} instead.}
+\item{file_cache_ttl}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Deprecated and
+ignored. The file cache is no longer supported and has no direct
+replacement in Polars 2.0.}
 
 \item{hive_partitioning}{Infer statistics and schema from Hive partitioned
 sources and use them to prune reads. If \code{NULL} (default), it is automatically

--- a/man/pl__read_ndjson.Rd
+++ b/man/pl__read_ndjson.Rd
@@ -82,9 +82,9 @@ information from environment variables.}
 accessing a cloud instance fails. Specify \code{max_retries} in
 \code{storage_options} instead.}
 
-\item{file_cache_ttl}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Amount of time to
-keep downloaded cloud files since their last access time, in seconds.
-Specify \code{file_cache_ttl} in \code{storage_options} instead.}
+\item{file_cache_ttl}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Deprecated and
+ignored. The file cache is no longer supported and has no direct
+replacement in Polars 2.0.}
 
 \item{include_file_paths}{Include the path of the source file(s) as a column
 with this name.}

--- a/man/pl__scan_csv.Rd
+++ b/man/pl__scan_csv.Rd
@@ -159,9 +159,9 @@ information from environment variables.}
 accessing a cloud instance fails. Specify \code{max_retries} in
 \code{storage_options} instead.}
 
-\item{file_cache_ttl}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Amount of time to
-keep downloaded cloud files since their last access time, in seconds.
-Specify \code{file_cache_ttl} in \code{storage_options} instead.}
+\item{file_cache_ttl}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Deprecated and
+ignored. The file cache is no longer supported and has no direct
+replacement in Polars 2.0.}
 
 \item{include_file_paths}{Include the path of the source file(s) as a column
 with this name.}

--- a/man/pl__scan_ipc.Rd
+++ b/man/pl__scan_ipc.Rd
@@ -62,9 +62,9 @@ information from environment variables.}
 accessing a cloud instance fails. Specify \code{max_retries} in
 \code{storage_options} instead.}
 
-\item{file_cache_ttl}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Amount of time to
-keep downloaded cloud files since their last access time, in seconds.
-Specify \code{file_cache_ttl} in \code{storage_options} instead.}
+\item{file_cache_ttl}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Deprecated and
+ignored. The file cache is no longer supported and has no direct
+replacement in Polars 2.0.}
 
 \item{hive_partitioning}{Infer statistics and schema from Hive partitioned
 sources and use them to prune reads. If \code{NULL} (default), it is automatically

--- a/man/pl__scan_ndjson.Rd
+++ b/man/pl__scan_ndjson.Rd
@@ -82,9 +82,9 @@ information from environment variables.}
 accessing a cloud instance fails. Specify \code{max_retries} in
 \code{storage_options} instead.}
 
-\item{file_cache_ttl}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Amount of time to
-keep downloaded cloud files since their last access time, in seconds.
-Specify \code{file_cache_ttl} in \code{storage_options} instead.}
+\item{file_cache_ttl}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Deprecated and
+ignored. The file cache is no longer supported and has no direct
+replacement in Polars 2.0.}
 
 \item{include_file_paths}{Include the path of the source file(s) as a column
 with this name.}

--- a/tests/testthat/test-input-csv-functions.R
+++ b/tests/testthat/test-input-csv-functions.R
@@ -324,7 +324,7 @@ test_that("read/scan: arg 'file_cache_ttl' is deprecated", {
   expect_no_condition(pl$read_csv(tmpf))
 
   captured <- NULL
-  original <- polars:::PlRLazyFrame$new_from_csv
+  original <- get("PlRLazyFrame", asNamespace("polars"))$new_from_csv
   mock <- new.env(parent = emptyenv())
   mock$new_from_csv <- function(...) {
     captured <<- list(...)

--- a/tests/testthat/test-input-csv-functions.R
+++ b/tests/testthat/test-input-csv-functions.R
@@ -306,6 +306,50 @@ test_that("read/scan: arg 'storage_options' throws basic errors", {
   )
 })
 
+test_that("read/scan: arg 'file_cache_ttl' is deprecated", {
+  tmpf <- withr::local_tempfile()
+  writeLines("a\n1", tmpf)
+
+  expect_warning(
+    pl$scan_csv(tmpf, file_cache_ttl = 10),
+    "file cache is no longer supported",
+    class = "polars_deprecation_warning"
+  )
+  expect_warning(
+    pl$read_csv(tmpf, file_cache_ttl = 10),
+    "file cache is no longer supported",
+    class = "polars_deprecation_warning"
+  )
+  expect_no_condition(pl$scan_csv(tmpf))
+  expect_no_condition(pl$read_csv(tmpf))
+
+  captured <- NULL
+  original <- polars:::PlRLazyFrame$new_from_csv
+  mock <- new.env(parent = emptyenv())
+  mock$new_from_csv <- function(...) {
+    captured <<- list(...)
+    original(...)
+  }
+  testthat::local_mocked_bindings(PlRLazyFrame = mock, .package = "polars")
+
+  expect_warning(
+    pl$scan_csv(
+      tmpf,
+      file_cache_ttl = 10,
+      storage_options = c(
+        endpoint_url = "https://example.com",
+        file_cache_ttl = "60"
+      )
+    ),
+    "file cache is no longer supported",
+    class = "polars_deprecation_warning"
+  )
+  expect_identical(
+    captured$storage_options,
+    c(endpoint_url = "https://example.com", file_cache_ttl = "60")
+  )
+})
+
 test_that("read/scan: arg 'decimal_comma' works", {
   tmpf <- withr::local_tempfile()
   writeLines("a|b|c\n1,5|a|2\n2||", tmpf)

--- a/tests/testthat/test-input-ipc-functions.R
+++ b/tests/testthat/test-input-ipc-functions.R
@@ -67,7 +67,7 @@ test_that("read/scan: arg 'file_cache_ttl' is deprecated", {
   expect_no_condition(pl$read_ipc(tmpf))
 
   captured <- NULL
-  original <- polars:::PlRLazyFrame$new_from_ipc
+  original <- get("PlRLazyFrame", asNamespace("polars"))$new_from_ipc
   mock <- new.env(parent = emptyenv())
   mock$new_from_ipc <- function(...) {
     captured <<- list(...)

--- a/tests/testthat/test-input-ipc-functions.R
+++ b/tests/testthat/test-input-ipc-functions.R
@@ -49,6 +49,50 @@ test_that("Test reading data from Apache Arrow file", {
   )
 })
 
+test_that("read/scan: arg 'file_cache_ttl' is deprecated", {
+  tmpf <- withr::local_tempfile()
+  pl$DataFrame(a = 1:3)$write_ipc(tmpf, compression = "uncompressed")
+
+  expect_warning(
+    pl$scan_ipc(tmpf, file_cache_ttl = 10),
+    "file cache is no longer supported",
+    class = "polars_deprecation_warning"
+  )
+  expect_warning(
+    pl$read_ipc(tmpf, file_cache_ttl = 10),
+    "file cache is no longer supported",
+    class = "polars_deprecation_warning"
+  )
+  expect_no_condition(pl$scan_ipc(tmpf))
+  expect_no_condition(pl$read_ipc(tmpf))
+
+  captured <- NULL
+  original <- polars:::PlRLazyFrame$new_from_ipc
+  mock <- new.env(parent = emptyenv())
+  mock$new_from_ipc <- function(...) {
+    captured <<- list(...)
+    original(...)
+  }
+  testthat::local_mocked_bindings(PlRLazyFrame = mock, .package = "polars")
+
+  expect_warning(
+    pl$scan_ipc(
+      tmpf,
+      file_cache_ttl = 10,
+      storage_options = c(
+        endpoint_url = "https://example.com",
+        file_cache_ttl = "60"
+      )
+    ),
+    "file cache is no longer supported",
+    class = "polars_deprecation_warning"
+  )
+  expect_identical(
+    captured$storage_options,
+    c(endpoint_url = "https://example.com", file_cache_ttl = "60")
+  )
+})
+
 test_that("scanning from hive partition works", {
   skip_if_not_installed("arrow")
   temp_dir <- withr::local_tempdir()

--- a/tests/testthat/test-input-json-functions.R
+++ b/tests/testthat/test-input-json-functions.R
@@ -92,6 +92,50 @@ test_that("scan_ndjson/read_ndjson error", {
   expect_error(pl$scan_ndjson("foo", batch_size = 0))
 })
 
+test_that("read/scan: arg 'file_cache_ttl' is deprecated", {
+  tmpf <- withr::local_tempfile()
+  writeLines('{"a": 1}', tmpf)
+
+  expect_warning(
+    pl$scan_ndjson(tmpf, file_cache_ttl = 10),
+    "file cache is no longer supported",
+    class = "polars_deprecation_warning"
+  )
+  expect_warning(
+    pl$read_ndjson(tmpf, file_cache_ttl = 10),
+    "file cache is no longer supported",
+    class = "polars_deprecation_warning"
+  )
+  expect_no_condition(pl$scan_ndjson(tmpf))
+  expect_no_condition(pl$read_ndjson(tmpf))
+
+  captured <- NULL
+  original <- polars:::PlRLazyFrame$new_from_ndjson
+  mock <- new.env(parent = emptyenv())
+  mock$new_from_ndjson <- function(...) {
+    captured <<- list(...)
+    original(...)
+  }
+  testthat::local_mocked_bindings(PlRLazyFrame = mock, .package = "polars")
+
+  expect_warning(
+    pl$scan_ndjson(
+      tmpf,
+      file_cache_ttl = 10,
+      storage_options = c(
+        endpoint_url = "https://example.com",
+        file_cache_ttl = "60"
+      )
+    ),
+    "file cache is no longer supported",
+    class = "polars_deprecation_warning"
+  )
+  expect_identical(
+    captured$storage_options,
+    c(endpoint_url = "https://example.com", file_cache_ttl = "60")
+  )
+})
+
 test_that("read/scan: arg rechunk is deprecated", {
   tmpf <- withr::local_tempfile(fileext = ".ndjson")
   pl$DataFrame(a = 1:3)$write_ndjson(tmpf)

--- a/tests/testthat/test-input-json-functions.R
+++ b/tests/testthat/test-input-json-functions.R
@@ -110,7 +110,7 @@ test_that("read/scan: arg 'file_cache_ttl' is deprecated", {
   expect_no_condition(pl$read_ndjson(tmpf))
 
   captured <- NULL
-  original <- polars:::PlRLazyFrame$new_from_ndjson
+  original <- get("PlRLazyFrame", asNamespace("polars"))$new_from_ndjson
   mock <- new.env(parent = emptyenv())
   mock$new_from_ndjson <- function(...) {
     captured <<- list(...)


### PR DESCRIPTION
The deprecated `file_cache_ttl` argument currently tells CSV, IPC, and NDJSON users to move the value into `storage_options`, and performs that conversion automatically. The upstream file cache has been removed without a direct Polars 2.0 replacement.

Keep accepting the argument with its existing R Polars 1.9.0 deprecation version, but ignore it and explain the removal. Share the warning across readers, preserve explicitly supplied storage options, and update the generated documentation and NEWS, including a correction to the earlier migration advice.

Tests cover all three formats' read/scan warnings, the deprecation condition class, silent omission, and preservation of explicitly supplied storage options.

Validation:

- `task test-filter 'FILTER=input-(csv|ipc|json)-functions'`: 118 passed; no failures, warnings, or skips, against the installed package using the matching release library.
- `task build-documents`, `task format-r`, and whitespace/format checks passed.
- `jarl check .` passed with Jarl 0.6.0.

Part of #1852; this does not complete the overall migration issue.
