### PR TITLE
style: shorten selector warning helper name

### DIFF
--- a/R/selectors.R
+++ b/R/selectors.R
@@ -86,7 +86,7 @@ selector__sub <- function(other) {
 selector__or <- function(other) {
   wrap({
     if (is_column(other)) {
-      warn_deprecated_selector_column_operation("|")
+      warn_deprecated_selector_col("|")
       other <- cs__by_name(other$meta$output_name())
     }
     if (is_polars_selector(other)) {
@@ -100,7 +100,7 @@ selector__or <- function(other) {
 selector__and <- function(other) {
   wrap({
     if (is_column(other)) {
-      warn_deprecated_selector_column_operation("&")
+      warn_deprecated_selector_col("&")
       colname <- other$meta$output_name()
       other <- cs__by_name(colname)
     }
@@ -115,7 +115,7 @@ selector__and <- function(other) {
 selector__xor <- function(other) {
   wrap({
     if (is_column(other)) {
-      warn_deprecated_selector_column_operation("$xor()")
+      warn_deprecated_selector_col("$xor()")
       other <- cs$by_name(other$meta$output_name())
     }
     if (is_polars_selector(other)) {

--- a/R/utils-deprecation.R
+++ b/R/utils-deprecation.R
@@ -119,7 +119,7 @@ warn_deprecated_selector_dots <- function(
   )
 }
 
-warn_deprecated_selector_column_operation <- function(
+warn_deprecated_selector_col <- function(
   operator,
   user_env = caller_env(2)
 ) {


### PR DESCRIPTION
## Summary

- shorten the selector deprecation warning helper name to satisfy the 30-character lintr limit
- update the three selector operator call sites without changing behavior or warning output

## Checks

- air format --check R/utils-deprecation.R R/selectors.R
- jarl check R/utils-deprecation.R R/selectors.R
- targeted lintr object_length_linter check