### PR TITLE
feat: prepare single-argument selector APIs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,8 @@
   2.0. Use `pl$lit(...)$implode()` for literal patterns or `pl$col()` for
   column patterns. A shared literal vector can also be passed as
   `list(c(...))`.
+* The `...` arguments of `pl$col()`, `cs$by_name()`, and `cs$by_dtype()`
+  are deprecated. Pass column names or data types as one vector or list.
 
 ## polars 1.15.0
 

--- a/R/as_polars_expr.R
+++ b/R/as_polars_expr.R
@@ -60,7 +60,7 @@
 #' # character
 #' ## as_lit = FALSE (default)
 #' as_polars_expr("a") # Same as `pl$col("a")`
-#' as_polars_expr(c("a", "b")) # Same as `pl$col("a", "b")`
+#' as_polars_expr(c("a", "b")) # Same as `pl$col(c("a", "b"))`
 #'
 #' ## as_lit = TRUE
 #' as_polars_expr(character(0), as_lit = TRUE)
@@ -104,7 +104,7 @@
 #'   as_polars_expr()
 #'
 #' # polars_expr
-#' as_polars_expr(pl$col("a", "b"))
+#' as_polars_expr(pl$col(c("a", "b")))
 #' @export
 as_polars_expr <- function(x, ...) {
   UseMethod("as_polars_expr")
@@ -157,7 +157,7 @@ as_polars_expr.polars_expr <- function(x, ..., structify = deprecated()) {
 #' @export
 as_polars_expr.character <- function(x, ..., as_lit = FALSE) {
   if (isFALSE(as_lit)) {
-    pl$col(!!!x)
+    pl$col(x)
   } else {
     NextMethod()
   }

--- a/R/as_polars_selector.R
+++ b/R/as_polars_selector.R
@@ -15,5 +15,5 @@ as_polars_selector.polars_expr <- function(x, ...) {
 #' @export
 as_polars_selector.character <- function(x, ..., strict = TRUE) {
   # Accept chr vec rather than single string
-  cs__by_name(!!!x, require_all = strict)
+  cs__by_name(x, require_all = strict)
 }

--- a/R/expr-meta.R
+++ b/R/expr-meta.R
@@ -17,7 +17,7 @@ namespace_expr_meta <- function(x) {
 #'
 #' @inherit as_polars_expr return
 #' @examples
-#' e <- pl$col("a", "b")$name$suffix("_foo")
+#' e <- pl$col(c("a", "b"))$name$suffix("_foo")
 #' e$meta$has_multiple_outputs()
 expr_meta_has_multiple_outputs <- function() {
   self$`_rexpr`$meta_has_multiple_outputs() |>

--- a/R/expr-name.R
+++ b/R/expr-name.R
@@ -38,7 +38,7 @@ expr_name_keep <- function() {
 #' dat$select(
 #'   pl$col("mpg"),
 #'   pl$col("mpg")$name$prefix("name_"),
-#'   pl$col("cyl", "drat")$name$prefix("bar_")
+#'   pl$col(c("cyl", "drat"))$name$prefix("bar_")
 #' )
 expr_name_prefix <- function(prefix) {
   self$`_rexpr`$name_prefix(prefix) |>
@@ -58,7 +58,7 @@ expr_name_prefix <- function(prefix) {
 #' dat$select(
 #'   pl$col("mpg"),
 #'   pl$col("mpg")$name$suffix("_foo"),
-#'   pl$col("cyl", "drat")$name$suffix("_bar")
+#'   pl$col(c("cyl", "drat"))$name$suffix("_bar")
 #' )
 expr_name_suffix <- function(suffix) {
   self$`_rexpr`$name_suffix(suffix) |>

--- a/R/functions-as_datatype.R
+++ b/R/functions-as_datatype.R
@@ -261,7 +261,7 @@ pl__duration <- function(
 #' # Pass a schema to specify the datatype of each field in the struct:
 #' struct_schema <- list(int = pl$UInt32, list = pl$List(pl$Float32))
 #' df$select(
-#'   new_struct = pl$struct(pl$col("int", "list"), .schema = struct_schema)
+#'   new_struct = pl$struct(pl$col(c("int", "list")), .schema = struct_schema)
 #' )$unnest("new_struct")
 pl__struct <- function(..., .schema = NULL) {
   wrap({

--- a/R/functions-col.R
+++ b/R/functions-col.R
@@ -2,29 +2,29 @@
 #' Create an expression representing column(s) in a DataFrame
 #'
 #' @inherit as_polars_expr return
-#' @param ... <[`dynamic-dots`][rlang::dyn-dots]>
-#' The name or [data type][DataType] of the column(s) to represent.
-#' Unnamed objects one of the following:
-#' - Single string(s) representing column names
+#' @param names The name(s) or [data type][DataType] of the column(s) to
+#' represent. It accepts one of the following:
+#' - A character vector representing column names
 #'   - Regular expressions starting with `^` and ending with `$` are allowed.
 #'   - Single wildcard `"*"`  has a special meaning: check the examples.
-#' - [Polars DataType(s)][DataType]
+#' - A [Polars DataType][DataType] or list of Polars data types
+#' @param ... <[`dynamic-dots`][rlang::dyn-dots]> Deprecated compatibility
+#' interface for passing multiple names or data types.
 #' @examples
 #' # a single column by a character
 #' pl$col("foo")
 #'
 #' # multiple columns by characters
-#' pl$col("foo", "bar")
+#' pl$col(c("foo", "bar"))
 #'
 #' # multiple columns by polars data types
-#' pl$col(pl$Float64, pl$String)
+#' pl$col(list(pl$Float64, pl$String))
 #'
 #' # Single `"*"` is converted to a wildcard expression
 #' pl$col("*")
 #'
-#' # Character vectors with length > 1 should be used with `!!!`
-#' pl$col(!!!c("foo", "bar"), "baz")
-#' pl$col("foo", !!!c("bar", "baz"))
+#' # The old dynamic-dots interface is deprecated:
+#' pl$col("foo", "bar")
 #'
 #' # there are some special notations for selecting columns
 #' df <- pl$DataFrame(foo = 1:3, bar = 4:6, baz = 7:9)
@@ -35,25 +35,84 @@
 #' ## select multiple columns by a regular expression
 #' ## starts with `^` and ends with `$`
 #' df$select(pl$col("^ba.*$"))
-pl__col <- function(...) {
+pl__col <- function(..., names) {
   wrap({
     check_dots_unnamed()
 
     dots <- list2(...)
+    has_names <- !missing(names)
 
-    if (is_list_of_string(dots)) {
-      if (length(dots) == 1L) {
-        col(dots[[1]])
+    if (has_names && length(dots) > 0L) {
+      abort("Can't combine `names` with positional values in `...`.")
+    }
+
+    if (!has_names && length(dots) >= 2L) {
+      warn_deprecated_selector_dots("pl$col", "names")
+      legacy_names <- dots
+
+      if (is_list_of_string(legacy_names)) {
+        if (length(legacy_names) == 1L) {
+          col(legacy_names[[1L]])
+        } else {
+          cs__by_name(
+            vapply(legacy_names, `[[`, character(1L), 1L),
+            require_all = TRUE,
+            expand_patterns = TRUE
+          )$as_expr()
+        }
+      } else if (is_list_of_polars_dtype(legacy_names)) {
+        cs__by_dtype(legacy_names)$as_expr()
       } else {
-        cs__by_name(!!!dots, require_all = TRUE, expand_patterns = TRUE)$as_expr()
+        abort(c(
+          "Invalid input for `pl$col()`.",
+          `*` = paste0(
+            "`pl$col()` accepts either a single character vector or a list ",
+            "of Polars data types."
+          )
+        ))
       }
-    } else if (is_list_of_polars_dtype(dots)) {
-      cs__by_dtype(!!!dots)$as_expr()
     } else {
-      abort(c(
-        "Invalid input for `pl$col()`.",
-        `*` = "`pl$col()` accepts either single strings or Polars data types."
-      ))
+      selected <- if (has_names) {
+        names
+      } else if (length(dots) == 0L) {
+        warn_deprecated_selector_dots("pl$col", "names", empty = TRUE)
+        character()
+      } else {
+        dots[[1L]]
+      }
+
+      if (is_character(selected)) {
+        if (anyNA(selected)) {
+          abort(c(
+            "Invalid input for `pl$col()`.",
+            `*` = paste0(
+              "`pl$col()` accepts either a single character vector or a list ",
+              "of Polars data types."
+            )
+          ))
+        }
+        if (length(selected) == 1L) {
+          col(selected[[1L]])
+        } else {
+          cs__by_name(
+            selected,
+            require_all = TRUE,
+            expand_patterns = TRUE
+          )$as_expr()
+        }
+      } else if (is_polars_dtype(selected)) {
+        cs__by_dtype(list(selected))$as_expr()
+      } else if (is_list_of_polars_dtype(selected)) {
+        cs__by_dtype(selected)$as_expr()
+      } else {
+        abort(c(
+          "Invalid input for `pl$col()`.",
+          `*` = paste0(
+            "`pl$col()` accepts either a single character vector or a list ",
+            "of Polars data types."
+          )
+        ))
+      }
     }
   })
 }

--- a/R/functions-col.R
+++ b/R/functions-col.R
@@ -18,7 +18,7 @@
 #' pl$col(c("foo", "bar"))
 #'
 #' # multiple columns by polars data types
-#' pl$col(list(pl$Float64, pl$String))
+#' pl$col(c(pl$Float64, pl$String))
 #'
 #' # Single `"*"` is converted to a wildcard expression
 #' pl$col("*")

--- a/R/functions-lazy.R
+++ b/R/functions-lazy.R
@@ -53,7 +53,7 @@ pl__element <- function() {
 #'
 #' df$with_columns(d = pl$coalesce("a", "b", "c", 10))
 #'
-#' df$with_columns(d = pl$coalesce(pl$col("a", "b", "c"), 10))
+#' df$with_columns(d = pl$coalesce(pl$col(c("a", "b", "c")), 10))
 pl__coalesce <- function(...) {
   check_dots_unnamed()
 

--- a/R/lazyframe-frame.R
+++ b/R/lazyframe-frame.R
@@ -1112,7 +1112,7 @@ lazyframe__fill_null <- function(
       if (!is.null(dtypes)) {
         return(
           self$with_columns(
-            pl$col(!!!dtypes)$fill_null(value = value, limit = limit)
+            pl$col(dtypes)$fill_null(value = value, limit = limit)
           ) |>
             wrap()
         )
@@ -2890,7 +2890,7 @@ lazyframe__describe <- function(
 
     # calculate requested metrics in parallel, then collect the result
     df_metrics <- if (length(sort_cols) > 0) {
-      self$with_columns(pl$col(!!!unique(sort_cols))$sort())
+      self$with_columns(pl$col(unique(sort_cols))$sort())
     } else {
       self
     }

--- a/R/output-json.R
+++ b/R/output-json.R
@@ -27,7 +27,7 @@
 #' dat <- as_polars_lf(head(mtcars))
 #' destination <- tempfile()
 #'
-#' dat$select(pl$col("drat", "mpg"))$sink_ndjson(destination)
+#' dat$select(pl$col(c("drat", "mpg")))$sink_ndjson(destination)
 #' jsonlite::stream_in(file(destination))
 lazyframe__sink_ndjson <- function(
   path,
@@ -144,7 +144,7 @@ lazyframe__lazy_sink_ndjson <- function(
 #' dat <- as_polars_df(head(mtcars))
 #' destination <- tempfile()
 #'
-#' dat$select(pl$col("drat", "mpg"))$write_json(destination)
+#' dat$select(pl$col(c("drat", "mpg")))$write_json(destination)
 #' jsonlite::fromJSON(destination)
 dataframe__write_json <- function(file) {
   wrap({
@@ -162,7 +162,7 @@ dataframe__write_json <- function(file) {
 #' dat <- as_polars_df(head(mtcars))
 #' destination <- tempfile()
 #'
-#' dat$select(pl$col("drat", "mpg"))$write_ndjson(destination)
+#' dat$select(pl$col(c("drat", "mpg")))$write_ndjson(destination)
 #' jsonlite::stream_in(file(destination))
 dataframe__write_ndjson <- function(
   file,

--- a/R/selectors.R
+++ b/R/selectors.R
@@ -148,9 +148,14 @@ selector__exclude <- function(...) {
     }
 
     if (length(exclude_dtypes) > 0L) {
-      self - cs__by_dtype(...)
+      self - cs__by_dtype(exclude_dtypes)
     } else {
-      self - cs__by_name(..., require_all = FALSE, expand_patterns = TRUE)
+      self -
+        cs__by_name(
+          as.character(exclude_cols),
+          require_all = FALSE,
+          expand_patterns = TRUE
+        )
     }
   })
 }
@@ -318,7 +323,9 @@ cs__boolean <- function() {
 
 #' Select all columns matching the given dtypes
 #'
-#' @param ... <[`dynamic-dots`][rlang::dyn-dots]> Data types to select.
+#' @param dtypes A Polars data type or list of Polars data types to select.
+#' @param ... <[`dynamic-dots`][rlang::dyn-dots]> Deprecated compatibility
+#' interface for passing multiple data types.
 #'
 #' @inherit cs__empty return seealso
 #' @examples
@@ -329,18 +336,44 @@ cs__boolean <- function() {
 #' )
 #'
 #' # Select all columns with date or string dtypes:
-#' df$select(cs$by_dtype(pl$Date, pl$String))
+#' df$select(cs$by_dtype(list(pl$Date, pl$String)))
 #'
 #' # Select all columns that are not of date or string dtype:
-#' df$select(!cs$by_dtype(pl$Date, pl$String))
+#' df$select(!cs$by_dtype(list(pl$Date, pl$String)))
 #'
 #' # Group by string columns and sum the numeric columns:
 #' df$group_by(cs$string())$agg(cs$numeric()$sum())$sort("other")
-cs__by_dtype <- function(...) {
+cs__by_dtype <- function(..., dtypes) {
   wrap({
     check_dots_unnamed()
-    parse_into_list_of_datatypes(...) |>
-      PlRSelector$by_dtype()
+    has_dtypes <- !missing(dtypes)
+    dots <- list2(...)
+
+    if (has_dtypes && length(dots) > 0L) {
+      abort("Can't combine `dtypes` with positional values in `...`.")
+    }
+
+    if (!has_dtypes && length(dots) >= 2L) {
+      warn_deprecated_selector_dots("cs$by_dtype", "dtypes")
+      legacy_dtypes <- dots
+      parse_into_list_of_datatypes(!!!legacy_dtypes) |>
+        PlRSelector$by_dtype()
+    } else {
+      selected <- if (has_dtypes) {
+        dtypes
+      } else if (length(dots) == 0L) {
+        warn_deprecated_selector_dots("cs$by_dtype", "dtypes", empty = TRUE)
+        list()
+      } else {
+        dots[[1L]]
+      }
+
+      if (is_polars_dtype(selected)) {
+        selected <- list(selected)
+      }
+      parse_list_of_datatypes(selected) |>
+        PlRSelector$by_dtype()
+    }
   })
 }
 
@@ -383,7 +416,9 @@ cs__by_index <- function(indices, ..., require_all = TRUE) {
 
 #' Select all columns matching the given names
 #'
-#' @param ... <[`dynamic-dots`][rlang::dyn-dots]> Column names to select.
+#' @param names A character vector of column names to select.
+#' @param ... <[`dynamic-dots`][rlang::dyn-dots]> Deprecated compatibility
+#' interface for passing multiple column names.
 #' @param require_all Whether to match all names (the default) or any of the names.
 #' @param expand_patterns Whether to expand regex patterns (`^...$`) and
 #'   wildcards (`*`) in names. Default is `FALSE` (treat names as literals).
@@ -399,20 +434,47 @@ cs__by_index <- function(indices, ..., require_all = TRUE) {
 #' )
 #'
 #' # Select columns by name:
-#' df$select(cs$by_name("foo", "bar"))
+#' df$select(cs$by_name(c("foo", "bar")))
 #'
 #' # Match any of the given columns by name:
-#' df$select(cs$by_name("baz", "moose", "foo", "bear", require_all = FALSE))
+#' df$select(cs$by_name(c("baz", "moose", "foo", "bear"), require_all = FALSE))
 #'
 #' # Match all columns except for those given:
-#' df$select(!cs$by_name("foo", "bar"))
-cs__by_name <- function(..., require_all = TRUE, expand_patterns = FALSE) {
+#' df$select(!cs$by_name(c("foo", "bar")))
+cs__by_name <- function(..., names, require_all = TRUE, expand_patterns = FALSE) {
   wrap({
     check_dots_unnamed()
-    names <- list2(...)
-    check_list_of_string(names, arg = "...")
+    has_names <- !missing(names)
+    dots <- list2(...)
 
-    PlRSelector$by_name(as.character(names), require_all, expand_patterns)
+    if (has_names && length(dots) > 0L) {
+      abort("Can't combine `names` with positional values in `...`.")
+    }
+
+    if (!has_names && length(dots) >= 2L) {
+      warn_deprecated_selector_dots("cs$by_name", "names")
+      legacy_names <- dots
+      check_list_of_string(legacy_names, arg = "...")
+      PlRSelector$by_name(
+        vapply(legacy_names, `[[`, character(1L), 1L),
+        require_all,
+        expand_patterns
+      )
+    } else {
+      selected <- if (has_names) {
+        names
+      } else if (length(dots) == 0L) {
+        warn_deprecated_selector_dots("cs$by_name", "names", empty = TRUE)
+        character()
+      } else {
+        dots[[1L]]
+      }
+
+      if (!is_character(selected) || anyNA(selected)) {
+        abort("`names` must be a character vector.")
+      }
+      PlRSelector$by_name(selected, require_all, expand_patterns)
+    }
   })
 }
 
@@ -883,8 +945,8 @@ cs__exclude <- function(...) {
     }
 
     all_selected <- c(
-      cs__by_name(!!!col_names, require_all = FALSE),
-      cs__by_dtype(!!!dtypes),
+      cs__by_name(as.character(col_names), require_all = FALSE),
+      cs__by_dtype(dtypes),
       if (length(regexes) > 0L) {
         cs__matches(sprintf("(%s)", paste0(unlist(regexes), collapse = "|")))
       },

--- a/R/selectors.R
+++ b/R/selectors.R
@@ -336,10 +336,10 @@ cs__boolean <- function() {
 #' )
 #'
 #' # Select all columns with date or string dtypes:
-#' df$select(cs$by_dtype(list(pl$Date, pl$String)))
+#' df$select(cs$by_dtype(c(pl$Date, pl$String)))
 #'
 #' # Select all columns that are not of date or string dtype:
-#' df$select(!cs$by_dtype(list(pl$Date, pl$String)))
+#' df$select(!cs$by_dtype(c(pl$Date, pl$String)))
 #'
 #' # Group by string columns and sum the numeric columns:
 #' df$group_by(cs$string())$agg(cs$numeric()$sum())$sort("other")

--- a/R/utils-deprecation.R
+++ b/R/utils-deprecation.R
@@ -68,3 +68,39 @@ warn_arrow_compression_default <- function(user_env = caller_env(2)) {
     user_env = user_env
   )
 }
+
+warn_deprecated_selector_dots <- function(
+  fn,
+  argument,
+  empty = FALSE,
+  user_env = caller_env(2)
+) {
+  message <- if (empty) {
+    sprintf(
+      "Calling %s without an argument is deprecated as of %s 1.16.0.",
+      format_fn(fn),
+      format_pkg("polars")
+    )
+  } else {
+    sprintf(
+      "Using `...` to supply values to %s is deprecated as of %s 1.16.0.",
+      format_fn(fn),
+      format_pkg("polars")
+    )
+  }
+
+  deprecate_warn(
+    c(
+      `!` = message,
+      i = sprintf(
+        if (empty) {
+          "Pass an explicit empty %s instead."
+        } else {
+          "Pass the values as a single %s argument instead."
+        },
+        format_code(argument)
+      )
+    ),
+    user_env = user_env
+  )
+}

--- a/R/utils-parse-datatype.R
+++ b/R/utils-parse-datatype.R
@@ -12,3 +12,11 @@ parse_into_list_of_datatypes <- function(...) {
       x$`_dt`
     })
 }
+
+parse_list_of_datatypes <- function(dtypes, arg = "dtypes") {
+  if (!is_list_of_polars_dtype(dtypes)) {
+    stop_input_type(dtypes, "a list of polars data types", arg = arg)
+  }
+
+  lapply(dtypes, `[[`, "_dt")
+}

--- a/man/as_polars_expr.Rd
+++ b/man/as_polars_expr.Rd
@@ -92,7 +92,7 @@ a \link[=DataType]{Binary} type scalar. Otherwise, the default method is called.
 # character
 ## as_lit = FALSE (default)
 as_polars_expr("a") # Same as `pl$col("a")`
-as_polars_expr(c("a", "b")) # Same as `pl$col("a", "b")`
+as_polars_expr(c("a", "b")) # Same as `pl$col(c("a", "b"))`
 
 ## as_lit = TRUE
 as_polars_expr(character(0), as_lit = TRUE)
@@ -136,7 +136,7 @@ as_polars_series(1) |>
   as_polars_expr()
 
 # polars_expr
-as_polars_expr(pl$col("a", "b"))
+as_polars_expr(pl$col(c("a", "b")))
 }
 \seealso{
 \itemize{

--- a/man/cs__by_dtype.Rd
+++ b/man/cs__by_dtype.Rd
@@ -26,10 +26,10 @@ df <- pl$DataFrame(
 )
 
 # Select all columns with date or string dtypes:
-df$select(cs$by_dtype(list(pl$Date, pl$String)))
+df$select(cs$by_dtype(c(pl$Date, pl$String)))
 
 # Select all columns that are not of date or string dtype:
-df$select(!cs$by_dtype(list(pl$Date, pl$String)))
+df$select(!cs$by_dtype(c(pl$Date, pl$String)))
 
 # Group by string columns and sum the numeric columns:
 df$group_by(cs$string())$agg(cs$numeric()$sum())$sort("other")

--- a/man/cs__by_dtype.Rd
+++ b/man/cs__by_dtype.Rd
@@ -4,10 +4,13 @@
 \alias{cs__by_dtype}
 \title{Select all columns matching the given dtypes}
 \usage{
-cs__by_dtype(...)
+cs__by_dtype(..., dtypes)
 }
 \arguments{
-\item{...}{<\code{\link[rlang:dyn-dots]{dynamic-dots}}> Data types to select.}
+\item{...}{<\code{\link[rlang:dyn-dots]{dynamic-dots}}> Deprecated compatibility
+interface for passing multiple data types.}
+
+\item{dtypes}{A Polars data type or list of Polars data types to select.}
 }
 \value{
 A Polars \link[=cs]{selector}
@@ -23,10 +26,10 @@ df <- pl$DataFrame(
 )
 
 # Select all columns with date or string dtypes:
-df$select(cs$by_dtype(pl$Date, pl$String))
+df$select(cs$by_dtype(list(pl$Date, pl$String)))
 
 # Select all columns that are not of date or string dtype:
-df$select(!cs$by_dtype(pl$Date, pl$String))
+df$select(!cs$by_dtype(list(pl$Date, pl$String)))
 
 # Group by string columns and sum the numeric columns:
 df$group_by(cs$string())$agg(cs$numeric()$sum())$sort("other")

--- a/man/cs__by_name.Rd
+++ b/man/cs__by_name.Rd
@@ -4,10 +4,13 @@
 \alias{cs__by_name}
 \title{Select all columns matching the given names}
 \usage{
-cs__by_name(..., require_all = TRUE, expand_patterns = FALSE)
+cs__by_name(..., names, require_all = TRUE, expand_patterns = FALSE)
 }
 \arguments{
-\item{...}{<\code{\link[rlang:dyn-dots]{dynamic-dots}}> Column names to select.}
+\item{...}{<\code{\link[rlang:dyn-dots]{dynamic-dots}}> Deprecated compatibility
+interface for passing multiple column names.}
+
+\item{names}{A character vector of column names to select.}
 
 \item{require_all}{Whether to match all names (the default) or any of the names.}
 
@@ -33,13 +36,13 @@ df <- pl$DataFrame(
 )
 
 # Select columns by name:
-df$select(cs$by_name("foo", "bar"))
+df$select(cs$by_name(c("foo", "bar")))
 
 # Match any of the given columns by name:
-df$select(cs$by_name("baz", "moose", "foo", "bear", require_all = FALSE))
+df$select(cs$by_name(c("baz", "moose", "foo", "bear"), require_all = FALSE))
 
 # Match all columns except for those given:
-df$select(!cs$by_name("foo", "bar"))
+df$select(!cs$by_name(c("foo", "bar")))
 }
 \seealso{
 \link{cs} for the documentation on operators supported by selectors.

--- a/man/dataframe__write_json.Rd
+++ b/man/dataframe__write_json.Rd
@@ -22,7 +22,7 @@ requireNamespace("jsonlite", quiet = TRUE)
 dat <- as_polars_df(head(mtcars))
 destination <- tempfile()
 
-dat$select(pl$col("drat", "mpg"))$write_json(destination)
+dat$select(pl$col(c("drat", "mpg")))$write_json(destination)
 jsonlite::fromJSON(destination)
 \dontshow{\}) # examplesIf}
 }

--- a/man/dataframe__write_ndjson.Rd
+++ b/man/dataframe__write_ndjson.Rd
@@ -42,7 +42,7 @@ requireNamespace("jsonlite", quiet = TRUE)
 dat <- as_polars_df(head(mtcars))
 destination <- tempfile()
 
-dat$select(pl$col("drat", "mpg"))$write_ndjson(destination)
+dat$select(pl$col(c("drat", "mpg")))$write_ndjson(destination)
 jsonlite::stream_in(file(destination))
 \dontshow{\}) # examplesIf}
 }

--- a/man/expr_meta_has_multiple_outputs.Rd
+++ b/man/expr_meta_has_multiple_outputs.Rd
@@ -13,6 +13,6 @@ A polars \link{expression}
 Indicate if this expression expands into multiple expressions
 }
 \examples{
-e <- pl$col("a", "b")$name$suffix("_foo")
+e <- pl$col(c("a", "b"))$name$suffix("_foo")
 e$meta$has_multiple_outputs()
 }

--- a/man/expr_name_prefix.Rd
+++ b/man/expr_name_prefix.Rd
@@ -21,7 +21,7 @@ dat <- as_polars_df(mtcars)
 dat$select(
   pl$col("mpg"),
   pl$col("mpg")$name$prefix("name_"),
-  pl$col("cyl", "drat")$name$prefix("bar_")
+  pl$col(c("cyl", "drat"))$name$prefix("bar_")
 )
 }
 \seealso{

--- a/man/expr_name_suffix.Rd
+++ b/man/expr_name_suffix.Rd
@@ -21,7 +21,7 @@ dat <- as_polars_df(mtcars)
 dat$select(
   pl$col("mpg"),
   pl$col("mpg")$name$suffix("_foo"),
-  pl$col("cyl", "drat")$name$suffix("_bar")
+  pl$col(c("cyl", "drat"))$name$suffix("_bar")
 )
 }
 \seealso{

--- a/man/lazyframe__sink_ndjson.Rd
+++ b/man/lazyframe__sink_ndjson.Rd
@@ -147,7 +147,7 @@ requireNamespace("jsonlite", quiet = TRUE)
 dat <- as_polars_lf(head(mtcars))
 destination <- tempfile()
 
-dat$select(pl$col("drat", "mpg"))$sink_ndjson(destination)
+dat$select(pl$col(c("drat", "mpg")))$sink_ndjson(destination)
 jsonlite::stream_in(file(destination))
 \dontshow{\}) # examplesIf}
 }

--- a/man/pl__coalesce.Rd
+++ b/man/pl__coalesce.Rd
@@ -27,5 +27,5 @@ df <- pl$DataFrame(
 
 df$with_columns(d = pl$coalesce("a", "b", "c", 10))
 
-df$with_columns(d = pl$coalesce(pl$col("a", "b", "c"), 10))
+df$with_columns(d = pl$coalesce(pl$col(c("a", "b", "c")), 10))
 }

--- a/man/pl__col.Rd
+++ b/man/pl__col.Rd
@@ -35,7 +35,7 @@ pl$col("foo")
 pl$col(c("foo", "bar"))
 
 # multiple columns by polars data types
-pl$col(list(pl$Float64, pl$String))
+pl$col(c(pl$Float64, pl$String))
 
 # Single `"*"` is converted to a wildcard expression
 pl$col("*")

--- a/man/pl__col.Rd
+++ b/man/pl__col.Rd
@@ -4,19 +4,21 @@
 \alias{pl__col}
 \title{Create an expression representing column(s) in a DataFrame}
 \usage{
-pl__col(...)
+pl__col(..., names)
 }
 \arguments{
-\item{...}{<\code{\link[rlang:dyn-dots]{dynamic-dots}}>
-The name or \link[=DataType]{data type} of the column(s) to represent.
-Unnamed objects one of the following:
+\item{...}{<\code{\link[rlang:dyn-dots]{dynamic-dots}}> Deprecated compatibility
+interface for passing multiple names or data types.}
+
+\item{names}{The name(s) or \link[=DataType]{data type} of the column(s) to
+represent. It accepts one of the following:
 \itemize{
-\item Single string(s) representing column names
+\item A character vector representing column names
 \itemize{
 \item Regular expressions starting with \code{^} and ending with \code{$} are allowed.
 \item Single wildcard \code{"*"}  has a special meaning: check the examples.
 }
-\item \link[=DataType]{Polars DataType(s)}
+\item A \link[=DataType]{Polars DataType} or list of Polars data types
 }}
 }
 \value{
@@ -30,17 +32,16 @@ Create an expression representing column(s) in a DataFrame
 pl$col("foo")
 
 # multiple columns by characters
-pl$col("foo", "bar")
+pl$col(c("foo", "bar"))
 
 # multiple columns by polars data types
-pl$col(pl$Float64, pl$String)
+pl$col(list(pl$Float64, pl$String))
 
 # Single `"*"` is converted to a wildcard expression
 pl$col("*")
 
-# Character vectors with length > 1 should be used with `!!!`
-pl$col(!!!c("foo", "bar"), "baz")
-pl$col("foo", !!!c("bar", "baz"))
+# The old dynamic-dots interface is deprecated:
+pl$col("foo", "bar")
 
 # there are some special notations for selecting columns
 df <- pl$DataFrame(foo = 1:3, bar = 4:6, baz = 7:9)

--- a/man/pl__struct.Rd
+++ b/man/pl__struct.Rd
@@ -43,6 +43,6 @@ df$select(pl$struct(p = "int", q = "bool")$alias("my_struct"))$schema
 # Pass a schema to specify the datatype of each field in the struct:
 struct_schema <- list(int = pl$UInt32, list = pl$List(pl$Float32))
 df$select(
-  new_struct = pl$struct(pl$col("int", "list"), .schema = struct_schema)
+  new_struct = pl$struct(pl$col(c("int", "list")), .schema = struct_schema)
 )$unnest("new_struct")
 }

--- a/tests/testthat/_snaps/functions-col.md
+++ b/tests/testthat/_snaps/functions-col.md
@@ -1,11 +1,11 @@
-# pl$col() works int8, int16
+# pl$col() works character vector
 
     Code
       object
     Output
       cs.by_name('i8', 'i16', require_all=true)
 
-# pl$col() works !!!c(int8, int16), string
+# pl$col() works character vector with three names
 
     Code
       object
@@ -33,7 +33,7 @@
     Output
       cs.matches("^str.*$")
 
-# pl$col() works ^str.*$, i8
+# pl$col() works patterns
 
     Code
       object
@@ -47,19 +47,145 @@
     Output
       cs.by_dtype([Int8])
 
-# pl$col() works pl$Int8, pl$Int16
+# pl$col() works dtype list
 
     Code
       object
     Output
       cs.by_dtype([Int8, Int16])
 
-# pl$col() works !!!list(pl$Int8, pl$Int16)
+# pl$col() input error
 
     Code
-      object
+      pl$col("foo", NA_character_)
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! Using `...` to supply values to `pl$col()` is deprecated as of polars 1.16.0.
+      i Pass the values as a single `names` argument instead.
+    Condition <rlang_error>
+      Error in `pl$col()`:
+      ! Evaluation failed in `$col()`.
+      Caused by error in `pl$col()`:
+      ! Invalid input for `pl$col()`.
+      * `pl$col()` accepts either a single character vector or a list of Polars data types.
+
+---
+
+    Code
+      pl$col("foo", 1)
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! Using `...` to supply values to `pl$col()` is deprecated as of polars 1.16.0.
+      i Pass the values as a single `names` argument instead.
+    Condition <rlang_error>
+      Error in `pl$col()`:
+      ! Evaluation failed in `$col()`.
+      Caused by error in `pl$col()`:
+      ! Invalid input for `pl$col()`.
+      * `pl$col()` accepts either a single character vector or a list of Polars data types.
+
+---
+
+    Code
+      pl$col("foo", pl$Int8)
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! Using `...` to supply values to `pl$col()` is deprecated as of polars 1.16.0.
+      i Pass the values as a single `names` argument instead.
+    Condition <rlang_error>
+      Error in `pl$col()`:
+      ! Evaluation failed in `$col()`.
+      Caused by error in `pl$col()`:
+      ! Invalid input for `pl$col()`.
+      * `pl$col()` accepts either a single character vector or a list of Polars data types.
+
+---
+
+    Code
+      pl$col(pl$Int8, "foo")
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! Using `...` to supply values to `pl$col()` is deprecated as of polars 1.16.0.
+      i Pass the values as a single `names` argument instead.
+    Condition <rlang_error>
+      Error in `pl$col()`:
+      ! Evaluation failed in `$col()`.
+      Caused by error in `pl$col()`:
+      ! Invalid input for `pl$col()`.
+      * `pl$col()` accepts either a single character vector or a list of Polars data types.
+
+# pl$col() dynamic dots are deprecated
+
+    Code
+      pl$col("i8", "i16")
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! Using `...` to supply values to `pl$col()` is deprecated as of polars 1.16.0.
+      i Pass the values as a single `names` argument instead.
     Output
-      cs.by_dtype([Int8, Int16])
+      cs.by_name('i8', 'i16', require_all=true)
+
+---
+
+    Code
+      pl$col(!!!c("i8", "i16"))
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! Using `...` to supply values to `pl$col()` is deprecated as of polars 1.16.0.
+      i Pass the values as a single `names` argument instead.
+    Output
+      cs.by_name('i8', 'i16', require_all=true)
+
+---
+
+    Code
+      pl$col()
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! Calling `pl$col()` without an argument is deprecated as of polars 1.16.0.
+      i Pass an explicit empty `names` instead.
+    Output
+      cs.by_name(require_all=true)
+
+---
+
+    Code
+      pl$col("i16", names = "i8")
+    Condition <rlang_error>
+      Error in `pl$col()`:
+      ! Evaluation failed in `$col()`.
+      Caused by error in `pl$col()`:
+      ! Can't combine `names` with positional values in `...`.
+
+---
+
+    Code
+      pl$col(c("i8", "i16"), "str")
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! Using `...` to supply values to `pl$col()` is deprecated as of polars 1.16.0.
+      i Pass the values as a single `names` argument instead.
+    Condition <rlang_error>
+      Error in `pl$col()`:
+      ! Evaluation failed in `$col()`.
+      Caused by error in `pl$col()`:
+      ! Invalid input for `pl$col()`.
+      * `pl$col()` accepts either a single character vector or a list of Polars data types.
+
+---
+
+    Code
+      pl$col(list(pl$Int8), pl$Int16)
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! Using `...` to supply values to `pl$col()` is deprecated as of polars 1.16.0.
+      i Pass the values as a single `names` argument instead.
+    Condition <rlang_error>
+      Error in `pl$col()`:
+      ! Evaluation failed in `$col()`.
+      Caused by error in `pl$col()`:
+      ! Invalid input for `pl$col()`.
+      * `pl$col()` accepts either a single character vector or a list of Polars data types.
 
 # pl$nth()
 

--- a/tests/testthat/_snaps/functions-col.md
+++ b/tests/testthat/_snaps/functions-col.md
@@ -47,6 +47,13 @@
     Output
       cs.by_dtype([Int8])
 
+# pl$col() works dtype vector
+
+    Code
+      object
+    Output
+      cs.by_dtype([Int8, Int16])
+
 # pl$col() works dtype list
 
     Code

--- a/tests/testthat/_snaps/selectors.md
+++ b/tests/testthat/_snaps/selectors.md
@@ -64,6 +64,110 @@
       x Problematic argument:
       * a = "foo"
 
+# single-argument selector interfaces deprecate dynamic dots
+
+    Code
+      cs$by_name("foo", "bar")
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! Using `...` to supply values to `cs$by_name()` is deprecated as of polars 1.16.0.
+      i Pass the values as a single `names` argument instead.
+    Output
+      cs.by_name('foo', 'bar', require_all=true)
+
+---
+
+    Code
+      cs$by_name(!!!c("foo", "bar"))
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! Using `...` to supply values to `cs$by_name()` is deprecated as of polars 1.16.0.
+      i Pass the values as a single `names` argument instead.
+    Output
+      cs.by_name('foo', 'bar', require_all=true)
+
+---
+
+    Code
+      cs$by_name()
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! Calling `cs$by_name()` without an argument is deprecated as of polars 1.16.0.
+      i Pass an explicit empty `names` instead.
+    Output
+      cs.by_name(require_all=true)
+
+---
+
+    Code
+      cs$by_dtype(pl$Date, pl$String)
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! Using `...` to supply values to `cs$by_dtype()` is deprecated as of polars 1.16.0.
+      i Pass the values as a single `dtypes` argument instead.
+    Output
+      cs.by_dtype([Date, String])
+
+---
+
+    Code
+      cs$by_dtype(!!!list(pl$Date, pl$String))
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! Using `...` to supply values to `cs$by_dtype()` is deprecated as of polars 1.16.0.
+      i Pass the values as a single `dtypes` argument instead.
+    Output
+      cs.by_dtype([Date, String])
+
+---
+
+    Code
+      cs$by_dtype()
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! Calling `cs$by_dtype()` without an argument is deprecated as of polars 1.16.0.
+      i Pass an explicit empty `dtypes` instead.
+    Output
+      cs.by_dtype([])
+
+---
+
+    Code
+      cs$by_name("bar", names = "foo")
+    Condition <rlang_error>
+      Error in `cs$by_name()`:
+      ! Evaluation failed in `$by_name()`.
+      Caused by error in `cs$by_name()`:
+      ! Can't combine `names` with positional values in `...`.
+
+---
+
+    Code
+      cs$by_name(c("foo", "bar"), "baz")
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! Using `...` to supply values to `cs$by_name()` is deprecated as of polars 1.16.0.
+      i Pass the values as a single `names` argument instead.
+    Condition <rlang_error>
+      Error in `cs$by_name()`:
+      ! Evaluation failed in `$by_name()`.
+      Caused by error in `cs$by_name()`:
+      ! `...` must be a list of single strings, not a list.
+
+---
+
+    Code
+      cs$by_dtype(list(pl$Date), pl$String)
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! Using `...` to supply values to `cs$by_dtype()` is deprecated as of polars 1.16.0.
+      i Pass the values as a single `dtypes` argument instead.
+    Condition <rlang_error>
+      Error in `cs$by_dtype()`:
+      ! Evaluation failed in `$by_dtype()`.
+      Caused by error in `cs$by_dtype()`:
+      ! Dynamic dots `...` must be polars data types, got a list
+
 # contains
 
     Code

--- a/tests/testthat/test-as_polars_expr.R
+++ b/tests/testthat/test-as_polars_expr.R
@@ -3,7 +3,7 @@ test_that("x argument can't be missing", {
 })
 
 test_that("as_polars_expr for polars_expr `structify=TRUE`", {
-  expect_deprecated(as_polars_expr(pl$col("a", "b"), structify = TRUE))
+  expect_deprecated(as_polars_expr(pl$col(c("a", "b")), structify = TRUE))
 
   # This feature is deprecated
   local_lifecycle_silence()
@@ -12,16 +12,16 @@ test_that("as_polars_expr for polars_expr `structify=TRUE`", {
     as_polars_expr(x, structify = TRUE)
   }
   expect_equal(as_func(pl$col("a")), pl$col("a"))
-  expect_equal(as_func(pl$col("a", "b")), pl$struct(pl$col("a", "b")))
+  expect_equal(as_func(pl$col(c("a", "b"))), pl$struct(pl$col(c("a", "b"))))
   expect_equal(as_func(pl$col("*")), pl$struct(pl$col("*")))
 })
 
 test_that("as_polars_expr for character `as_lit=FALSE`", {
   invalid_error_message <- r"(Invalid input for `pl\$col\(\)`)"
 
-  expect_equal(as_polars_expr(character()), pl$col())
+  expect_equal(as_polars_expr(character()), pl$col(character()))
   expect_equal(as_polars_expr(c("foo")), pl$col("foo"))
-  expect_equal(as_polars_expr(c("foo", "bar")), pl$col("foo", "bar"))
+  expect_equal(as_polars_expr(c("foo", "bar")), pl$col(c("foo", "bar")))
   expect_error(as_polars_expr(NA_character_), invalid_error_message)
   expect_error(as_polars_expr(c("foo", NA_character_)), invalid_error_message)
 })

--- a/tests/testthat/test-expr-datetime.R
+++ b/tests/testthat/test-expr-datetime.R
@@ -252,7 +252,7 @@ test_that("dt$quarter, month, day", {
   )
 
   expect_equal(
-    df$select(pl$col("quarter", "month", "day")$cast(pl$Float64)),
+    df$select(pl$col(c("quarter", "month", "day"))$cast(pl$Float64)),
     pl$DataFrame(!!!l_exp)
   )
 })
@@ -297,7 +297,7 @@ test_that("hour minute", {
     )
   )
   expect_equal(
-    df$select(pl$col("hour", "minute")$cast(pl$Float64)),
+    df$select(pl$col(c("hour", "minute"))$cast(pl$Float64)),
     pl$DataFrame(!!!l_exp)
   )
 })

--- a/tests/testthat/test-expr-expr.R
+++ b/tests/testthat/test-expr-expr.R
@@ -348,7 +348,7 @@ test_that("col DataType + col(s) + col regex", {
 
   # multiple
   expect_equal(
-    df$select(pl$col(list(pl$Float64, pl$Categorical()))),
+    df$select(pl$col(c(pl$Float64, pl$Categorical()))),
     df
   )
 

--- a/tests/testthat/test-expr-expr.R
+++ b/tests/testthat/test-expr-expr.R
@@ -3,14 +3,14 @@ test_that("map_batches works", {
 
   expect_query_equal(
     .input$select(
-      pl$col("a", "b")$map_batches(\(...) NULL)
+      pl$col(c("a", "b"))$map_batches(\(...) NULL)
     ),
     .data,
     pl$DataFrame(a = NULL, b = NULL)
   )
   expect_query_equal(
     .input$select(
-      pl$col("a", "b")$map_batches(\(x) x$name)
+      pl$col(c("a", "b"))$map_batches(\(x) x$name)
     ),
     .data,
     pl$DataFrame(a = "a", b = "b")
@@ -348,14 +348,14 @@ test_that("col DataType + col(s) + col regex", {
 
   # multiple
   expect_equal(
-    df$select(pl$col(pl$Float64, pl$Categorical())),
+    df$select(pl$col(list(pl$Float64, pl$Categorical()))),
     df
   )
 
   # multiple cols
   selected_cols <- c("Sepal.Length", "Sepal.Width")
   expect_equal(
-    df$select(pl$col(!!!selected_cols)),
+    df$select(pl$col(selected_cols)),
     as_polars_df(iris[, selected_cols])
   )
 
@@ -1569,10 +1569,10 @@ test_that("hash", {
   df <- as_polars_df(iris)
 
   hash_values1 <- df$select(
-    pl$col("Sepal.Width", "Species")$unique()$hash()$implode()
+    pl$col(c("Sepal.Width", "Species"))$unique()$hash()$implode()
   )
   hash_values2 <- df$select(
-    pl$col("Sepal.Width", "Species")$unique()$hash(1, 2, 3, 4)$implode()
+    pl$col(c("Sepal.Width", "Species"))$unique()$hash(1, 2, 3, 4)$implode()
   )
 
   expect_false(

--- a/tests/testthat/test-expr-meta.R
+++ b/tests/testthat/test-expr-meta.R
@@ -74,7 +74,7 @@ test_that("meta$undo_aliases", {
 
 test_that("meta$has_multiple_outputs", {
   e1 <- pl$col("alice")
-  e2 <- pl$col("alice", "bob")
+  e2 <- pl$col(c("alice", "bob"))
 
   expect_false(e1$meta$has_multiple_outputs())
   expect_true(e2$meta$has_multiple_outputs())

--- a/tests/testthat/test-functions-as_datatype.R
+++ b/tests/testthat/test-functions-as_datatype.R
@@ -173,7 +173,7 @@ test_that("pl$struct()", {
   struct_schema <- list(int = pl$UInt32, list = pl$List(pl$Float32))
   expect_equal(
     df$select(
-      my_struct = pl$struct(pl$col("int", "list"), .schema = struct_schema)
+      my_struct = pl$struct(pl$col(c("int", "list")), .schema = struct_schema)
     )$unnest("my_struct"),
     df$select("int", "list")$cast(int = pl$UInt32, list = pl$List(pl$Float32))
   )

--- a/tests/testthat/test-functions-col.R
+++ b/tests/testthat/test-functions-col.R
@@ -3,15 +3,14 @@ patrick::with_parameters_test_that(
   .cases = {
     tibble::tribble(
       ~.test_name, ~object, ~expected_columns,
-      "int8, int16", pl$col("i8", "i16"), c("i8", "i16"),
-      "!!!c(int8, int16), string", pl$col(!!!c("i8", "i16"), "str"), c("i8", "i16", "str"),
+      "character vector", pl$col(c("i8", "i16")), c("i8", "i16"),
+      "character vector with three names", pl$col(c("i8", "i16", "str")), c("i8", "i16", "str"),
       "wildcard", pl$col("*"), c("i8", "i16", "i32", "str", "struct"),
       "str", pl$col("str"), c("str"),
       "^str.*$", pl$col("^str.*$"), c("str", "struct"),
-      "^str.*$, i8", pl$col("^str.*$", "i8"), c("i8", "str", "struct"),
+      "patterns", pl$col(c("^str.*$", "i8")), c("i8", "str", "struct"),
       "pl$Int8", pl$col(pl$Int8), c("i8"),
-      "pl$Int8, pl$Int16", pl$col(pl$Int8, pl$Int16), c("i8", "i16"),
-      "!!!list(pl$Int8, pl$Int16)", pl$col(!!!list(pl$Int8, pl$Int16)), c("i8", "i16"),
+      "dtype list", pl$col(list(pl$Int8, pl$Int16)), c("i8", "i16"),
     )
   },
   code = {
@@ -29,16 +28,41 @@ patrick::with_parameters_test_that(
 )
 
 test_that("pl$col() input error", {
+  local_lifecycle_warnings()
   invalid_error_message <- r"(Invalid input for `pl\$col\(\)`)"
 
   expect_error(pl$col(NA_character_), invalid_error_message)
-  expect_error(pl$col("foo", NA_character_), invalid_error_message)
-  expect_error(pl$col("foo", 1), invalid_error_message)
+  expect_snapshot(pl$col("foo", NA_character_), error = TRUE, cnd_class = TRUE)
+  expect_snapshot(pl$col("foo", 1), error = TRUE, cnd_class = TRUE)
   expect_error(pl$col(1), invalid_error_message)
   expect_error(pl$col(list("foo")), invalid_error_message)
-  expect_error(pl$col("foo", pl$Int8), invalid_error_message)
-  expect_error(pl$col(pl$Int8, "foo"), invalid_error_message)
+  expect_snapshot(pl$col("foo", pl$Int8), error = TRUE, cnd_class = TRUE)
+  expect_snapshot(pl$col(pl$Int8, "foo"), error = TRUE, cnd_class = TRUE)
   expect_error(pl$col(foo = "bar"), "Arguments in `...` must be passed by position, not name")
+})
+
+test_that("pl$col() dynamic dots are deprecated", {
+  local_lifecycle_warnings()
+  expect_snapshot(pl$col("i8", "i16"), cnd_class = TRUE)
+  expect_snapshot(pl$col(!!!c("i8", "i16")), cnd_class = TRUE)
+  expect_snapshot(pl$col(), cnd_class = TRUE)
+  expect_snapshot(pl$col("i16", names = "i8"), error = TRUE, cnd_class = TRUE)
+  expect_snapshot(pl$col(c("i8", "i16"), "str"), error = TRUE, cnd_class = TRUE)
+  expect_snapshot(pl$col(list(pl$Int8), pl$Int16), error = TRUE, cnd_class = TRUE)
+
+  expect_silent(pl$col(names = c("i8", "i16")))
+  expect_silent(pl$col(character()))
+  expect_silent(pl$col(list()))
+  expect_silent(pl$col(pl$Int8))
+
+  df <- pl$DataFrame(i8 = 1:2, i16 = 3:4)
+  local_lifecycle_silence()
+  old_columns <- df$select(pl$col("i8", "i16"))$columns
+  new_columns <- df$select(pl$col(c("i8", "i16")))$columns
+  expect_identical(old_columns, new_columns)
+  old_empty <- df$select(pl$col())$columns
+  new_empty <- df$select(pl$col(character()))$columns
+  expect_identical(old_empty, new_empty)
 })
 
 test_that("pl$nth()", {

--- a/tests/testthat/test-functions-col.R
+++ b/tests/testthat/test-functions-col.R
@@ -10,6 +10,7 @@ patrick::with_parameters_test_that(
       "^str.*$", pl$col("^str.*$"), c("str", "struct"),
       "patterns", pl$col(c("^str.*$", "i8")), c("i8", "str", "struct"),
       "pl$Int8", pl$col(pl$Int8), c("i8"),
+      "dtype vector", pl$col(c(pl$Int8, pl$Int16)), c("i8", "i16"),
       "dtype list", pl$col(list(pl$Int8, pl$Int16)), c("i8", "i16"),
     )
   },

--- a/tests/testthat/test-functions-lazy.R
+++ b/tests/testthat/test-functions-lazy.R
@@ -10,7 +10,7 @@ test_that("pl$coalesce()", {
     pl$DataFrame(a = c(1, 2, 3, 10))
   )
   expect_equal(
-    df$select(pl$coalesce(pl$col("a", "b", "c"), 10)),
+    df$select(pl$coalesce(pl$col(c("a", "b", "c")), 10)),
     pl$DataFrame(a = c(1, 2, 3, 10))
   )
   expect_error(

--- a/tests/testthat/test-lazyframe-frame.R
+++ b/tests/testthat/test-lazyframe-frame.R
@@ -465,7 +465,7 @@ patrick::with_parameters_test_that(
       ~.test_name, ~value,
       "NULL", NULL,
       "list of strings", list("bar", "ham"),
-      "expr", pl$col("bar", "ham")
+      "expr", pl$col(c("bar", "ham"))
     )
   },
   code = {
@@ -1131,7 +1131,7 @@ test_that("unnest", {
   )
 
   expect_query_equal(
-    .input$unnest(pl$col("first_struct", "second_struct")),
+    .input$unnest(pl$col(c("first_struct", "second_struct"))),
     .input = df2,
     df
   )
@@ -1157,7 +1157,7 @@ test_that("unnest", {
     .input$unnest("first_struct"),
     .input = df2,
     df$select(
-      pl$col("a", "b", "c"),
+      pl$col(c("a", "b", "c")),
       pl$struct(c("d", "e", "f"))$alias("second_struct")
     )
   )

--- a/tests/testthat/test-selectors.R
+++ b/tests/testthat/test-selectors.R
@@ -158,11 +158,11 @@ test_that("by_dtype", {
   )
 
   expect_named(
-    df$select(cs$by_dtype(list(pl$Date, pl$String))),
+    df$select(cs$by_dtype(c(pl$Date, pl$String))),
     c("dt", "other")
   )
   expect_named(
-    df$select(!cs$by_dtype(list(pl$Date, pl$String))),
+    df$select(!cs$by_dtype(c(pl$Date, pl$String))),
     "value"
   )
   expect_snapshot(

--- a/tests/testthat/test-selectors.R
+++ b/tests/testthat/test-selectors.R
@@ -158,11 +158,11 @@ test_that("by_dtype", {
   )
 
   expect_named(
-    df$select(cs$by_dtype(pl$Date, pl$String)),
+    df$select(cs$by_dtype(list(pl$Date, pl$String))),
     c("dt", "other")
   )
   expect_named(
-    df$select(!cs$by_dtype(pl$Date, pl$String)),
+    df$select(!cs$by_dtype(list(pl$Date, pl$String))),
     "value"
   )
   expect_snapshot(
@@ -188,17 +188,45 @@ test_that("by_name", {
   )
 
   expect_equal(
-    df$select(cs$by_name("foo", "bar")),
+    df$select(cs$by_name(c("foo", "bar"))),
     df$select("foo", "bar")
   )
   expect_equal(
-    df$select(cs$by_name("baz", "moose", "foo", "bear", require_all = FALSE)),
+    df$select(cs$by_name(c("baz", "moose", "foo", "bear"), require_all = FALSE)),
     df$select("baz", "foo")
   )
   expect_snapshot(
     df$select(cs$by_name(a = "foo")),
     error = TRUE
   )
+})
+
+test_that("single-argument selector interfaces deprecate dynamic dots", {
+  local_lifecycle_warnings()
+  expect_snapshot(cs$by_name("foo", "bar"), cnd_class = TRUE)
+  expect_snapshot(cs$by_name(!!!c("foo", "bar")), cnd_class = TRUE)
+  expect_snapshot(cs$by_name(), cnd_class = TRUE)
+  expect_snapshot(cs$by_dtype(pl$Date, pl$String), cnd_class = TRUE)
+  expect_snapshot(cs$by_dtype(!!!list(pl$Date, pl$String)), cnd_class = TRUE)
+  expect_snapshot(cs$by_dtype(), cnd_class = TRUE)
+  expect_snapshot(cs$by_name("bar", names = "foo"), error = TRUE, cnd_class = TRUE)
+  expect_snapshot(cs$by_name(c("foo", "bar"), "baz"), error = TRUE, cnd_class = TRUE)
+  expect_snapshot(cs$by_dtype(list(pl$Date), pl$String), error = TRUE, cnd_class = TRUE)
+
+  expect_silent(cs$by_name(names = c("foo", "bar")))
+  expect_silent(cs$by_name(character()))
+  expect_silent(cs$by_name("foo"))
+  expect_silent(cs$by_dtype(dtypes = list(pl$Date, pl$String)))
+  expect_silent(cs$by_dtype(list()))
+  expect_silent(cs$by_dtype(pl$Date))
+
+  local_lifecycle_silence()
+  old_names <- cs$by_name("foo", "bar")
+  new_names <- cs$by_name(c("foo", "bar"))
+  old_dtypes <- cs$by_dtype(pl$Date, pl$String)
+  new_dtypes <- cs$by_dtype(list(pl$Date, pl$String))
+  expect_equal(new_names, old_names, ignore_attr = TRUE)
+  expect_equal(new_dtypes, old_dtypes, ignore_attr = TRUE)
 })
 
 test_that("categorical", {

--- a/tests/testthat/test-utils-parse-expr.R
+++ b/tests/testthat/test-utils-parse-expr.R
@@ -31,14 +31,14 @@ test_that("parse_into_selector works", {
   expect_snapshot(parse_into_selector(NA_character_), error = TRUE)
   expect_equal(
     parse_into_selector(character()),
-    cs$by_name(require_all = TRUE)
+    cs$by_name(character(), require_all = TRUE)
   )
   expect_snapshot(parse_into_selector(integer()), error = TRUE)
 
   # Including selector and expr
   expect_equal(
     parse_into_selector(c("foo", "bar"), cs$numeric(), pl$col("baz")),
-    cs$by_name("foo", "bar", require_all = TRUE) |
+    cs$by_name(c("foo", "bar"), require_all = TRUE) |
       cs$numeric() |
       cs$by_name("baz", require_all = TRUE)
   )

--- a/vignettes/polars.Rmd
+++ b/vignettes/polars.Rmd
@@ -248,7 +248,7 @@ dat$filter(pl$col("cyl") == 6)
 
 dat$filter(pl$col("cyl") == 6 & pl$col("am") == 1)
 
-dat$select(pl$col("mpg", "hp"))
+dat$select(pl$col(c("mpg", "hp")))
 ```
 
 Of course, we can chain those methods to create a pipeline:
@@ -257,7 +257,7 @@ Of course, we can chain those methods to create a pipeline:
 dat$filter(
   pl$col("cyl") == 6
 )$select(
-  pl$col("mpg", "hp", "cyl")
+  pl$col(c("mpg", "hp", "cyl"))
 )
 ```
 
@@ -284,7 +284,7 @@ For what it's worth, the previous query could have been written more concisely a
 
 ```{r}
 dat$with_columns(
-  pl$col("mpg", "hp")$sum()$over("cyl")$name$prefix("sum_")
+  pl$col(c("mpg", "hp"))$sum()$over("cyl")$name$prefix("sum_")
 )
 ```
 
@@ -294,7 +294,7 @@ by groups instead of modifying them. We need simply invoke the `$group_by()` and
 
 ```{r}
 dat$group_by("cyl", .maintain_order = TRUE)$agg(
-  pl$col("mpg", "hp")$sum()
+  pl$col(c("mpg", "hp"))$sum()
 )
 ```
 
@@ -418,7 +418,7 @@ LazyFrame.
 subset_query <- ldat$filter(
   pl$col("cyl") == 6
 )$select(
-  pl$col("mpg", "hp", "cyl")
+  pl$col(c("mpg", "hp", "cyl"))
 )
 
 subset_query
@@ -483,7 +483,7 @@ aq$filter(
 )$group_by(
   "Month"
 )$agg(
-  pl$col("Ozone", "Temp")$mean()
+  pl$col(c("Ozone", "Temp"))$mean()
 )$collect()
 ```
 


### PR DESCRIPTION
## Summary

- accept column names and data types as a single vector or list in `pl$col()`, `cs$by_name()`, and `cs$by_dtype()`
- deprecate the legacy multi-value dynamic-dots forms while preserving their behavior through R Polars 1.16
- preserve leading `!!!` compatibility with a transitional 1.16 signature and keep no-argument empty selections with a migration warning
- update internal callers, documentation, examples, NEWS, and warning snapshots to use the future-compatible forms

## Testing

- `task test-filter FILTER="functions-col|selectors"` (137 passed)
- related regression filter covering expression, lazy-frame, datatype, and parsing paths (1449 passed)
- `task test-file FILE=tests/testthat/test-utils-parse-expr.R` (11 passed)
- `air format --check .`
- `jarl check .`

All task tests reused the release Rust library. No pkgload or debug build was used.

Closes #1480