### PR TITLE
feat: deprecate selector column set operations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,9 @@
   have a local scope and are always ordered lexically.
 * `<Enum>$union()` is deprecated. Construct an Enum explicitly from the
   combined categories instead.
+* Using a bare `pl$col()` as the right-hand operand of selector `&`, `|`, or
+  `$xor()` is deprecated. Use `cs$by_name()` for set operations or
+  `<selector>$as_expr()` for element-wise operations.
 
 ## polars 1.15.0
 

--- a/R/selectors.R
+++ b/R/selectors.R
@@ -24,6 +24,10 @@
 #' `<selector>$as_expr()` can be used to materialize the selector as a normal
 #' expression.
 #'
+#' Using a bare `pl$col()` expression as the right-hand operand of `&`, `|`,
+#' or `$xor()` on a selector is deprecated. Use `cs$by_name()` for set
+#' operations or `<selector>$as_expr()` for element-wise operations.
+#'
 #' @examples
 #' cs
 #'
@@ -82,7 +86,7 @@ selector__sub <- function(other) {
 selector__or <- function(other) {
   wrap({
     if (is_column(other)) {
-      # TODO: @2.0 remove? (check polars-python)
+      warn_deprecated_selector_column_operation("|")
       other <- cs__by_name(other$meta$output_name())
     }
     if (is_polars_selector(other)) {
@@ -96,7 +100,7 @@ selector__or <- function(other) {
 selector__and <- function(other) {
   wrap({
     if (is_column(other)) {
-      # TODO: @2.0 remove? (check polars-python)
+      warn_deprecated_selector_column_operation("&")
       colname <- other$meta$output_name()
       other <- cs__by_name(colname)
     }
@@ -111,7 +115,7 @@ selector__and <- function(other) {
 selector__xor <- function(other) {
   wrap({
     if (is_column(other)) {
-      # TODO: @2.0 remove? (check polars-python)
+      warn_deprecated_selector_column_operation("$xor()")
       other <- cs$by_name(other$meta$output_name())
     }
     if (is_polars_selector(other)) {

--- a/R/utils-deprecation.R
+++ b/R/utils-deprecation.R
@@ -118,3 +118,25 @@ warn_deprecated_selector_dots <- function(
     user_env = user_env
   )
 }
+
+warn_deprecated_selector_column_operation <- function(
+  operator,
+  user_env = caller_env(2)
+) {
+  deprecate_warn(
+    c(
+      `!` = sprintf(
+        "Using %s as the right-hand operand of %s on a selector is deprecated as of %s 1.16.0.",
+        format_code("pl$col(...)"),
+        format_code(operator),
+        format_pkg("polars")
+      ),
+      i = sprintf(
+        "Use %s for set operations or %s for element-wise operations.",
+        format_code("cs$by_name(...)"),
+        format_code("<selector>$as_expr()")
+      )
+    ),
+    user_env = user_env
+  )
+}

--- a/man/cs.Rd
+++ b/man/cs.Rd
@@ -36,6 +36,10 @@ Note that Python Polars uses \code{~} instead of \code{!} to invert selectors.
 If we want to apply operators on the data instead of the selector sets,
 \verb{<selector>$as_expr()} can be used to materialize the selector as a normal
 expression.
+
+Using a bare \code{pl$col()} expression as the right-hand operand of \code{&}, \code{|},
+or \verb{$xor()} on a selector is deprecated. Use \code{cs$by_name()} for set
+operations or \verb{<selector>$as_expr()} for element-wise operations.
 }
 
 \examples{

--- a/tests/testthat/_snaps/selectors.md
+++ b/tests/testthat/_snaps/selectors.md
@@ -1,3 +1,36 @@
+# selector and column operations are deprecated
+
+    Code
+      cs$string() | pl$col("foo2")
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! Using `pl$col(...)` as the right-hand operand of `|` on a selector is deprecated as of polars 1.16.0.
+      i Use `cs$by_name(...)` for set operations or `<selector>$as_expr()` for element-wise operations.
+    Output
+      [cs.string() | cs.by_name('foo2', require_all=true)]
+
+---
+
+    Code
+      cs$numeric() & pl$col("foot")
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! Using `pl$col(...)` as the right-hand operand of `&` on a selector is deprecated as of polars 1.16.0.
+      i Use `cs$by_name(...)` for set operations or `<selector>$as_expr()` for element-wise operations.
+    Output
+      [cs.numeric() & cs.by_name('foot', require_all=true)]
+
+---
+
+    Code
+      cs$by_name("foo")$xor(pl$col("foo"))
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! Using `pl$col(...)` as the right-hand operand of `$xor()` on a selector is deprecated as of polars 1.16.0.
+      i Use `cs$by_name(...)` for set operations or `<selector>$as_expr()` for element-wise operations.
+    Output
+      [cs.by_name('foo', require_all=true) ^ cs.by_name('foo', require_all=true)]
+
 # alpha
 
     Code

--- a/tests/testthat/test-selectors.R
+++ b/tests/testthat/test-selectors.R
@@ -13,7 +13,7 @@ test_that("'union' operator works", {
     c("foo", "foo2")
   )
   expect_named(
-    df$select(cs$string() | pl$col("foo2")),
+    df$select(suppressWarnings(cs$string() | pl$col("foo2"))),
     c("foo", "foo2")
   )
 })
@@ -25,12 +25,45 @@ test_that("'and' operator works", {
     "foot"
   )
   expect_named(
-    df$select(cs$numeric() & pl$col("foot")),
+    df$select(suppressWarnings(cs$numeric() & pl$col("foot"))),
     "foot"
   )
   expect_named(
-    df$select(cs$by_name("foo") & pl$col("foot")),
+    df$select(suppressWarnings(cs$by_name("foo") & pl$col("foot"))),
     character(0)
+  )
+})
+
+test_that("selector and column operations are deprecated", {
+  local_lifecycle_warnings()
+  df <- pl$DataFrame(foo = c("a", "b"), foot = c(1, 2), foo2 = c(TRUE, FALSE))
+
+  expect_snapshot(cs$string() | pl$col("foo2"), cnd_class = TRUE)
+  expect_snapshot(cs$numeric() & pl$col("foot"), cnd_class = TRUE)
+  expect_snapshot(cs$by_name("foo")$xor(pl$col("foo")), cnd_class = TRUE)
+
+  expect_named(
+    df$select(suppressWarnings(cs$string() | pl$col("foo2"))),
+    c("foo", "foo2")
+  )
+  expect_named(
+    df$select(suppressWarnings(cs$numeric() & pl$col("foot"))),
+    "foot"
+  )
+  expect_named(
+    df$select(suppressWarnings(cs$by_name("foo")$xor(pl$col("foo")))),
+    character(0)
+  )
+
+  expect_no_condition(cs$string() | cs$by_name("foo2"))
+  expect_no_condition(cs$numeric() & cs$by_name("foot"))
+  expect_no_condition(cs$string()$xor(cs$by_name("foo")))
+  expect_no_condition(cs$by_name("foo2")$as_expr() | pl$lit(TRUE))
+  expect_no_condition(pl$col("foo") | cs$by_name("foo"))
+
+  expect_equal(
+    df$select(cs$by_name("foo2")$as_expr() | pl$lit(TRUE)),
+    pl$DataFrame(foo2 = c(TRUE, TRUE))
   )
 })
 


### PR DESCRIPTION
## Summary

- deprecate bare pl$col expressions used as the right-hand operand of selector &, |, and $xor() set operations
- preserve the 1.x selector-set conversion while directing users to cs$by_name()
- document $as_expr() for explicit element-wise semantics
- keep selector-selector operations and the reverse expression order warning-free
- add lifecycle warning snapshots and behavior tests

## Validation

- task build-documents
- task test-filter FILTER=selectors\|functions-col\|utils-parse-expr (162 passed)
- task format-r
- air format --check .
- jarl check .
- git diff --check main...HEAD