### PR TITLE
feat: deprecate `<expr>$agg_groups()`, `<series>$cat$is_local()`, `<series>$cat$uses_lexical_ordering()`, and `<Enum>$union()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,12 @@
   `list(c(...))`.
 * The `...` arguments of `pl$col()`, `cs$by_name()`, and `cs$by_dtype()`
   are deprecated. Pass column names or data types as one vector or list.
+* `<expr>$agg_groups()`, `<series>$cat$is_local()`, and
+  `<series>$cat$uses_lexical_ordering()` are deprecated. Use the documented
+  row-index aggregation pattern for `agg_groups()`; categoricals no longer
+  have a local scope and are always ordered lexically.
+* `<Enum>$union()` is deprecated. Construct an Enum explicitly from the
+  combined categories instead.
 
 ## polars 1.15.0
 

--- a/R/datatypes-s3-base.R
+++ b/R/datatypes-s3-base.R
@@ -13,6 +13,20 @@
           )
         }
 
+        deprecate_warn(
+          c(
+            `!` = sprintf(
+              "%s is deprecated as of %s 1.16.0.",
+              format_fn("<Enum>$union"),
+              format_pkg("polars")
+            ),
+            i = sprintf(
+              "Use %s instead.",
+              format_code("pl$Enum(unique(c(lhs$categories, rhs$categories)))")
+            )
+          )
+        )
+
         PlRDataType$new_enum(
           as_polars_series(unique(c(self$categories, other$categories)), name = "category")$`_s`
         )

--- a/R/expr-expr.R
+++ b/R/expr-expr.R
@@ -1429,6 +1429,12 @@ expr__cumulative_eval <- function(expr, ..., min_samples = 1) {
 
 #' Get the group indexes of the group by operation
 #'
+#' `r lifecycle::badge("deprecated")`
+#'
+#' `agg_groups()` is deprecated as of polars 1.16.0. Use
+#' `df$with_row_index()$group_by(..., .maintain_order = TRUE)$agg(pl$col("index"))`
+#' instead.
+#'
 #' Should be used in aggregation context only.
 #' @inherit as_polars_expr return
 #' @examples
@@ -1437,8 +1443,26 @@ expr__cumulative_eval <- function(expr, ..., min_samples = 1) {
 #'   value = c(94, 95, 96, 97, 97, 99)
 #' )
 #'
-#' df$group_by("group", maintain_order = TRUE)$agg(pl$col("value")$agg_groups())
+#' df$group_by("group", .maintain_order = TRUE)$agg(pl$col("value")$agg_groups())
+#'
+#' # Recommended approach
+#' df$with_row_index()$group_by("group", .maintain_order = TRUE)$agg(pl$col("index"))
 expr__agg_groups <- function() {
+  deprecate_warn(
+    c(
+      `!` = sprintf(
+        "%s is deprecated as of %s 1.16.0.",
+        format_fn("agg_groups"),
+        format_pkg("polars")
+      ),
+      i = sprintf(
+        "Use %s instead.",
+        format_code(
+          'df$with_row_index()$group_by(..., .maintain_order = TRUE)$agg(pl$col("index"))'
+        )
+      )
+    )
+  )
   self$`_rexpr`$agg_groups() |>
     wrap()
 }

--- a/R/series-categorical.R
+++ b/R/series-categorical.R
@@ -14,6 +14,16 @@ namespace_series_cat <- function(x) {
 }
 
 series_cat_is_local <- function() {
+  deprecate_warn(
+    c(
+      `!` = sprintf(
+        "%s is deprecated as of %s 1.16.0.",
+        format_fn("cat$is_local"),
+        format_pkg("polars")
+      ),
+      i = "Categoricals no longer have a local scope."
+    )
+  )
   self$`_s`$cat_is_local() |>
     wrap()
 }
@@ -36,6 +46,16 @@ series_cat_to_local <- function() {
 
 # nolint start: object_length_linter
 series_cat_uses_lexical_ordering <- function() {
+  deprecate_warn(
+    c(
+      `!` = sprintf(
+        "%s is deprecated as of %s 1.16.0.",
+        format_fn("cat$uses_lexical_ordering"),
+        format_pkg("polars")
+      ),
+      i = "Categoricals are now always ordered lexically."
+    )
+  )
   self$`_s`$cat_uses_lexical_ordering() |>
     wrap()
 }

--- a/man/expr__agg_groups.Rd
+++ b/man/expr__agg_groups.Rd
@@ -10,6 +10,13 @@ expr__agg_groups()
 A polars \link{expression}
 }
 \description{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
+}
+\details{
+\code{agg_groups()} is deprecated as of polars 1.16.0. Use
+\code{df$with_row_index()$group_by(..., .maintain_order = TRUE)$agg(pl$col("index"))}
+instead.
+
 Should be used in aggregation context only.
 }
 \examples{
@@ -18,5 +25,8 @@ df <- pl$DataFrame(
   value = c(94, 95, 96, 97, 97, 99)
 )
 
-df$group_by("group", maintain_order = TRUE)$agg(pl$col("value")$agg_groups())
+df$group_by("group", .maintain_order = TRUE)$agg(pl$col("value")$agg_groups())
+
+# Recommended approach
+df$with_row_index()$group_by("group", .maintain_order = TRUE)$agg(pl$col("index"))
 }

--- a/tests/testthat/_snaps/datatypes-classes.md
+++ b/tests/testthat/_snaps/datatypes-classes.md
@@ -541,6 +541,17 @@
       Caused by error in `pl$Enum()`:
       ! Enum categories must be unique, found duplicated: b, a
 
+# Enum union is deprecated
+
+    Code
+      lhs$union(rhs)
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! `<Enum>$union()` is deprecated as of polars 1.16.0.
+      i Use `pl$Enum(unique(c(lhs$categories, rhs$categories)))` instead.
+    Output
+      Enum(categories=c('b', 'd', 'a'))
+
 # Decimal deprecation
 
     Code

--- a/tests/testthat/_snaps/expr-expr.md
+++ b/tests/testthat/_snaps/expr-expr.md
@@ -160,6 +160,25 @@
       Caused by error:
       ! type bool is incompatible with expected type str
 
+# agg_groups is deprecated
+
+    Code
+      df$group_by("group", .maintain_order = TRUE)$agg(pl$col("value")$agg_groups())
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! `agg_groups()` is deprecated as of polars 1.16.0.
+      i Use `df$with_row_index()$group_by(..., .maintain_order = TRUE)$agg(pl$col("index"))` instead.
+    Output
+      shape: (2, 2)
+      ┌───────┬───────────┐
+      │ group ┆ value     │
+      │ ---   ┆ ---       │
+      │ str   ┆ list[u32] │
+      ╞═══════╪═══════════╡
+      │ one   ┆ [0, 1, 2] │
+      │ two   ┆ [3, 4, 5] │
+      └───────┴───────────┘
+
 # truncate
 
     Code

--- a/tests/testthat/_snaps/series-categorical.md
+++ b/tests/testthat/_snaps/series-categorical.md
@@ -1,0 +1,22 @@
+# categorical helper methods are deprecated
+
+    Code
+      series$cat$is_local()
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! `cat$is_local()` is deprecated as of polars 1.16.0.
+      i Categoricals no longer have a local scope.
+    Output
+      [1] FALSE
+
+---
+
+    Code
+      series$cat$uses_lexical_ordering()
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! `cat$uses_lexical_ordering()` is deprecated as of polars 1.16.0.
+      i Categoricals are now always ordered lexically.
+    Output
+      [1] TRUE
+

--- a/tests/testthat/test-datatypes-classes.R
+++ b/tests/testthat/test-datatypes-classes.R
@@ -73,10 +73,23 @@ patrick::with_parameters_test_that(
     )
   },
   code = {
-    expect_equal(pl$Enum(c("b", "d"))$union(input), expected_output)
-    expect_equal(input$union(input), input)
+    expect_equal(suppressWarnings(pl$Enum(c("b", "d"))$union(input)), expected_output)
+    expect_equal(suppressWarnings(input$union(input)), input)
   }
 )
+
+test_that("Enum union is deprecated", {
+  local_lifecycle_warnings()
+  lhs <- pl$Enum(c("b", "d"))
+  rhs <- pl$Enum(c("d", "a"))
+
+  expect_snapshot(lhs$union(rhs), cnd_class = TRUE)
+
+  old <- suppressWarnings(lhs$union(rhs))
+  expect_no_condition(pl$Enum(unique(c(lhs$categories, rhs$categories))))
+  recommended <- pl$Enum(unique(c(lhs$categories, rhs$categories)))
+  expect_equal(old, recommended)
+})
 
 test_that("Enum union error", {
   expect_error(pl$Enum("a")$union(1), "`other` must be a polars data type, not the number 1")

--- a/tests/testthat/test-expr-expr.R
+++ b/tests/testthat/test-expr-expr.R
@@ -764,6 +764,32 @@ test_that("Expr_append", {
   )
 })
 
+test_that("agg_groups is deprecated", {
+  local_lifecycle_warnings()
+  df <- pl$DataFrame(
+    group = rep(c("one", "two"), each = 3),
+    value = c(94, 95, 96, 97, 97, 99)
+  )
+
+  expect_snapshot(
+    df$group_by("group", .maintain_order = TRUE)$agg(pl$col("value")$agg_groups()),
+    cnd_class = TRUE
+  )
+
+  old <- suppressWarnings(
+    df$group_by("group", .maintain_order = TRUE)$agg(pl$col("value")$agg_groups())
+  )
+  expect_no_condition(
+    df$with_row_index()$group_by("group", .maintain_order = TRUE)$agg(pl$col("index"))
+  )
+  recommended <- df$with_row_index()$group_by("group", .maintain_order = TRUE)$agg(pl$col("index"))
+  expect_equal(old$get_column("group"), recommended$get_column("group"))
+  expect_equal(
+    unclass(old$get_column("value")$to_r_vector()),
+    unclass(recommended$get_column("index")$to_r_vector())
+  )
+})
+
 test_that("rechunk() works but is deprecated", {
   expect_deprecated(pl$col("a")$rechunk())
 

--- a/tests/testthat/test-series-categorical.R
+++ b/tests/testthat/test-series-categorical.R
@@ -1,0 +1,10 @@
+test_that("categorical helper methods are deprecated", {
+  local_lifecycle_warnings()
+  series <- as_polars_series(c("a", "b", "a"))$cast(pl$Categorical())
+
+  expect_snapshot(series$cat$is_local(), cnd_class = TRUE)
+  expect_snapshot(series$cat$uses_lexical_ordering(), cnd_class = TRUE)
+
+  expect_false(suppressWarnings(series$cat$is_local()))
+  expect_true(suppressWarnings(series$cat$uses_lexical_ordering()))
+})


### PR DESCRIPTION
## Summary

- deprecate Expr agg_groups and document the row-index aggregation replacement
- deprecate categorical locality and ordering helpers while preserving their current results
- deprecate Enum union and document explicit Enum construction
- add lifecycle warning snapshots and migration-focused regression tests

## Validation

- task build-documents
- task --force test-filter FILTER=expr-expr\|series-categorical\|datatypes-classes (472 passed)
- task --force test-file FILE=tests/testthat/test-datatypes-classes.R
- task format-r
- air format --check .
- jarl check .