### PR TITLE
feat: prepare Arrow file compression migration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,10 @@
   readers now warns that the file cache is no longer supported and has no
   direct replacement in Polars 2.0. It is no longer translated into
   `storage_options`.
+* Omitting `compression` in Arrow file output functions now warns that the
+  default will change from `"zstd"` to `"uncompressed"` in Polars 2.0. Pass
+  `compression = "zstd"` to keep the current behavior or
+  `compression = "uncompressed"` to opt into the new default.
 * Bare character vectors passed to `<expr>$str$contains_any()` and
   `<expr>$str$replace_many()` will be interpreted as column names in Polars
   2.0. Use `pl$lit(...)$implode()` for literal patterns or `pl$col()` for

--- a/R/output-ipc.R
+++ b/R/output-ipc.R
@@ -1,15 +1,19 @@
-# TODO: @2.0.0: Fix the default value of compression to "uncompressed"
+# TODO: @2.0.0: Remove the migration warning branches and change the
+# default of compression to "uncompressed" in all Arrow file output functions.
 
-#' Evaluate the query in streaming mode and write to Arrow IPC File Format
+#' Evaluate the query in streaming mode and write to Arrow File Format
 #'
 #' @inherit lazyframe__sink_parquet description params return
 #' @inheritParams rlang::args_dots_empty
 #' @inheritParams lazyframe__collect
 #' @param compression Determines the compression algorithm.
+#' In Polars 1.16, omitting this argument uses `"zstd"` and emits a
+#' deprecation warning. The default changes to `"uncompressed"` in Polars 2.0;
+#' pass an explicit value to choose either behavior without a warning.
 #' Must be one of:
 #' - `"uncompressed"` or `NULL`: Write an uncompressed Arrow file.
 #' - `"lz4"`: Fast compression/decompression.
-#' - `"zstd"` (default): Good compression performance.
+#' - `"zstd"`: Good compression performance.
 #' @param compat_level Determines the compatibility level when exporting
 #'   Polars' internal data structures. When specifying a new compatibility level,
 #'   Polars exports its internal data structures that might not be interpretable by
@@ -24,7 +28,7 @@
 #'   - `"oldest"`: Same as `0` (High compatibility).
 #' @examples
 #' tmpf <- tempfile(fileext = ".arrow")
-#' as_polars_lf(mtcars)$sink_ipc(tmpf)
+#' as_polars_lf(mtcars)$sink_ipc(tmpf, compression = "zstd")
 #'
 #' pl$read_ipc(tmpf)
 lazyframe__sink_ipc <- function(
@@ -47,8 +51,14 @@ lazyframe__sink_ipc <- function(
   collapse_joins = deprecated(),
   no_optimization = deprecated()
 ) {
+  compression_missing <- missing(compression)
   wrap({
     check_dots_empty0(...)
+
+    if (compression_missing) {
+      warn_deprecated_ipc_compression()
+      compression <- "zstd"
+    }
 
     # Allow override by option at the downstream function
     if (missing(compat_level)) {
@@ -92,9 +102,15 @@ lazyframe__lazy_sink_ipc <- function(
   sync_on_close = c("none", "data", "all"),
   mkdir = FALSE
 ) {
+  compression_missing <- missing(compression)
   wrap({
     check_dots_empty0(...)
     check_character(storage_options, allow_null = TRUE)
+
+    if (compression_missing) {
+      warn_deprecated_ipc_compression()
+      compression <- "zstd"
+    }
 
     if (is_present(retries)) {
       deprecate_warn(
@@ -144,14 +160,14 @@ lazyframe__lazy_sink_ipc <- function(
   })
 }
 
-#' Write to Arrow IPC File Format
+#' Write to Arrow File Format
 #'
 #' @inheritParams rlang::args_dots_empty
 #' @inheritParams lazyframe__sink_ipc
 #' @inherit dataframe__write_parquet return
 #' @examples
 #' tmpf <- tempfile(fileext = ".arrow")
-#' as_polars_df(mtcars)$write_ipc(tmpf)
+#' as_polars_df(mtcars)$write_ipc(tmpf, compression = "zstd")
 #'
 #' pl$read_ipc(tmpf)
 dataframe__write_ipc <- function(
@@ -162,8 +178,14 @@ dataframe__write_ipc <- function(
   storage_options = NULL,
   retries = deprecated()
 ) {
+  compression_missing <- missing(compression)
   wrap({
     check_dots_empty0(...)
+
+    if (compression_missing) {
+      warn_deprecated_ipc_compression()
+      compression <- "zstd"
+    }
 
     # Allow override by option at the downstream function
     if (missing(compat_level)) {
@@ -186,14 +208,14 @@ dataframe__write_ipc <- function(
   invisible(NULL)
 }
 
-#' Write to Arrow IPC Streaming Format
+#' Write to Arrow Streaming Format
 #'
 #' @inheritParams rlang::args_dots_empty
 #' @inheritParams lazyframe__sink_ipc
 #' @inherit dataframe__write_parquet return
 #' @examplesIf requireNamespace("nanoarrow", quiet = TRUE) && nanoarrow::nanoarrow_with_zstd()
 #' tmpf <- tempfile(fileext = ".arrows")
-#' as_polars_df(mtcars)$write_ipc_stream(tmpf)
+#' as_polars_df(mtcars)$write_ipc_stream(tmpf, compression = "zstd")
 #'
 #' nanoarrow::read_nanoarrow(tmpf)
 dataframe__write_ipc_stream <- function(
@@ -202,8 +224,14 @@ dataframe__write_ipc_stream <- function(
   compression = c("zstd", "lz4", "uncompressed"),
   compat_level = c("newest", "oldest")
 ) {
+  compression_missing <- missing(compression)
   wrap({
     check_dots_empty0(...)
+
+    if (compression_missing) {
+      warn_deprecated_ipc_compression()
+      compression <- "zstd"
+    }
 
     # Handle missing values with use_option_if_missing (similar to lazy_sink_ipc)
     compat_level <- use_option_if_missing(

--- a/R/output-ipc.R
+++ b/R/output-ipc.R
@@ -56,7 +56,7 @@ lazyframe__sink_ipc <- function(
     check_dots_empty0(...)
 
     if (compression_missing) {
-      warn_deprecated_ipc_compression()
+      warn_arrow_compression_default()
       compression <- "zstd"
     }
 
@@ -108,7 +108,7 @@ lazyframe__lazy_sink_ipc <- function(
     check_character(storage_options, allow_null = TRUE)
 
     if (compression_missing) {
-      warn_deprecated_ipc_compression()
+      warn_arrow_compression_default()
       compression <- "zstd"
     }
 
@@ -183,7 +183,7 @@ dataframe__write_ipc <- function(
     check_dots_empty0(...)
 
     if (compression_missing) {
-      warn_deprecated_ipc_compression()
+      warn_arrow_compression_default()
       compression <- "zstd"
     }
 
@@ -229,7 +229,7 @@ dataframe__write_ipc_stream <- function(
     check_dots_empty0(...)
 
     if (compression_missing) {
-      warn_deprecated_ipc_compression()
+      warn_arrow_compression_default()
       compression <- "zstd"
     }
 

--- a/R/utils-deprecation.R
+++ b/R/utils-deprecation.R
@@ -46,7 +46,7 @@ warn_deprecated_file_cache_ttl <- function(user_env = caller_env(2)) {
   )
 }
 
-warn_deprecated_ipc_compression <- function(user_env = caller_env(2)) {
+warn_arrow_compression_default <- function(user_env = caller_env(2)) {
   deprecate_warn(
     c(
       `!` = sprintf(
@@ -55,7 +55,10 @@ warn_deprecated_ipc_compression <- function(user_env = caller_env(2)) {
         format_pkg("polars")
       ),
       i = sprintf(
-        "The default will change from %s to %s in Polars 2.0. Use %s to keep the current behavior or %s to opt into the new default.",
+        paste0(
+          "The default will change from %s to %s in Polars 2.0. ",
+          "Use %s to keep the current behavior or %s to opt into the new default."
+        ),
         format_code('"zstd"'),
         format_code('"uncompressed"'),
         format_code('compression = "zstd"'),

--- a/R/utils-deprecation.R
+++ b/R/utils-deprecation.R
@@ -45,3 +45,23 @@ warn_deprecated_file_cache_ttl <- function(user_env = caller_env(2)) {
     user_env = user_env
   )
 }
+
+warn_deprecated_ipc_compression <- function(user_env = caller_env(2)) {
+  deprecate_warn(
+    c(
+      `!` = sprintf(
+        "The default value of %s is deprecated as of %s 1.16.0.",
+        format_arg("compression"),
+        format_pkg("polars")
+      ),
+      i = sprintf(
+        "The default will change from %s to %s in Polars 2.0. Use %s to keep the current behavior or %s to opt into the new default.",
+        format_code('"zstd"'),
+        format_code('"uncompressed"'),
+        format_code('compression = "zstd"'),
+        format_code('compression = "uncompressed"')
+      )
+    ),
+    user_env = user_env
+  )
+}

--- a/man/dataframe__write_ipc.Rd
+++ b/man/dataframe__write_ipc.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/output-ipc.R
 \name{dataframe__write_ipc}
 \alias{dataframe__write_ipc}
-\title{Write to Arrow IPC File Format}
+\title{Write to Arrow File Format}
 \usage{
 dataframe__write_ipc(
   path,
@@ -19,11 +19,14 @@ dataframe__write_ipc(
 \item{...}{These dots are for future extensions and must be empty.}
 
 \item{compression}{Determines the compression algorithm.
+In Polars 1.16, omitting this argument uses \code{"zstd"} and emits a
+deprecation warning. The default changes to \code{"uncompressed"} in Polars 2.0;
+pass an explicit value to choose either behavior without a warning.
 Must be one of:
 \itemize{
 \item \code{"uncompressed"} or \code{NULL}: Write an uncompressed Arrow file.
 \item \code{"lz4"}: Fast compression/decompression.
-\item \code{"zstd"} (default): Good compression performance.
+\item \code{"zstd"}: Good compression performance.
 }}
 
 \item{compat_level}{Determines the compatibility level when exporting
@@ -64,11 +67,11 @@ accessing a cloud instance fails. Specify \code{max_retries} in
 \code{NULL} invisibly.
 }
 \description{
-Write to Arrow IPC File Format
+Write to Arrow File Format
 }
 \examples{
 tmpf <- tempfile(fileext = ".arrow")
-as_polars_df(mtcars)$write_ipc(tmpf)
+as_polars_df(mtcars)$write_ipc(tmpf, compression = "zstd")
 
 pl$read_ipc(tmpf)
 }

--- a/man/dataframe__write_ipc_stream.Rd
+++ b/man/dataframe__write_ipc_stream.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/output-ipc.R
 \name{dataframe__write_ipc_stream}
 \alias{dataframe__write_ipc_stream}
-\title{Write to Arrow IPC Streaming Format}
+\title{Write to Arrow Streaming Format}
 \usage{
 dataframe__write_ipc_stream(
   path,
@@ -17,11 +17,14 @@ dataframe__write_ipc_stream(
 \item{...}{These dots are for future extensions and must be empty.}
 
 \item{compression}{Determines the compression algorithm.
+In Polars 1.16, omitting this argument uses \code{"zstd"} and emits a
+deprecation warning. The default changes to \code{"uncompressed"} in Polars 2.0;
+pass an explicit value to choose either behavior without a warning.
 Must be one of:
 \itemize{
 \item \code{"uncompressed"} or \code{NULL}: Write an uncompressed Arrow file.
 \item \code{"lz4"}: Fast compression/decompression.
-\item \code{"zstd"} (default): Good compression performance.
+\item \code{"zstd"}: Good compression performance.
 }}
 
 \item{compat_level}{Determines the compatibility level when exporting
@@ -42,14 +45,14 @@ Use the highest level, currently same as
 \code{NULL} invisibly.
 }
 \description{
-Write to Arrow IPC Streaming Format
+Write to Arrow Streaming Format
 }
 \examples{
 \dontshow{if (\{
 requireNamespace("nanoarrow", quiet = TRUE) && nanoarrow::nanoarrow_with_zstd()
 \}) withAutoprint(\{ # examplesIf}
 tmpf <- tempfile(fileext = ".arrows")
-as_polars_df(mtcars)$write_ipc_stream(tmpf)
+as_polars_df(mtcars)$write_ipc_stream(tmpf, compression = "zstd")
 
 nanoarrow::read_nanoarrow(tmpf)
 \dontshow{\}) # examplesIf}

--- a/man/lazyframe__sink_ipc.Rd
+++ b/man/lazyframe__sink_ipc.Rd
@@ -3,7 +3,7 @@
 \name{lazyframe__sink_ipc}
 \alias{lazyframe__sink_ipc}
 \alias{lazyframe__lazy_sink_ipc}
-\title{Evaluate the query in streaming mode and write to Arrow IPC File Format}
+\title{Evaluate the query in streaming mode and write to Arrow File Format}
 \usage{
 lazyframe__sink_ipc(
   path,
@@ -44,11 +44,14 @@ lazyframe__lazy_sink_ipc(
 \item{...}{These dots are for future extensions and must be empty.}
 
 \item{compression}{Determines the compression algorithm.
+In Polars 1.16, omitting this argument uses \code{"zstd"} and emits a
+deprecation warning. The default changes to \code{"uncompressed"} in Polars 2.0;
+pass an explicit value to choose either behavior without a warning.
 Must be one of:
 \itemize{
 \item \code{"uncompressed"} or \code{NULL}: Write an uncompressed Arrow file.
 \item \code{"lz4"}: Fast compression/decompression.
-\item \code{"zstd"} (default): Good compression performance.
+\item \code{"zstd"}: Good compression performance.
 }}
 
 \item{compat_level}{Determines the compatibility level when exporting
@@ -157,7 +160,7 @@ This is useful if you want to save a query to review or run later.
 }
 \examples{
 tmpf <- tempfile(fileext = ".arrow")
-as_polars_lf(mtcars)$sink_ipc(tmpf)
+as_polars_lf(mtcars)$sink_ipc(tmpf, compression = "zstd")
 
 pl$read_ipc(tmpf)
 }

--- a/tests/testthat/_snaps/output-ipc.md
+++ b/tests/testthat/_snaps/output-ipc.md
@@ -16,6 +16,44 @@
       ╞╡
       └┘
 
+# Arrow file compression defaults are deprecated
+
+    Code
+      lf$lazy_sink_ipc(withr::local_tempfile())
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! The default value of `compression` is deprecated as of polars 1.16.0.
+      i The default will change from `"zstd"` to `"uncompressed"` in Polars 2.0. Use `compression = "zstd"` to keep the current behavior or `compression = "uncompressed"` to opt into the new default.
+    Output
+      <polars_lazy_frame>
+
+---
+
+    Code
+      lf$sink_ipc(withr::local_tempfile())
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! The default value of `compression` is deprecated as of polars 1.16.0.
+      i The default will change from `"zstd"` to `"uncompressed"` in Polars 2.0. Use `compression = "zstd"` to keep the current behavior or `compression = "uncompressed"` to opt into the new default.
+
+---
+
+    Code
+      df$write_ipc(withr::local_tempfile())
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! The default value of `compression` is deprecated as of polars 1.16.0.
+      i The default will change from `"zstd"` to `"uncompressed"` in Polars 2.0. Use `compression = "zstd"` to keep the current behavior or `compression = "uncompressed"` to opt into the new default.
+
+---
+
+    Code
+      df$write_ipc_stream(withr::local_tempfile())
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! The default value of `compression` is deprecated as of polars 1.16.0.
+      i The default will change from `"zstd"` to `"uncompressed"` in Polars 2.0. Use `compression = "zstd"` to keep the current behavior or `compression = "uncompressed"` to opt into the new default.
+
 # Test writing data to Arrow file "uncompressed" - 0
 
     Code

--- a/tests/testthat/_snaps/output-partition.md
+++ b/tests/testthat/_snaps/output-partition.md
@@ -106,7 +106,7 @@
 
     Code
       as_polars_lf(mtcars)$sink_ipc(pl$PartitionBy(out_max_size_max,
-        max_rows_per_file = 2^64 - 1), mkdir = TRUE)
+        max_rows_per_file = 2^64 - 1), compression = "zstd", mkdir = TRUE)
     Condition
       Error in `as_polars_lf(mtcars)$sink_ipc()`:
       ! Evaluation failed in `$sink_ipc()`.

--- a/tests/testthat/_snaps/polars_options.md
+++ b/tests/testthat/_snaps/polars_options.md
@@ -2660,24 +2660,24 @@
 # polars.compat_level option works level=newest
 
     Code
-      pl$LazyFrame(x = 1:3)$lazy_sink_ipc(tmpf)
+      pl$LazyFrame(x = 1:3)$lazy_sink_ipc(tmpf, compression = "zstd")
     Output
       <polars_lazy_frame>
 
 ---
 
     Code
-      pl$LazyFrame(x = 1:3)$sink_ipc(tmpf)
+      pl$LazyFrame(x = 1:3)$sink_ipc(tmpf, compression = "zstd")
 
 ---
 
     Code
-      pl$DataFrame(x = 1:3)$write_ipc(tmpf)
+      pl$DataFrame(x = 1:3)$write_ipc(tmpf, compression = "zstd")
 
 ---
 
     Code
-      pl$DataFrame(x = 1:3)$write_ipc_stream(tmpf)
+      pl$DataFrame(x = 1:3)$write_ipc_stream(tmpf, compression = "zstd")
 
 ---
 
@@ -2707,7 +2707,7 @@
 # polars.compat_level option works level=oldest
 
     Code
-      pl$LazyFrame(x = 1:3)$lazy_sink_ipc(tmpf)
+      pl$LazyFrame(x = 1:3)$lazy_sink_ipc(tmpf, compression = "zstd")
     Message
       `compat_level` is overridden by the option "polars.compat_level" with the string "oldest"
     Output
@@ -2716,21 +2716,21 @@
 ---
 
     Code
-      pl$LazyFrame(x = 1:3)$sink_ipc(tmpf)
+      pl$LazyFrame(x = 1:3)$sink_ipc(tmpf, compression = "zstd")
     Message
       `compat_level` is overridden by the option "polars.compat_level" with the string "oldest"
 
 ---
 
     Code
-      pl$DataFrame(x = 1:3)$write_ipc(tmpf)
+      pl$DataFrame(x = 1:3)$write_ipc(tmpf, compression = "zstd")
     Message
       `compat_level` is overridden by the option "polars.compat_level" with the string "oldest"
 
 ---
 
     Code
-      pl$DataFrame(x = 1:3)$write_ipc_stream(tmpf)
+      pl$DataFrame(x = 1:3)$write_ipc_stream(tmpf, compression = "zstd")
     Message
       `compat_level` is overridden by the option "polars.compat_level" with the string "oldest"
 
@@ -2768,7 +2768,7 @@
 # polars.compat_level option works level=1
 
     Code
-      pl$LazyFrame(x = 1:3)$lazy_sink_ipc(tmpf)
+      pl$LazyFrame(x = 1:3)$lazy_sink_ipc(tmpf, compression = "zstd")
     Message
       `compat_level` is overridden by the option "polars.compat_level" with the number 1
     Output
@@ -2777,21 +2777,21 @@
 ---
 
     Code
-      pl$LazyFrame(x = 1:3)$sink_ipc(tmpf)
+      pl$LazyFrame(x = 1:3)$sink_ipc(tmpf, compression = "zstd")
     Message
       `compat_level` is overridden by the option "polars.compat_level" with the number 1
 
 ---
 
     Code
-      pl$DataFrame(x = 1:3)$write_ipc(tmpf)
+      pl$DataFrame(x = 1:3)$write_ipc(tmpf, compression = "zstd")
     Message
       `compat_level` is overridden by the option "polars.compat_level" with the number 1
 
 ---
 
     Code
-      pl$DataFrame(x = 1:3)$write_ipc_stream(tmpf)
+      pl$DataFrame(x = 1:3)$write_ipc_stream(tmpf, compression = "zstd")
     Message
       `compat_level` is overridden by the option "polars.compat_level" with the number 1
 
@@ -2829,7 +2829,7 @@
 # polars.compat_level option works level=0
 
     Code
-      pl$LazyFrame(x = 1:3)$lazy_sink_ipc(tmpf)
+      pl$LazyFrame(x = 1:3)$lazy_sink_ipc(tmpf, compression = "zstd")
     Message
       `compat_level` is overridden by the option "polars.compat_level" with the number 0
     Output
@@ -2838,21 +2838,21 @@
 ---
 
     Code
-      pl$LazyFrame(x = 1:3)$sink_ipc(tmpf)
+      pl$LazyFrame(x = 1:3)$sink_ipc(tmpf, compression = "zstd")
     Message
       `compat_level` is overridden by the option "polars.compat_level" with the number 0
 
 ---
 
     Code
-      pl$DataFrame(x = 1:3)$write_ipc(tmpf)
+      pl$DataFrame(x = 1:3)$write_ipc(tmpf, compression = "zstd")
     Message
       `compat_level` is overridden by the option "polars.compat_level" with the number 0
 
 ---
 
     Code
-      pl$DataFrame(x = 1:3)$write_ipc_stream(tmpf)
+      pl$DataFrame(x = 1:3)$write_ipc_stream(tmpf, compression = "zstd")
     Message
       `compat_level` is overridden by the option "polars.compat_level" with the number 0
 

--- a/tests/testthat/test-input-ipc-functions.R
+++ b/tests/testthat/test-input-ipc-functions.R
@@ -216,7 +216,7 @@ test_that("read_ipc_stream works", {
 
 test_that("read/scan: arg rechunk is deprecated", {
   tmpf <- withr::local_tempfile(fileext = ".arrow")
-  pl$DataFrame(a = 1:3)$write_ipc(tmpf)
+  pl$DataFrame(a = 1:3)$write_ipc(tmpf, compression = "uncompressed")
 
   expect_deprecated(pl$read_ipc(tmpf, rechunk = TRUE))
   expect_deprecated(pl$scan_ipc(tmpf, rechunk = TRUE))

--- a/tests/testthat/test-lazyframe-frame.R
+++ b/tests/testthat/test-lazyframe-frame.R
@@ -2,7 +2,7 @@ patrick::with_parameters_test_that(
   "roundtrip around serialization",
   .cases = {
     tmpf <- withr::local_tempfile(fileext = ".arrow")
-    pl$DataFrame(a = 1, b = "foo")$write_ipc(tmpf)
+    pl$DataFrame(a = 1, b = "foo")$write_ipc(tmpf, compression = "uncompressed")
 
     tibble::tribble(
       ~.test_name, ~x,

--- a/tests/testthat/test-output-ipc.R
+++ b/tests/testthat/test-output-ipc.R
@@ -8,7 +8,7 @@ patrick::with_parameters_test_that(
     expect_equal(pl$read_ipc(tmpf), df)
 
     # update with new data
-    expect_null(lf$slice(5, 5)$sink_ipc(tmpf))
+    expect_null(lf$slice(5, 5)$sink_ipc(tmpf, compression = compression))
     expect_equal(
       pl$read_ipc(tmpf),
       df$slice(5, 5)
@@ -19,11 +19,79 @@ patrick::with_parameters_test_that(
 
 test_that("lazy_sink_ipc works", {
   temp_out <- withr::local_tempfile()
-  lf <- as_polars_lf(mtcars)$lazy_sink_ipc(temp_out)
+  lf <- as_polars_lf(mtcars)$lazy_sink_ipc(temp_out, compression = "zstd")
 
   expect_snapshot(lf$explain() |> cat())
   expect_snapshot(lf$collect())
   expect_equal(pl$read_ipc(temp_out), as_polars_df(mtcars))
+})
+
+test_that("Arrow file compression defaults are deprecated", {
+  local_lifecycle_warnings()
+  lf <- as_polars_lf(iris)
+  df <- as_polars_df(iris)
+
+  expect_snapshot(
+    lf$lazy_sink_ipc(withr::local_tempfile()),
+    cnd_class = TRUE
+  )
+  expect_snapshot(
+    lf$sink_ipc(withr::local_tempfile()),
+    cnd_class = TRUE
+  )
+  expect_snapshot(
+    df$write_ipc(withr::local_tempfile()),
+    cnd_class = TRUE
+  )
+  expect_snapshot(
+    df$write_ipc_stream(withr::local_tempfile()),
+    cnd_class = TRUE
+  )
+})
+
+test_that("Arrow file compression explicit values are quiet", {
+  local_lifecycle_warnings()
+  lf <- as_polars_lf(iris)
+  df <- as_polars_df(iris)
+
+  expect_no_condition(
+    lf$lazy_sink_ipc(withr::local_tempfile(), compression = "uncompressed")
+  )
+  expect_no_condition(
+    lf$sink_ipc(withr::local_tempfile(), compression = "zstd")
+  )
+  expect_no_condition(
+    df$write_ipc(withr::local_tempfile(), compression = "lz4")
+  )
+  expect_no_condition(
+    df$write_ipc_stream(withr::local_tempfile(), compression = NULL)
+  )
+})
+
+test_that("Arrow file default compression remains zstd in 1.16", {
+  local_lifecycle_silence()
+  lf <- as_polars_lf(iris)
+  df <- as_polars_df(iris)
+  read_raw <- function(path) {
+    readBin(path, what = raw(), n = file.info(path)$size)
+  }
+
+  lazy_default <- withr::local_tempfile()
+  lazy_zstd <- withr::local_tempfile()
+  lf$lazy_sink_ipc(lazy_default)$collect()
+  lf$lazy_sink_ipc(lazy_zstd, compression = "zstd")$collect()
+  expect_identical(read_raw(lazy_default), read_raw(lazy_zstd))
+  expect_equal(pl$read_ipc(lazy_default), pl$read_ipc(lazy_zstd))
+
+  stream_default <- withr::local_tempfile()
+  stream_zstd <- withr::local_tempfile()
+  df$write_ipc_stream(stream_default)
+  df$write_ipc_stream(stream_zstd, compression = "zstd")
+  expect_identical(read_raw(stream_default), read_raw(stream_zstd))
+  expect_equal(
+    pl$read_ipc_stream(stream_default),
+    pl$read_ipc_stream(stream_zstd)
+  )
 })
 
 test_that("sink_ipc: wrong compression", {
@@ -60,7 +128,7 @@ patrick::with_parameters_test_that(
     expect_equal(pl$read_ipc(tmpf), df)
 
     # update with new data
-    df$slice(5, 5)$write_ipc(tmpf)
+    df$slice(5, 5)$write_ipc(tmpf, compression = compression)
     expect_equal(
       pl$read_ipc(tmpf),
       df$slice(5, 5)
@@ -103,7 +171,7 @@ patrick::with_parameters_test_that(
 
     # update with new data
     skip_on_os("windows") # Windows has file locking issues
-    df$slice(5, 5)$write_ipc_stream(tmpf)
+    df$slice(5, 5)$write_ipc_stream(tmpf, compression = compression)
     expect_equal(
       pl$read_ipc_stream(tmpf),
       df$slice(5, 5)

--- a/tests/testthat/test-output-partition.R
+++ b/tests/testthat/test-output-partition.R
@@ -2,11 +2,15 @@ patrick::with_parameters_test_that(
   "partition functions work",
   .cases = {
     lf <- as_polars_lf(mtcars)
+    sink_ipc <- function(...) lf$sink_ipc(..., compression = "zstd")
+    sink_ipc_sorted <- function(...) {
+      lf$sort("am", "cyl")$sink_ipc(..., compression = "zstd")
+    }
 
     tibble::tribble(
       ~.test_name, ~fn, ~reader, ~fn_sorted,
       "sink_csv", lf$sink_csv, pl$read_csv, lf$sort("am", "cyl")$sink_csv,
-      "sink_ipc", lf$sink_ipc, pl$read_ipc, lf$sort("am", "cyl")$sink_ipc,
+      "sink_ipc", sink_ipc, pl$read_ipc, sink_ipc_sorted,
       "sink_ndjson", lf$sink_ndjson, pl$read_ndjson, lf$sort("am", "cyl")$sink_ndjson,
       "sink_parquet", lf$sink_parquet, pl$read_parquet, lf$sort("am", "cyl")$sink_parquet,
     )
@@ -45,6 +49,7 @@ test_that("approximate_bytes_per_file does not support 2^64 - 1 for now", {
   expect_snapshot(
     as_polars_lf(mtcars)$sink_ipc(
       pl$PartitionBy(out_max_size_max, max_rows_per_file = 2^64 - 1),
+      compression = "zstd",
       mkdir = TRUE
     ),
     error = TRUE
@@ -55,11 +60,15 @@ patrick::with_parameters_test_that(
   "deprecated partition functions work",
   .cases = {
     lf <- as_polars_lf(mtcars)
+    sink_ipc <- function(...) lf$sink_ipc(..., compression = "zstd")
+    sink_ipc_sorted <- function(...) {
+      lf$sort("am", "cyl")$sink_ipc(..., compression = "zstd")
+    }
 
     # Only tests sink_ipc for simplicity
     tibble::tribble(
       ~.test_name, ~fn, ~reader, ~fn_sorted,
-      "sink_ipc", lf$sink_ipc, pl$read_ipc, lf$sort("am", "cyl")$sink_ipc,
+      "sink_ipc", sink_ipc, pl$read_ipc, sink_ipc_sorted,
     )
   },
   code = {

--- a/tests/testthat/test-polars_options.R
+++ b/tests/testthat/test-polars_options.R
@@ -126,10 +126,18 @@ patrick::with_parameters_test_that(
     withr::with_options(list(polars.compat_level = level), {
       tmpf <- withr::local_tempfile(fileext = ".arrow")
 
-      expect_snapshot(pl$LazyFrame(x = 1:3)$lazy_sink_ipc(tmpf))
-      expect_snapshot(pl$LazyFrame(x = 1:3)$sink_ipc(tmpf))
-      expect_snapshot(pl$DataFrame(x = 1:3)$write_ipc(tmpf))
-      expect_snapshot(pl$DataFrame(x = 1:3)$write_ipc_stream(tmpf))
+      expect_snapshot(
+        pl$LazyFrame(x = 1:3)$lazy_sink_ipc(tmpf, compression = "zstd")
+      )
+      expect_snapshot(
+        pl$LazyFrame(x = 1:3)$sink_ipc(tmpf, compression = "zstd")
+      )
+      expect_snapshot(
+        pl$DataFrame(x = 1:3)$write_ipc(tmpf, compression = "zstd")
+      )
+      expect_snapshot(
+        pl$DataFrame(x = 1:3)$write_ipc_stream(tmpf, compression = "zstd")
+      )
 
       skip_if_not_installed("nanoarrow")
 


### PR DESCRIPTION
## Summary

- warn when `compression` is omitted from Arrow file output functions while preserving the current `"zstd"` behavior
- keep explicit compression choices warning-free and document the planned `"uncompressed"` default in Polars 2.0
- add warning snapshots and verify that omitted compression produces the same bytes as explicit `"zstd"`
- update unrelated tests and examples to specify compression explicitly

Closes #1572.

## Validation

- `task test-filter FILTER='output-ipc|input-ipc-functions|lazyframe-frame|output-partition|polars_options'` (978 passed, 0 failed, 0 warnings)
- `task test-filter FILTER='output-ipc'` (161 passed, 0 failed, 0 warnings)
- `jarl check .`
- `air format --check .`
- `git diff --check`
