### PR TITLE
feat: deprecate additional hash seeds

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,8 @@
   `list(c(...))`.
 * The `...` arguments of `pl$col()`, `cs$by_name()`, and `cs$by_dtype()`
   are deprecated. Pass column names or data types as one vector or list.
+* The `seed_1`, `seed_2`, and `seed_3` arguments of `<expr>$hash()` and
+  `<dataframe>$hash_rows()` are deprecated. Use `seed` instead.
 
 ## polars 1.15.0
 

--- a/R/dataframe-frame.R
+++ b/R/dataframe-frame.R
@@ -2128,9 +2128,8 @@ dataframe__group_by_dynamic <- function(
 #' The hash value is of type [UInt64][polars_dtype].
 #'
 #' @param seed Random seed parameter. Defaults to 0.
-#' @param seed_1 Random seed parameter. Defaults to `seed` if not set.
-#' @param seed_2 Random seed parameter. Defaults to `seed` if not set.
-#' @param seed_3 Random seed parameter. Defaults to `seed` if not set.
+#' @param seed_1,seed_2,seed_3 `r lifecycle::badge("deprecated")` Random seed
+#' parameters. Defaults to `seed` if not set.
 #'
 #' @details
 #' This implementation does not guarantee stable results across different
@@ -2143,18 +2142,42 @@ dataframe__group_by_dynamic <- function(
 #'   ham = c("a", "b", NA, "d")
 #' )
 #' df$hash_rows(seed = 42)
-dataframe__hash_rows <- function(seed = 0, seed_1 = NULL, seed_2 = NULL, seed_3 = NULL) {
+dataframe__hash_rows <- function(
+  seed = 0,
+  seed_1 = deprecated(),
+  seed_2 = deprecated(),
+  seed_3 = deprecated()
+) {
+  if (is_present(seed_1) || is_present(seed_2) || is_present(seed_3)) {
+    warn_deprecated_hash_seeds("<dataframe>$hash_rows")
+  }
+
   wrap({
     check_number_whole(seed, min = 0)
-    check_number_whole(seed_1, min = 0, allow_null = TRUE)
-    check_number_whole(seed_2, min = 0, allow_null = TRUE)
-    check_number_whole(seed_3, min = 0, allow_null = TRUE)
+    seed_1 <- if (is_present(seed_1)) {
+      check_number_whole(seed_1, min = 0, allow_null = TRUE)
+      seed_1 %||% seed
+    } else {
+      seed
+    }
+    seed_2 <- if (is_present(seed_2)) {
+      check_number_whole(seed_2, min = 0, allow_null = TRUE)
+      seed_2 %||% seed
+    } else {
+      seed
+    }
+    seed_3 <- if (is_present(seed_3)) {
+      check_number_whole(seed_3, min = 0, allow_null = TRUE)
+      seed_3 %||% seed
+    } else {
+      seed
+    }
 
     self$`_df`$hash_rows(
       seed,
-      seed_1 %||% seed,
-      seed_2 %||% seed,
-      seed_3 %||% seed
+      seed_1,
+      seed_2,
+      seed_3
     )
   })
 }

--- a/R/expr-expr.R
+++ b/R/expr-expr.R
@@ -2039,8 +2039,8 @@ expr__log1p <- function() {
 #' Hash elements
 #'
 #' @param seed Integer, random seed parameter. Defaults to 0.
-#' @param seed_1,seed_2,seed_3 Integer, random seed parameters. Default to
-#' `seed` if not set.
+#' @param seed_1,seed_2,seed_3 `r lifecycle::badge("deprecated")` Integer,
+#' random seed parameters. Default to `seed` if not set.
 #' @inherit as_polars_expr return
 #'
 #' @details
@@ -2050,12 +2050,21 @@ expr__log1p <- function() {
 #'
 #' @examples
 #' df <- pl$DataFrame(a = c(1, 2, NA), b = c("x", NA, "z"))
-#' df$with_columns(pl$all()$hash(10, 20, 30, 40))
-expr__hash <- function(seed = 0, seed_1 = NULL, seed_2 = NULL, seed_3 = NULL) {
+#' df$with_columns(pl$all()$hash(seed = 10))
+expr__hash <- function(
+  seed = 0,
+  seed_1 = deprecated(),
+  seed_2 = deprecated(),
+  seed_3 = deprecated()
+) {
+  if (is_present(seed_1) || is_present(seed_2) || is_present(seed_3)) {
+    warn_deprecated_hash_seeds("<expr>$hash")
+  }
+
   wrap({
-    seed_1 <- seed_1 %||% seed
-    seed_2 <- seed_2 %||% seed
-    seed_3 <- seed_3 %||% seed
+    seed_1 <- if (is_present(seed_1)) seed_1 %||% seed else seed
+    seed_2 <- if (is_present(seed_2)) seed_2 %||% seed else seed
+    seed_3 <- if (is_present(seed_3)) seed_3 %||% seed else seed
     self$`_rexpr`$hash(seed, seed_1, seed_2, seed_3)
   })
 }

--- a/R/utils-deprecation.R
+++ b/R/utils-deprecation.R
@@ -69,6 +69,20 @@ warn_arrow_compression_default <- function(user_env = caller_env(2)) {
   )
 }
 
+warn_deprecated_hash_seeds <- function(fn, user_env = caller_env(2)) {
+  deprecate_warn(
+    c(
+      `!` = sprintf(
+        "The `seed_1`, `seed_2`, and `seed_3` arguments of %s are deprecated as of %s 1.16.0.",
+        format_fn(fn),
+        format_pkg("polars")
+      ),
+      i = sprintf("Use the %s argument instead.", format_arg("seed"))
+    ),
+    user_env = user_env
+  )
+}
+
 warn_deprecated_selector_dots <- function(
   fn,
   argument,

--- a/man/dataframe__hash_rows.Rd
+++ b/man/dataframe__hash_rows.Rd
@@ -4,16 +4,18 @@
 \alias{dataframe__hash_rows}
 \title{Hash and combine the rows in this DataFrame}
 \usage{
-dataframe__hash_rows(seed = 0, seed_1 = NULL, seed_2 = NULL, seed_3 = NULL)
+dataframe__hash_rows(
+  seed = 0,
+  seed_1 = deprecated(),
+  seed_2 = deprecated(),
+  seed_3 = deprecated()
+)
 }
 \arguments{
 \item{seed}{Random seed parameter. Defaults to 0.}
 
-\item{seed_1}{Random seed parameter. Defaults to \code{seed} if not set.}
-
-\item{seed_2}{Random seed parameter. Defaults to \code{seed} if not set.}
-
-\item{seed_3}{Random seed parameter. Defaults to \code{seed} if not set.}
+\item{seed_1, seed_2, seed_3}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Random seed
+parameters. Defaults to \code{seed} if not set.}
 }
 \value{
 A \link[=Series]{polars Series}

--- a/man/expr__hash.Rd
+++ b/man/expr__hash.Rd
@@ -4,13 +4,18 @@
 \alias{expr__hash}
 \title{Hash elements}
 \usage{
-expr__hash(seed = 0, seed_1 = NULL, seed_2 = NULL, seed_3 = NULL)
+expr__hash(
+  seed = 0,
+  seed_1 = deprecated(),
+  seed_2 = deprecated(),
+  seed_3 = deprecated()
+)
 }
 \arguments{
 \item{seed}{Integer, random seed parameter. Defaults to 0.}
 
-\item{seed_1, seed_2, seed_3}{Integer, random seed parameters. Default to
-\code{seed} if not set.}
+\item{seed_1, seed_2, seed_3}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Integer,
+random seed parameters. Default to \code{seed} if not set.}
 }
 \value{
 A polars \link{expression}
@@ -25,5 +30,5 @@ version.
 }
 \examples{
 df <- pl$DataFrame(a = c(1, 2, NA), b = c("x", NA, "z"))
-df$with_columns(pl$all()$hash(10, 20, 30, 40))
+df$with_columns(pl$all()$hash(seed = 10))
 }

--- a/tests/testthat/_snaps/dataframe-frame.md
+++ b/tests/testthat/_snaps/dataframe-frame.md
@@ -150,6 +150,51 @@
       x Problematic argument:
       * frac = 0.1
 
+# hash_rows additional seeds are deprecated
+
+    Code
+      invisible(df$hash_rows(seed_1 = 1))
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! The `seed_1`, `seed_2`, and `seed_3` arguments of `<dataframe>$hash_rows()` are deprecated as of polars 1.16.0.
+      i Use the `seed` argument instead.
+
+---
+
+    Code
+      invisible(df$hash_rows(seed_2 = 2))
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! The `seed_1`, `seed_2`, and `seed_3` arguments of `<dataframe>$hash_rows()` are deprecated as of polars 1.16.0.
+      i Use the `seed` argument instead.
+
+---
+
+    Code
+      invisible(df$hash_rows(seed_3 = 3))
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! The `seed_1`, `seed_2`, and `seed_3` arguments of `<dataframe>$hash_rows()` are deprecated as of polars 1.16.0.
+      i Use the `seed` argument instead.
+
+---
+
+    Code
+      invisible(df$hash_rows(seed_1 = 1, seed_2 = 2, seed_3 = 3))
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! The `seed_1`, `seed_2`, and `seed_3` arguments of `<dataframe>$hash_rows()` are deprecated as of polars 1.16.0.
+      i Use the `seed` argument instead.
+
+---
+
+    Code
+      invisible(df$hash_rows(seed_1 = NULL))
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! The `seed_1`, `seed_2`, and `seed_3` arguments of `<dataframe>$hash_rows()` are deprecated as of polars 1.16.0.
+      i Use the `seed` argument instead.
+
 # unstack() works
 
     Code

--- a/tests/testthat/_snaps/expr-expr.md
+++ b/tests/testthat/_snaps/expr-expr.md
@@ -282,6 +282,51 @@
       Caused by error:
       ! `closed` must be one of "both", "left", "right", or "none", not "foo".
 
+# hash additional seeds are deprecated
+
+    Code
+      invisible(expr$hash(seed_1 = 1))
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! The `seed_1`, `seed_2`, and `seed_3` arguments of `<expr>$hash()` are deprecated as of polars 1.16.0.
+      i Use the `seed` argument instead.
+
+---
+
+    Code
+      invisible(expr$hash(seed_2 = 2))
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! The `seed_1`, `seed_2`, and `seed_3` arguments of `<expr>$hash()` are deprecated as of polars 1.16.0.
+      i Use the `seed` argument instead.
+
+---
+
+    Code
+      invisible(expr$hash(seed_3 = 3))
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! The `seed_1`, `seed_2`, and `seed_3` arguments of `<expr>$hash()` are deprecated as of polars 1.16.0.
+      i Use the `seed` argument instead.
+
+---
+
+    Code
+      invisible(expr$hash(seed_1 = 1, seed_2 = 2, seed_3 = 3))
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! The `seed_1`, `seed_2`, and `seed_3` arguments of `<expr>$hash()` are deprecated as of polars 1.16.0.
+      i Use the `seed` argument instead.
+
+---
+
+    Code
+      invisible(expr$hash(seed_1 = NULL))
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! The `seed_1`, `seed_2`, and `seed_3` arguments of `<expr>$hash()` are deprecated as of polars 1.16.0.
+      i Use the `seed` argument instead.
+
 # rolling_*_by only works with date, datetime, or integers
 
     Code

--- a/tests/testthat/_snaps/series-s3-base.md
+++ b/tests/testthat/_snaps/series-s3-base.md
@@ -1,3 +1,12 @@
+# Series hash uses the Expr seed deprecation
+
+    Code
+      invisible(series$hash(seed_1 = 1))
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! The `seed_1`, `seed_2`, and `seed_3` arguments of `<expr>$hash()` are deprecated as of polars 1.16.0.
+      i Use the `seed` argument instead.
+
 # .DollarNames(<series>)
 
     Code

--- a/tests/testthat/test-dataframe-frame.R
+++ b/tests/testthat/test-dataframe-frame.R
@@ -638,21 +638,47 @@ test_that("hash_rows() works", {
     pl$UInt64
   )
   expect_error(
-    df$hash_rows(seed = 42, seed_1 = "a"),
+    suppressWarnings(df$hash_rows(seed = 42, seed_1 = "a")),
     "`seed_1` must be a whole number or `NULL`, not the string"
   )
   expect_error(
-    df$hash_rows(seed = 42, seed_1 = 1.5),
+    suppressWarnings(df$hash_rows(seed = 42, seed_1 = 1.5)),
     "`seed_1` must be a whole number or `NULL`"
   )
   expect_error(
-    df$hash_rows(seed = 42, seed_1 = 1:2),
+    suppressWarnings(df$hash_rows(seed = 42, seed_1 = 1:2)),
     "`seed_1` must be a whole number or `NULL`"
   )
   expect_error(
-    df$hash_rows(seed = 42, seed_1 = -1),
+    suppressWarnings(df$hash_rows(seed = 42, seed_1 = -1)),
     "`seed_1` must be a whole number larger than or equal to 0 or `NULL`"
   )
+})
+
+test_that("hash_rows additional seeds are deprecated", {
+  local_lifecycle_warnings()
+  df <- pl$DataFrame(foo = 1:3, bar = c("a", "b", "c"))
+
+  expect_snapshot(invisible(df$hash_rows(seed_1 = 1)), cnd_class = TRUE)
+  expect_snapshot(invisible(df$hash_rows(seed_2 = 2)), cnd_class = TRUE)
+  expect_snapshot(invisible(df$hash_rows(seed_3 = 3)), cnd_class = TRUE)
+  expect_snapshot(
+    invisible(df$hash_rows(seed_1 = 1, seed_2 = 2, seed_3 = 3)),
+    cnd_class = TRUE
+  )
+  expect_snapshot(invisible(df$hash_rows(seed_1 = NULL)), cnd_class = TRUE)
+
+  expect_no_condition(df$hash_rows())
+  expect_no_condition(df$hash_rows(seed = 42))
+
+  old <- suppressWarnings(df$hash_rows(42, 1, 2, 3))
+  explicit <- suppressWarnings(
+    df$hash_rows(seed = 42, seed_1 = 1, seed_2 = 2, seed_3 = 3)
+  )
+  expect_equal(old, explicit)
+
+  null_seed <- suppressWarnings(df$hash_rows(seed = 42, seed_1 = NULL))
+  expect_equal(null_seed, df$hash_rows(seed = 42))
 })
 
 test_that("unstack() works", {

--- a/tests/testthat/test-expr-expr.R
+++ b/tests/testthat/test-expr-expr.R
@@ -1572,13 +1572,40 @@ test_that("hash", {
     pl$col(c("Sepal.Width", "Species"))$unique()$hash()$implode()
   )
   hash_values2 <- df$select(
-    pl$col(c("Sepal.Width", "Species"))$unique()$hash(1, 2, 3, 4)$implode()
+    suppressWarnings(pl$col(c("Sepal.Width", "Species"))$unique()$hash(1, 2, 3, 4))$implode()
   )
 
   expect_false(
     identical(as.list(hash_values1, as_series = FALSE), as.list(hash_values2, as_series = FALSE))
   )
   expect_false(anyDuplicated(as.list(hash_values1, as_series = FALSE)$Sepal.Width) > 0)
+})
+
+test_that("hash additional seeds are deprecated", {
+  local_lifecycle_warnings()
+  expr <- pl$col("a")
+
+  expect_snapshot(invisible(expr$hash(seed_1 = 1)), cnd_class = TRUE)
+  expect_snapshot(invisible(expr$hash(seed_2 = 2)), cnd_class = TRUE)
+  expect_snapshot(invisible(expr$hash(seed_3 = 3)), cnd_class = TRUE)
+  expect_snapshot(
+    invisible(expr$hash(seed_1 = 1, seed_2 = 2, seed_3 = 3)),
+    cnd_class = TRUE
+  )
+  expect_snapshot(invisible(expr$hash(seed_1 = NULL)), cnd_class = TRUE)
+
+  expect_no_condition(expr$hash())
+  expect_no_condition(expr$hash(seed = 42))
+
+  df <- pl$DataFrame(a = 1:3)
+  old <- suppressWarnings(df$select(pl$col("a")$hash(42, 1, 2, 3)))
+  explicit <- suppressWarnings(
+    df$select(pl$col("a")$hash(seed = 42, seed_1 = 1, seed_2 = 2, seed_3 = 3))
+  )
+  expect_equal(old, explicit)
+
+  null_seed <- suppressWarnings(df$select(pl$col("a")$hash(seed = 42, seed_1 = NULL)))
+  expect_equal(null_seed, df$select(pl$col("a")$hash(seed = 42)))
 })
 
 test_that("reinterpret", {

--- a/tests/testthat/test-series-s3-base.R
+++ b/tests/testthat/test-series-s3-base.R
@@ -5,6 +5,14 @@ test_that("Expr methods works for Series", {
   )
 })
 
+test_that("Series hash uses the Expr seed deprecation", {
+  local_lifecycle_warnings()
+  series <- as_polars_series(1:3)
+
+  expect_snapshot(invisible(series$hash(seed_1 = 1)), cnd_class = TRUE)
+  expect_no_condition(series$hash(seed = 42))
+})
+
 test_that("Extract works for series struct namespace", {
   s <- as_polars_series(mtcars)
 


### PR DESCRIPTION
## Summary

- deprecate seed_1, seed_2, and seed_3 for expression hashes and DataFrame row hashes
- distinguish omitted arguments from explicit NULL while preserving the 1.x fallback behavior
- keep single-seed calls warning-free and cover Series expression dispatch
- update documentation, NEWS, and lifecycle warning snapshots

## Validation

- task build-documents
- task --force test-filter FILTER=expr-expr\|dataframe-frame\|series-s3-base (535 passed)
- task format-r
- air format --check .
- jarl check .
- git diff --check