### PR TITLE
docs: prepare string pattern migration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,11 @@
   readers now warns that the file cache is no longer supported and has no
   direct replacement in Polars 2.0. It is no longer translated into
   `storage_options`.
+* Bare character vectors passed to `<expr>$str$contains_any()` and
+  `<expr>$str$replace_many()` will be interpreted as column names in Polars
+  2.0. Use `pl$lit(...)$implode()` for literal patterns or `pl$col()` for
+  column patterns. A shared literal vector can also be passed as
+  `list(c(...))`.
 
 ## polars 1.15.0
 

--- a/R/expr-string.R
+++ b/R/expr-string.R
@@ -1156,9 +1156,12 @@ expr_str_reverse <- function() {
 #'
 #' This function determines if any of the patterns find a match.
 #' @inherit expr_str_contains params return
-#' @param patterns String patterns to search. Accepts expression input. To use
-#' the same character vector for all rows, use
-#' `list(c(...))` instead of `c(...)` (see Examples).
+#' @param patterns String patterns to search. Accepts expression input. In
+#'   Polars 1.16, bare character vectors are interpreted as literal patterns;
+#'   in Polars 2.0, they will be interpreted as column names. Use
+#'   `pl$lit(...)$implode()` for literal patterns or `pl$col()` for column
+#'   patterns. To use the same character vector for all rows, use
+#'   `list(c(...))` instead of `c(...)` (see Examples).
 #' @param ascii_case_insensitive Enable ASCII-aware case insensitive matching.
 #' When this option is enabled, searching will be performed without respect to
 #' case for ASCII letters (a-z and A-Z) only.
@@ -1184,7 +1187,7 @@ expr_str_contains_any <- function(
   wrap({
     check_dots_empty0(...)
     self$`_rexpr`$str_contains_any(
-      # TODO: set this to FALSE in 2.0.0
+      # TODO: @2.0 set this to FALSE to parse character vectors as columns.
       as_polars_expr(patterns, as_lit = TRUE)$`_rexpr`,
       ascii_case_insensitive = ascii_case_insensitive
     )
@@ -1197,7 +1200,8 @@ expr_str_contains_any <- function(
 #'
 #' @inherit as_polars_expr return
 #' @inheritParams rlang::args_dots_empty
-# TODO: @2.0 remove inheriting from expr_str_contains_any
+# TODO: @2.0 remove inheriting from expr_str_contains_any and document the
+#       column-name interpretation of bare character vectors directly.
 #' @inheritParams expr_str_contains_any
 #' @inheritParams expr_str_extract_many
 #' @param replace_with A vector of strings used as replacements. If this is of
@@ -1234,9 +1238,8 @@ expr_str_replace_many <- function(
 ) {
   wrap({
     check_dots_empty0(...)
-
     self$`_rexpr`$str_replace_many(
-      # TODO: set this to FALSE in 2.0.0 (just for arg `patterns`)
+      # TODO: @2.0 set this to FALSE to parse character vectors as columns.
       as_polars_expr(patterns, as_lit = TRUE)$`_rexpr`,
       as_polars_expr(replace_with, as_lit = TRUE)$`_rexpr`,
       ascii_case_insensitive = ascii_case_insensitive,

--- a/man/expr_str_contains_any.Rd
+++ b/man/expr_str_contains_any.Rd
@@ -7,8 +7,11 @@
 expr_str_contains_any(patterns, ..., ascii_case_insensitive = FALSE)
 }
 \arguments{
-\item{patterns}{String patterns to search. Accepts expression input. To use
-the same character vector for all rows, use
+\item{patterns}{String patterns to search. Accepts expression input. In
+Polars 1.16, bare character vectors are interpreted as literal patterns;
+in Polars 2.0, they will be interpreted as column names. Use
+\code{pl$lit(...)$implode()} for literal patterns or \code{pl$col()} for column
+patterns. To use the same character vector for all rows, use
 \code{list(c(...))} instead of \code{c(...)} (see Examples).}
 
 \item{...}{These dots are for future extensions and must be empty.}

--- a/man/expr_str_replace_many.Rd
+++ b/man/expr_str_replace_many.Rd
@@ -13,8 +13,11 @@ expr_str_replace_many(
 )
 }
 \arguments{
-\item{patterns}{String patterns to search. Accepts expression input. To use
-the same character vector for all rows, use
+\item{patterns}{String patterns to search. Accepts expression input. In
+Polars 1.16, bare character vectors are interpreted as literal patterns;
+in Polars 2.0, they will be interpreted as column names. Use
+\code{pl$lit(...)$implode()} for literal patterns or \code{pl$col()} for column
+patterns. To use the same character vector for all rows, use
 \code{list(c(...))} instead of \code{c(...)} (see Examples).}
 
 \item{replace_with}{A vector of strings used as replacements. If this is of

--- a/tests/testthat/_snaps/expr-string.md
+++ b/tests/testthat/_snaps/expr-string.md
@@ -510,7 +510,47 @@
       This error occurred in the following expression:
       	col("x").str.to_integer([10.0])
 
+# str$contains_any
+
+    Code
+      dat$select(pl$col("x")$str$contains_any(c("hi", "hello")))
+    Condition <polars_deprecation_warning>
+      Warning:
+      `str.contains_any` with a flat string datatype is deprecated. Please use `implode` to return to previous behavior. See https://github.com/pola-rs/polars/issues/22149 for more information.
+    Output
+      shape: (4, 1)
+      ┌───────┐
+      │ x     │
+      │ ---   │
+      │ bool  │
+      ╞═══════╡
+      │ false │
+      │ true  │
+      │ false │
+      │ null  │
+      └───────┘
+
 # str$replace_many
+
+    Code
+      dat$select(pl$col("x")$str$replace_many(c("hello", "he"), list(c("foo"))))
+    Condition <polars_deprecation_warning>
+      Warning:
+      `str.replace_many` with a flat string datatype is deprecated. please use `implode` to return to previous behavior. See https://github.com/pola-rs/polars/issues/22149 for more information.
+    Output
+      shape: (4, 1)
+      ┌──────────────┐
+      │ x            │
+      │ ---          │
+      │ str          │
+      ╞══════════════╡
+      │ HELLO tfoore │
+      │ hi tfoore    │
+      │ good bye     │
+      │ null         │
+      └──────────────┘
+
+---
 
     Code
       dat$with_columns(pl$col("x")$str$replace_many(list(c("hi", "hello")), list(c(

--- a/tests/testthat/test-expr-string.R
+++ b/tests/testthat/test-expr-string.R
@@ -880,6 +880,36 @@ test_that("str$reverse", {
 
 test_that("str$contains_any", {
   dat <- pl$DataFrame(x = c("HELLO there", "hi there", "good bye", NA))
+
+  expect_snapshot(
+    dat$select(pl$col("x")$str$contains_any(c("hi", "hello"))),
+    cnd_class = TRUE
+  )
+
+  actual <- NULL
+  expect_no_condition(
+    actual <- dat$select(
+      pl$col("x")$str$contains_any(pl$lit(list(c("hi", "hello"))))
+    )
+  )
+  expect_equal(actual, pl$DataFrame(x = c(FALSE, TRUE, FALSE, NA)))
+
+  patterns <- pl$DataFrame(
+    x = "hi there",
+    patterns = list(c("hi", "hello"))
+  )
+  actual <- NULL
+  expect_no_condition(
+    actual <- patterns$select(
+      pl$col("x")$str$contains_any(pl$col("patterns"))
+    )
+  )
+  expect_equal(actual, pl$DataFrame(x = TRUE))
+
+  expect_no_condition(
+    pl$col("x")$str$contains_any(list(c("hi", "hello")))
+  )
+
   expect_equal(
     dat$with_columns(pl$col("x")$str$contains_any(list(c("hi", "hello")))),
     pl$DataFrame(x = c(FALSE, TRUE, FALSE, NA))
@@ -896,6 +926,42 @@ test_that("str$contains_any", {
 
 test_that("str$replace_many", {
   dat <- pl$DataFrame(x = c("HELLO there", "hi there", "good bye", NA))
+
+  expect_snapshot(
+    dat$select(
+      pl$col("x")$str$replace_many(c("hello", "he"), list(c("foo")))
+    ),
+    cnd_class = TRUE
+  )
+
+  actual <- NULL
+  expect_no_condition(
+    actual <- dat$select(
+      pl$col("x")$str$replace_many(
+        pl$lit(list(c("hello", "he"))),
+        list(c("foo"))
+      )
+    )
+  )
+  expect_equal(
+    actual,
+    pl$DataFrame(x = c("HELLO tfoore", "hi tfoore", "good bye", NA))
+  )
+
+  patterns <- pl$DataFrame(
+    x = "hello there",
+    patterns = list(c("hello", "he"))
+  )
+  actual <- NULL
+  expect_no_condition(
+    actual <- patterns$select(
+      pl$col("x")$str$replace_many(
+        pl$col("patterns"),
+        list(c("X"))
+      )
+    )
+  )
+  expect_equal(actual, pl$DataFrame(x = "Xllo tXre"))
 
   expect_equal(
     dat$select(


### PR DESCRIPTION
## Summary

- document the Polars 2.0 interpretation of bare character `patterns` in `str$contains_any()` and `str$replace_many()`
- recommend `pl$lit(...)$implode()` or `list(c(...))` for literal patterns and `pl$col()` for column patterns
- snapshot the existing Rust deprecation warning and the preserved 1.x result
- test explicit literal and column expressions without adding a duplicate R-side warning

Closes #1663.

## Validation

- `task build-documents`
- `task test-snapshot-accept`
- `task test-filter FILTER='expr-string'` (179 passed, 1 skipped)
- `jarl check .`
- `air format --check R/expr-string.R R/utils-deprecation.R tests/testthat/test-expr-string.R`

No `pkgload` or debug build was used.
