### PR TITLE
feat: deprecate legacy `$to_struct()` arguments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,12 @@
 * Using a bare `pl$col()` as the right-hand operand of selector `&`, `|`, or
   `$xor()` is deprecated. Use `cs$by_name()` for set operations or
   `<selector>$as_expr()` for element-wise operations.
+* Omitted or function-valued `fields` and `n_field_strategy` are deprecated
+  for `<expr>$list$to_struct()` and `<series>$list$to_struct()`. Use an
+  explicit character vector of field names instead.
+* `upper_bound` is deprecated for `<expr>$list$to_struct()`. Function-valued
+  `fields` are deprecated for `<expr>$arr$to_struct()` and
+  `<series>$arr$to_struct()`.
 
 ## polars 1.15.0
 

--- a/R/expr-array.R
+++ b/R/expr-array.R
@@ -354,12 +354,11 @@ expr_arr_to_list <- function() {
 #' Convert the Series of type Array to a Series of type Struct
 #'
 #' @param fields `r lifecycle::badge("experimental")`
-#'   `NULL` (default) or character vector of field names, or a function that
-#'   takes an integer index and returns character.
-#'   If the name and number of the desired fields is known in advance,
-#'   character vector of field names can be given, which will be assigned by index.
-#'   Otherwise, to dynamically assign field names, a custom function can be used;
-#'   if neither are set, fields will be `field_0`, `field_1`...
+#'   `NULL` (default) or character vector of field names. A function that
+#'   takes an integer index and returns character remains accepted only for
+#'   compatibility; explicit character names are preferred.
+#'   A character vector assigns explicit names by index. If `NULL` is used,
+#'   names are generated as `field_0`, `field_1`, ... from the fixed array width.
 #'   See the examples for details.
 #' @inherit as_polars_expr return
 #' @examples
@@ -370,7 +369,7 @@ expr_arr_to_list <- function() {
 #'
 #' df$with_columns(struct = pl$col("n")$arr$to_struct())
 #'
-#' # Convert array to struct with field name assignment by function/index:
+#' # Dynamic field-name functions are deprecated:
 #' df$select(pl$col("n")$arr$to_struct(\(idx) paste0("n", idx)))$unnest("n")
 #'
 #' # Convert array to struct with field name assignment by index from character:
@@ -380,6 +379,9 @@ expr_arr_to_struct <- function(fields = NULL) {
     if (is_character(fields)) {
       wrap(self$`_rexpr`$arr_to_struct())$struct$rename_fields(fields)
     } else {
+      if (!is.null(fields)) {
+        warn_deprecated_to_struct("<expr>$arr$to_struct()")
+      }
       name_gen <- if (is.null(fields)) {
         NULL
       } else {

--- a/R/expr-list.R
+++ b/R/expr-list.R
@@ -753,15 +753,24 @@ expr_list_to_array <- function(width) {
 #'
 #' @details
 #' As of polars 1.3.0, the `n_field_strategy` argument is ignored and deprecated.
-#' The `fields` needs to be a character vector or the `upper_bound` is regarded as ground truth.
+#' Use an explicit character vector for `fields`; this form is warning-free and
+#' will be required in Polars 2.0. The `upper_bound` argument is deprecated.
 #'
 #' If inferring field length is needed, [`<series>$list$to_struct()`][series_list_to_struct]
 #' can be used, which inspects the data at runtime.
 #' @inherit as_polars_expr return
-#' @inheritParams expr_arr_to_struct
+#' @param fields Character vector of field names. `NULL` (default) and
+#'   function-valued fields are deprecated; use an explicit character vector,
+#'   which will be required in Polars 2.0.
+#' @param ... A character vector of field names can be supplied as the first
+#'   positional argument. Scalar `"first_non_null"` and `"max_width"` values
+#'   are interpreted as legacy `n_field_strategy`; use `fields = ...` when
+#'   either is a field name. Additional positional arguments are deprecated
+#'   compatibility arguments.
 #' @param n_field_strategy `r lifecycle::badge("deprecated")`
 #'   Ignored.
-#' @param upper_bound Single positive integer value or `NULL` (default).
+#' @param upper_bound `r lifecycle::badge("deprecated")` Single positive
+#'   integer value or `NULL` (default).
 #'   A [polars expression][Expr] needs to be able to evaluate the output datatype at all
 #'   times, so the caller must provide an upper bound of the number of struct
 #'   fields that will be created if `fields` is not a character vector of field names.
@@ -771,13 +780,11 @@ expr_list_to_array <- function(width) {
 #' @examples
 #' df <- pl$DataFrame(n = list(c(0, 1), c(0, 1, 2)))
 #'
-#' # Convert list to struct with default field name assignment:
+#' # Convert list to struct with explicit field names:
 #'
-#' # This will become a struct with 2 fields.
-#' df$select(pl$col("n")$list$to_struct(upper_bound = 2))$unnest("n")
+#' df$select(pl$col("n")$list$to_struct(c("one", "two", "three")))$unnest("n")
 #'
-#' # Convert list to struct with field name assignment by
-#' # function/index:
+#' # Dynamic field-name functions are deprecated:
 #' df$select(
 #'   pl$col("n")$list$to_struct(
 #'     fields = \(idx) paste0("n", idx + 1),
@@ -791,21 +798,26 @@ expr_list_to_array <- function(width) {
 #'   fields = c("one", "two", "three"))
 #' )$unnest("n")
 expr_list_to_struct <- function(
-  n_field_strategy = deprecated(),
+  ...,
   fields = NULL,
-  upper_bound = NULL
+  n_field_strategy = deprecated(),
+  upper_bound = deprecated()
 ) {
+  fields_present <- !missing(fields)
   wrap({
-    if (is_present(n_field_strategy)) {
-      deprecate_warn(
-        c(
-          `!` = sprintf(
-            "%s with %s is deprecated and has no effect on execution.",
-            format_code("<expr>$list$to_struct()"),
-            format_arg("n_field_strategy")
-          )
-        )
-      )
+    args <- parse_to_struct_args(
+      ...,
+      fields = fields,
+      fields_present = fields_present,
+      n_field_strategy = n_field_strategy,
+      upper_bound = upper_bound,
+      method = "<expr>$list$to_struct()"
+    )
+    fields <- args$fields
+    upper_bound <- args$upper_bound
+
+    if (args$deprecated) {
+      warn_deprecated_to_struct("<expr>$list$to_struct()")
     }
 
     check_number_whole(upper_bound, min = 1, allow_null = TRUE)
@@ -816,22 +828,6 @@ expr_list_to_struct <- function(
       if (is.null(upper_bound)) {
         # Python Polars does not allow `upper_bound` to be empty,
         # but avoiding breaking change for the API, this is needed.
-        deprecate_warn(
-          c(
-            `!` = sprintf(
-              "%s without %s is deprecated, automatically setting %s.",
-              format_code("<expr>$list$to_struct()"),
-              format_arg("upper_bound"),
-              format_code("upper_bound = 1L")
-            ),
-            i = sprintf(
-              "Either modify %s to be a vector or specify %s to suppress this warning.",
-              format_code("fields"),
-              format_code("upper_bound")
-            )
-          ),
-          always = TRUE
-        )
         upper_bound <- 1L
       }
       idx <- seq(0L, upper_bound - 1L)
@@ -849,6 +845,91 @@ expr_list_to_struct <- function(
     }
     self$`_rexpr`$list_to_struct(fields)
   })
+}
+
+parse_to_struct_args <- function(
+  ...,
+  fields = NULL,
+  n_field_strategy = deprecated(),
+  upper_bound = deprecated(),
+  method,
+  max_positional = 3L,
+  fields_present = !missing(fields),
+  allow_upper_bound = TRUE
+) {
+  check_dots_unnamed()
+  dots <- list2(...)
+  if (length(dots) > max_positional) {
+    abort(sprintf("Too many positional arguments supplied to %s.", method))
+  }
+
+  strategy_present <- is_present(n_field_strategy)
+  upper_bound_present <- is_present(upper_bound)
+
+  if (!allow_upper_bound && upper_bound_present) {
+    abort(sprintf("`upper_bound` is not supported by %s.", method))
+  }
+
+  if (
+    length(dots) == 1L &&
+      !fields_present &&
+      !upper_bound_present &&
+      is_character(dots[[1L]]) &&
+      length(dots[[1L]]) == 1L &&
+      !is.na(dots[[1L]]) &&
+      dots[[1L]] %in% c("first_non_null", "max_width") &&
+      !strategy_present
+  ) {
+    n_field_strategy <- dots[[1L]]
+    strategy_present <- TRUE
+    dots <- list()
+  } else if (
+    length(dots) == 1L &&
+      !fields_present &&
+      !strategy_present &&
+      !upper_bound_present &&
+      is_character(dots[[1L]])
+  ) {
+    fields <- dots[[1L]]
+    fields_present <- TRUE
+    dots <- list()
+  } else if (length(dots) > 0L) {
+    slots <- c(!strategy_present, !fields_present)
+    if (allow_upper_bound) {
+      slots <- c(slots, !upper_bound_present)
+    }
+    if (length(dots) > sum(slots)) {
+      abort(sprintf("Arguments were supplied more than once to %s.", method))
+    }
+    for (i in seq_along(dots)) {
+      slot <- which(slots)[[1L]]
+      if (slot == 1L) {
+        n_field_strategy <- dots[[i]]
+        strategy_present <- TRUE
+      } else if (slot == 2L) {
+        fields <- dots[[i]]
+        fields_present <- TRUE
+      } else {
+        upper_bound <- dots[[i]]
+        upper_bound_present <- TRUE
+      }
+      slots[[slot]] <- FALSE
+    }
+  }
+
+  if (!fields_present) {
+    fields <- NULL
+  }
+  if (!upper_bound_present) {
+    upper_bound <- NULL
+  }
+
+  list(
+    fields = fields,
+    n_field_strategy = n_field_strategy,
+    upper_bound = upper_bound,
+    deprecated = strategy_present || upper_bound_present || !is_character(fields)
+  )
 }
 
 #' Drop all null values in every sub-list

--- a/R/series-list.R
+++ b/R/series-list.R
@@ -16,26 +16,33 @@ namespace_series_list <- function(x) {
 #' Convert the series of type List to a series of type Struct
 #'
 #' @inherit as_polars_series return
-#' @inheritParams expr_list_to_struct
-#' @param n_field_strategy One of `"first_non_null"` or `"max_width"`.
+#' @param fields Character vector of field names. `NULL` (default) and
+#'   function-valued fields are deprecated; use an explicit character vector,
+#'   which will be required in Polars 2.0.
+#' @param ... A character vector of field names can be supplied as the first
+#'   positional argument. Scalar `"first_non_null"` and `"max_width"` values
+#'   are interpreted as legacy `n_field_strategy`; use `fields = ...` when
+#'   either is a field name. Additional positional arguments are deprecated
+#'   compatibility arguments.
+#' @param n_field_strategy `r lifecycle::badge("deprecated")` One of
+#'   `"first_non_null"` or `"max_width"`.
 #'   Strategy to determine the number of fields of the struct.
 #'
 #'   - `"first_non_null"` (default): Set number of fields equal to
 #'     the length of the first non zero-length sublist.
 #'   - `"max_width"`: Set number of fields as max length of all sublists.
 #'
-#'   If the `field` argument is character, this argument will be ignored.
+#'   If the `fields` argument is character, this argument will be ignored.
 #' @seealso
 #' - [`<expr>$list$to_struct()`][expr_list_to_struct]
 #' @examples
-#' # Convert list to struct with default field name assignment:
+#' # Convert list to struct with explicit field names:
 #' s1 <- as_polars_series(list(0:2, 0:1))
-#' s2 <- s1$list$to_struct()
+#' s2 <- s1$list$to_struct(c("one", "two", "three"))
 #' s2
 #' s2$struct$fields
 #'
-#' # Convert list to struct with field name assignment by
-#' # function/index:
+#' # Dynamic field-name functions are deprecated:
 #' s3 <- s1$list$to_struct(fields = \(idx) sprintf("n%02d", idx))
 #' s3$struct$fields
 #'
@@ -43,14 +50,35 @@ namespace_series_list <- function(x) {
 #' # index from a list of names:
 #' s1$list$to_struct(fields = c("one", "two", "three"))$struct$unnest()
 series_list_to_struct <- function(
-  n_field_strategy = c("first_non_null", "max_width"),
-  fields = NULL
+  ...,
+  fields = NULL,
+  n_field_strategy = deprecated()
 ) {
+  fields_present <- !missing(fields)
   wrap({
+    args <- parse_to_struct_args(
+      ...,
+      fields = fields,
+      fields_present = fields_present,
+      n_field_strategy = n_field_strategy,
+      method = "<series>$list$to_struct()",
+      max_positional = 2L,
+      allow_upper_bound = FALSE
+    )
+    fields <- args$fields
+    n_field_strategy <- args$n_field_strategy
+
+    if (args$deprecated) {
+      warn_deprecated_to_struct("<series>$list$to_struct()")
+    }
+
     if (is_character(fields)) {
       s <- wrap(self$`_s`)
       s$to_frame()$select_seq(pl__col(s$name)$list$to_struct(fields = fields))$to_series()
     } else {
+      if (!is_present(n_field_strategy)) {
+        n_field_strategy <- "first_non_null"
+      }
       n_field_strategy <- arg_match0(n_field_strategy, values = c("first_non_null", "max_width"))
 
       name_gen <- if (is.null(fields)) {

--- a/R/utils-deprecation.R
+++ b/R/utils-deprecation.R
@@ -140,3 +140,20 @@ warn_deprecated_selector_col <- function(
     user_env = user_env
   )
 }
+
+warn_deprecated_to_struct <- function(method, user_env = caller_env(2)) {
+  deprecate_warn(
+    c(
+      `!` = sprintf(
+        "Legacy arguments of %s are deprecated as of %s 1.16.0.",
+        format_code(method),
+        format_pkg("polars")
+      ),
+      i = sprintf(
+        "Use an explicit character vector for %s.",
+        format_arg("fields")
+      )
+    ),
+    user_env = user_env
+  )
+}

--- a/man/expr_arr_to_struct.Rd
+++ b/man/expr_arr_to_struct.Rd
@@ -8,12 +8,11 @@ expr_arr_to_struct(fields = NULL)
 }
 \arguments{
 \item{fields}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
-\code{NULL} (default) or character vector of field names, or a function that
-takes an integer index and returns character.
-If the name and number of the desired fields is known in advance,
-character vector of field names can be given, which will be assigned by index.
-Otherwise, to dynamically assign field names, a custom function can be used;
-if neither are set, fields will be \code{field_0}, \code{field_1}...
+\code{NULL} (default) or character vector of field names. A function that
+takes an integer index and returns character remains accepted only for
+compatibility; explicit character names are preferred.
+A character vector assigns explicit names by index. If \code{NULL} is used,
+names are generated as \code{field_0}, \code{field_1}, ... from the fixed array width.
 See the examples for details.}
 }
 \value{
@@ -30,7 +29,7 @@ df <- pl$DataFrame(
 
 df$with_columns(struct = pl$col("n")$arr$to_struct())
 
-# Convert array to struct with field name assignment by function/index:
+# Dynamic field-name functions are deprecated:
 df$select(pl$col("n")$arr$to_struct(\\(idx) paste0("n", idx)))$unnest("n")
 
 # Convert array to struct with field name assignment by index from character:

--- a/man/expr_list_to_struct.Rd
+++ b/man/expr_list_to_struct.Rd
@@ -5,25 +5,28 @@
 \title{Convert the Series of type List to a Series of type Struct}
 \usage{
 expr_list_to_struct(
-  n_field_strategy = deprecated(),
+  ...,
   fields = NULL,
-  upper_bound = NULL
+  n_field_strategy = deprecated(),
+  upper_bound = deprecated()
 )
 }
 \arguments{
+\item{...}{A character vector of field names can be supplied as the first
+positional argument. Scalar \code{"first_non_null"} and \code{"max_width"} values
+are interpreted as legacy \code{n_field_strategy}; use \code{fields = ...} when
+either is a field name. Additional positional arguments are deprecated
+compatibility arguments.}
+
+\item{fields}{Character vector of field names. \code{NULL} (default) and
+function-valued fields are deprecated; use an explicit character vector,
+which will be required in Polars 2.0.}
+
 \item{n_field_strategy}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 Ignored.}
 
-\item{fields}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
-\code{NULL} (default) or character vector of field names, or a function that
-takes an integer index and returns character.
-If the name and number of the desired fields is known in advance,
-character vector of field names can be given, which will be assigned by index.
-Otherwise, to dynamically assign field names, a custom function can be used;
-if neither are set, fields will be \code{field_0}, \code{field_1}...
-See the examples for details.}
-
-\item{upper_bound}{Single positive integer value or \code{NULL} (default).
+\item{upper_bound}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Single positive
+integer value or \code{NULL} (default).
 A \link[=Expr]{polars expression} needs to be able to evaluate the output datatype at all
 times, so the caller must provide an upper bound of the number of struct
 fields that will be created if \code{fields} is not a character vector of field names.}
@@ -36,7 +39,8 @@ Convert the Series of type List to a Series of type Struct
 }
 \details{
 As of polars 1.3.0, the \code{n_field_strategy} argument is ignored and deprecated.
-The \code{fields} needs to be a character vector or the \code{upper_bound} is regarded as ground truth.
+Use an explicit character vector for \code{fields}; this form is warning-free and
+will be required in Polars 2.0. The \code{upper_bound} argument is deprecated.
 
 If inferring field length is needed, \code{\link[=series_list_to_struct]{<series>$list$to_struct()}}
 can be used, which inspects the data at runtime.
@@ -44,13 +48,11 @@ can be used, which inspects the data at runtime.
 \examples{
 df <- pl$DataFrame(n = list(c(0, 1), c(0, 1, 2)))
 
-# Convert list to struct with default field name assignment:
+# Convert list to struct with explicit field names:
 
-# This will become a struct with 2 fields.
-df$select(pl$col("n")$list$to_struct(upper_bound = 2))$unnest("n")
+df$select(pl$col("n")$list$to_struct(c("one", "two", "three")))$unnest("n")
 
-# Convert list to struct with field name assignment by
-# function/index:
+# Dynamic field-name functions are deprecated:
 df$select(
   pl$col("n")$list$to_struct(
     fields = \\(idx) paste0("n", idx + 1),

--- a/man/series_list_to_struct.Rd
+++ b/man/series_list_to_struct.Rd
@@ -4,13 +4,21 @@
 \alias{series_list_to_struct}
 \title{Convert the series of type List to a series of type Struct}
 \usage{
-series_list_to_struct(
-  n_field_strategy = c("first_non_null", "max_width"),
-  fields = NULL
-)
+series_list_to_struct(..., fields = NULL, n_field_strategy = deprecated())
 }
 \arguments{
-\item{n_field_strategy}{One of \code{"first_non_null"} or \code{"max_width"}.
+\item{...}{A character vector of field names can be supplied as the first
+positional argument. Scalar \code{"first_non_null"} and \code{"max_width"} values
+are interpreted as legacy \code{n_field_strategy}; use \code{fields = ...} when
+either is a field name. Additional positional arguments are deprecated
+compatibility arguments.}
+
+\item{fields}{Character vector of field names. \code{NULL} (default) and
+function-valued fields are deprecated; use an explicit character vector,
+which will be required in Polars 2.0.}
+
+\item{n_field_strategy}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} One of
+\code{"first_non_null"} or \code{"max_width"}.
 Strategy to determine the number of fields of the struct.
 \itemize{
 \item \code{"first_non_null"} (default): Set number of fields equal to
@@ -18,16 +26,7 @@ the length of the first non zero-length sublist.
 \item \code{"max_width"}: Set number of fields as max length of all sublists.
 }
 
-If the \code{field} argument is character, this argument will be ignored.}
-
-\item{fields}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
-\code{NULL} (default) or character vector of field names, or a function that
-takes an integer index and returns character.
-If the name and number of the desired fields is known in advance,
-character vector of field names can be given, which will be assigned by index.
-Otherwise, to dynamically assign field names, a custom function can be used;
-if neither are set, fields will be \code{field_0}, \code{field_1}...
-See the examples for details.}
+If the \code{fields} argument is character, this argument will be ignored.}
 }
 \value{
 A \link[=Series]{polars Series}
@@ -36,14 +35,13 @@ A \link[=Series]{polars Series}
 Convert the series of type List to a series of type Struct
 }
 \examples{
-# Convert list to struct with default field name assignment:
+# Convert list to struct with explicit field names:
 s1 <- as_polars_series(list(0:2, 0:1))
-s2 <- s1$list$to_struct()
+s2 <- s1$list$to_struct(c("one", "two", "three"))
 s2
 s2$struct$fields
 
-# Convert list to struct with field name assignment by
-# function/index:
+# Dynamic field-name functions are deprecated:
 s3 <- s1$list$to_struct(fields = \\(idx) sprintf("n\%02d", idx))
 s3$struct$fields
 

--- a/tests/testthat/_snaps/expr-array.md
+++ b/tests/testthat/_snaps/expr-array.md
@@ -162,6 +162,10 @@
       pl$DataFrame(values = list(c(1, 2), c(1, 1), c(2, 2)), .schema_overrides = list(
         values = pl$Array(pl$Int64, 2)))$select(pl$col("values")$arr$to_struct(
         fields = fields))$unnest("values")
+    Condition
+      Warning:
+      ! Legacy arguments of `<expr>$arr$to_struct()` are deprecated as of polars 1.16.0.
+      i Use an explicit character vector for `fields`.
     Output
       shape: (3, 2)
       ┌─────────┬─────────┐
@@ -180,6 +184,10 @@
       pl$DataFrame(values = list(c(1, 2), c(1, 1), c(2, 2)), .schema_overrides = list(
         values = pl$Array(pl$Int64, 2)))$select(pl$col("values")$arr$to_struct(
         fields = fields))$unnest("values")
+    Condition
+      Warning:
+      ! Legacy arguments of `<expr>$arr$to_struct()` are deprecated as of polars 1.16.0.
+      i Use an explicit character vector for `fields`.
     Output
       shape: (3, 2)
       ┌─────────┬─────────┐
@@ -190,6 +198,64 @@
       │ 1       ┆ 2       │
       │ 1       ┆ 1       │
       │ 2       ┆ 2       │
+      └─────────┴─────────┘
+
+# arr$to_struct deprecates dynamic field names
+
+    Code
+      df$select(pl$col("values")$arr$to_struct(fields = function(idx) paste0("field_",
+        idx)))
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! Legacy arguments of `<expr>$arr$to_struct()` are deprecated as of polars 1.16.0.
+      i Use an explicit character vector for `fields`.
+    Output
+      shape: (2, 1)
+      ┌───────────┐
+      │ values    │
+      │ ---       │
+      │ struct[2] │
+      ╞═══════════╡
+      │ {1,2}     │
+      │ {1,1}     │
+      └───────────┘
+
+# series arr$to_struct delegates to the expression API
+
+    Code
+      as_polars_df(series$arr$to_struct(fields = function(idx) paste0("field_", idx)))
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! Legacy arguments of `<expr>$arr$to_struct()` are deprecated as of polars 1.16.0.
+      i Use an explicit character vector for `fields`.
+    Output
+      shape: (2, 2)
+      ┌─────────┬─────────┐
+      │ field_0 ┆ field_1 │
+      │ ---     ┆ ---     │
+      │ i64     ┆ i64     │
+      ╞═════════╪═════════╡
+      │ 1       ┆ 2       │
+      │ 1       ┆ 1       │
+      └─────────┴─────────┘
+
+---
+
+    Code
+      as_polars_df(series$arr$to_struct(fields = ~ paste0("field_", .)))
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! Legacy arguments of `<expr>$arr$to_struct()` are deprecated as of polars 1.16.0.
+      i Use an explicit character vector for `fields`.
+    Output
+      shape: (2, 2)
+      ┌─────────┬─────────┐
+      │ field_0 ┆ field_1 │
+      │ ---     ┆ ---     │
+      │ i64     ┆ i64     │
+      ╞═════════╪═════════╡
+      │ 1       ┆ 2       │
+      │ 1       ┆ 1       │
       └─────────┴─────────┘
 
 # arr$eval()

--- a/tests/testthat/_snaps/expr-list.md
+++ b/tests/testthat/_snaps/expr-list.md
@@ -199,6 +199,10 @@
       pl$DataFrame(values = list(c(1, 2), c(1, 2, 3), c(1)), .schema_overrides = list(
         values = pl$List(pl$Int64)))$select(pl$col("values")$list$to_struct(fields = fields,
         upper_bound = upper_bound))$unnest("values")
+    Condition
+      Warning:
+      ! Legacy arguments of `<expr>$list$to_struct()` are deprecated as of polars 1.16.0.
+      i Use an explicit character vector for `fields`.
     Output
       shape: (3, 1)
       ┌─────────┐
@@ -217,6 +221,10 @@
       pl$DataFrame(values = list(c(1, 2), c(1, 2, 3), c(1)), .schema_overrides = list(
         values = pl$List(pl$Int64)))$select(pl$col("values")$list$to_struct(fields = fields,
         upper_bound = upper_bound))$unnest("values")
+    Condition
+      Warning:
+      ! Legacy arguments of `<expr>$list$to_struct()` are deprecated as of polars 1.16.0.
+      i Use an explicit character vector for `fields`.
     Output
       shape: (3, 1)
       ┌─────────┐
@@ -235,6 +243,10 @@
       pl$DataFrame(values = list(c(1, 2), c(1, 2, 3), c(1)), .schema_overrides = list(
         values = pl$List(pl$Int64)))$select(pl$col("values")$list$to_struct(fields = fields,
         upper_bound = upper_bound))$unnest("values")
+    Condition
+      Warning:
+      ! Legacy arguments of `<expr>$list$to_struct()` are deprecated as of polars 1.16.0.
+      i Use an explicit character vector for `fields`.
     Output
       shape: (3, 1)
       ┌─────────┐
@@ -253,6 +265,10 @@
       pl$DataFrame(values = list(c(1, 2), c(1, 2, 3), c(1)), .schema_overrides = list(
         values = pl$List(pl$Int64)))$select(pl$col("values")$list$to_struct(fields = fields,
         upper_bound = upper_bound))$unnest("values")
+    Condition
+      Warning:
+      ! Legacy arguments of `<expr>$list$to_struct()` are deprecated as of polars 1.16.0.
+      i Use an explicit character vector for `fields`.
     Output
       shape: (3, 1)
       ┌─────┐
@@ -271,6 +287,10 @@
       pl$DataFrame(values = list(c(1, 2), c(1, 2, 3), c(1)), .schema_overrides = list(
         values = pl$List(pl$Int64)))$select(pl$col("values")$list$to_struct(fields = fields,
         upper_bound = upper_bound))$unnest("values")
+    Condition
+      Warning:
+      ! Legacy arguments of `<expr>$list$to_struct()` are deprecated as of polars 1.16.0.
+      i Use an explicit character vector for `fields`.
     Output
       shape: (3, 4)
       ┌─────┬──────┬──────┬──────┐
@@ -289,6 +309,10 @@
       pl$DataFrame(values = list(c(1, 2), c(1, 2, 3), c(1)), .schema_overrides = list(
         values = pl$List(pl$Int64)))$select(pl$col("values")$list$to_struct(fields = fields,
         upper_bound = upper_bound))$unnest("values")
+    Condition
+      Warning:
+      ! Legacy arguments of `<expr>$list$to_struct()` are deprecated as of polars 1.16.0.
+      i Use an explicit character vector for `fields`.
     Output
       shape: (3, 5)
       ┌─────────┬─────────┬─────────┬─────────┬─────────┐
@@ -307,6 +331,10 @@
       pl$DataFrame(values = list(c(1, 2), c(1, 2, 3), c(1)), .schema_overrides = list(
         values = pl$List(pl$Int64)))$select(pl$col("values")$list$to_struct(fields = fields,
         upper_bound = upper_bound))$unnest("values")
+    Condition
+      Warning:
+      ! Legacy arguments of `<expr>$list$to_struct()` are deprecated as of polars 1.16.0.
+      i Use an explicit character vector for `fields`.
     Output
       shape: (3, 5)
       ┌─────────┬─────────┬─────────┬─────────┬─────────┐
@@ -325,6 +353,10 @@
       pl$DataFrame(values = list(c(1, 2), c(1, 2, 3), c(1)), .schema_overrides = list(
         values = pl$List(pl$Int64)))$select(pl$col("values")$list$to_struct(fields = fields,
         upper_bound = upper_bound))$unnest("values")
+    Condition
+      Warning:
+      ! Legacy arguments of `<expr>$list$to_struct()` are deprecated as of polars 1.16.0.
+      i Use an explicit character vector for `fields`.
     Output
       shape: (3, 5)
       ┌─────────┬─────────┬─────────┬─────────┬─────────┐
@@ -343,6 +375,10 @@
       pl$DataFrame(values = list(c(1, 2), c(1, 2, 3), c(1)), .schema_overrides = list(
         values = pl$List(pl$Int64)))$select(pl$col("values")$list$to_struct(fields = fields,
         upper_bound = upper_bound))$unnest("values")
+    Condition
+      Warning:
+      ! Legacy arguments of `<expr>$list$to_struct()` are deprecated as of polars 1.16.0.
+      i Use an explicit character vector for `fields`.
     Output
       shape: (3, 1)
       ┌─────┐
@@ -361,6 +397,10 @@
       pl$DataFrame(values = list(c(1, 2), c(1, 2, 3), c(1)), .schema_overrides = list(
         values = pl$List(pl$Int64)))$select(pl$col("values")$list$to_struct(fields = fields,
         upper_bound = upper_bound))$unnest("values")
+    Condition
+      Warning:
+      ! Legacy arguments of `<expr>$list$to_struct()` are deprecated as of polars 1.16.0.
+      i Use an explicit character vector for `fields`.
     Output
       shape: (3, 4)
       ┌─────┬──────┬──────┬──────┐
@@ -379,7 +419,8 @@
       pl$col("foo")$list$to_struct("foo", fields = "a")
     Condition <lifecycle_warning_deprecated>
       Warning:
-      ! `<expr>$list$to_struct()` with `n_field_strategy` is deprecated and has no effect on execution.
+      ! Legacy arguments of `<expr>$list$to_struct()` are deprecated as of polars 1.16.0.
+      i Use an explicit character vector for `fields`.
     Output
       col("foo").list.to_struct()
 
@@ -389,10 +430,94 @@
       pl$col("foo")$list$to_struct()
     Condition <lifecycle_warning_deprecated>
       Warning:
-      ! `<expr>$list$to_struct()` without `upper_bound` is deprecated, automatically setting `upper_bound = 1L`.
-      i Either modify `fields` to be a vector or specify `upper_bound` to suppress this warning.
+      ! Legacy arguments of `<expr>$list$to_struct()` are deprecated as of polars 1.16.0.
+      i Use an explicit character vector for `fields`.
     Output
       col("foo").list.to_struct()
+
+---
+
+    Code
+      pl$col("foo")$list$to_struct(fields = NULL)
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! Legacy arguments of `<expr>$list$to_struct()` are deprecated as of polars 1.16.0.
+      i Use an explicit character vector for `fields`.
+    Output
+      col("foo").list.to_struct()
+
+---
+
+    Code
+      pl$col("foo")$list$to_struct(fields = function(idx) paste0("field_", idx),
+      upper_bound = 2)
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! Legacy arguments of `<expr>$list$to_struct()` are deprecated as of polars 1.16.0.
+      i Use an explicit character vector for `fields`.
+    Output
+      col("foo").list.to_struct()
+
+---
+
+    Code
+      pl$col("foo")$list$to_struct(fields = c("a"), upper_bound = 1)
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! Legacy arguments of `<expr>$list$to_struct()` are deprecated as of polars 1.16.0.
+      i Use an explicit character vector for `fields`.
+    Output
+      col("foo").list.to_struct()
+
+# list$to_struct accepts future-compatible fields
+
+    Code
+      pl$col("foo")$list$to_struct("max_width")
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! Legacy arguments of `<expr>$list$to_struct()` are deprecated as of polars 1.16.0.
+      i Use an explicit character vector for `fields`.
+    Output
+      col("foo").list.to_struct()
+
+# list$to_struct preserves mixed legacy positional forms
+
+    Code
+      df$select(pl$col("values")$list$to_struct(c("a", "b"), upper_bound = 2))
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! Legacy arguments of `<expr>$list$to_struct()` are deprecated as of polars 1.16.0.
+      i Use an explicit character vector for `fields`.
+    Output
+      shape: (2, 1)
+      ┌───────────┐
+      │ values    │
+      │ ---       │
+      │ struct[2] │
+      ╞═══════════╡
+      │ {1.0,2.0} │
+      │ {1.0,2.0} │
+      └───────────┘
+
+---
+
+    Code
+      df$select(pl$col("values")$list$to_struct(n_field_strategy = "ignored", c("a",
+        "b")))
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! Legacy arguments of `<expr>$list$to_struct()` are deprecated as of polars 1.16.0.
+      i Use an explicit character vector for `fields`.
+    Output
+      shape: (2, 1)
+      ┌───────────┐
+      │ values    │
+      │ ---       │
+      │ struct[2] │
+      ╞═══════════╡
+      │ {1.0,2.0} │
+      │ {1.0,2.0} │
+      └───────────┘
 
 # list$agg() works
 

--- a/tests/testthat/_snaps/series-list.md
+++ b/tests/testthat/_snaps/series-list.md
@@ -3,6 +3,10 @@
     Code
       as_polars_df(as_polars_series(list(c(1, 2), c(1, 2, 3), c(1)))$list$to_struct(
         fields = fields, n_field_strategy = n_field_strategy))
+    Condition
+      Warning:
+      ! Legacy arguments of `<series>$list$to_struct()` are deprecated as of polars 1.16.0.
+      i Use an explicit character vector for `fields`.
     Output
       shape: (3, 2)
       ┌─────────┬─────────┐
@@ -20,6 +24,10 @@
     Code
       as_polars_df(as_polars_series(list(c(1, 2), c(1, 2, 3), c(1)))$list$to_struct(
         fields = fields, n_field_strategy = n_field_strategy))
+    Condition
+      Warning:
+      ! Legacy arguments of `<series>$list$to_struct()` are deprecated as of polars 1.16.0.
+      i Use an explicit character vector for `fields`.
     Output
       shape: (3, 2)
       ┌─────────┬─────────┐
@@ -37,6 +45,10 @@
     Code
       as_polars_df(as_polars_series(list(c(1, 2), c(1, 2, 3), c(1)))$list$to_struct(
         fields = fields, n_field_strategy = n_field_strategy))
+    Condition
+      Warning:
+      ! Legacy arguments of `<series>$list$to_struct()` are deprecated as of polars 1.16.0.
+      i Use an explicit character vector for `fields`.
     Output
       shape: (3, 2)
       ┌─────────┬─────────┐
@@ -54,6 +66,10 @@
     Code
       as_polars_df(as_polars_series(list(c(1, 2), c(1, 2, 3), c(1)))$list$to_struct(
         fields = fields, n_field_strategy = n_field_strategy))
+    Condition
+      Warning:
+      ! Legacy arguments of `<series>$list$to_struct()` are deprecated as of polars 1.16.0.
+      i Use an explicit character vector for `fields`.
     Output
       shape: (3, 3)
       ┌─────────┬─────────┬─────────┐
@@ -71,6 +87,10 @@
     Code
       as_polars_df(as_polars_series(list(c(1, 2), c(1, 2, 3), c(1)))$list$to_struct(
         fields = fields, n_field_strategy = n_field_strategy))
+    Condition
+      Warning:
+      ! Legacy arguments of `<series>$list$to_struct()` are deprecated as of polars 1.16.0.
+      i Use an explicit character vector for `fields`.
     Output
       shape: (3, 3)
       ┌─────────┬─────────┬─────────┐
@@ -88,6 +108,10 @@
     Code
       as_polars_df(as_polars_series(list(c(1, 2), c(1, 2, 3), c(1)))$list$to_struct(
         fields = fields, n_field_strategy = n_field_strategy))
+    Condition
+      Warning:
+      ! Legacy arguments of `<series>$list$to_struct()` are deprecated as of polars 1.16.0.
+      i Use an explicit character vector for `fields`.
     Output
       shape: (3, 3)
       ┌─────────┬─────────┬─────────┐
@@ -105,6 +129,10 @@
     Code
       as_polars_df(as_polars_series(list(c(1, 2), c(1, 2, 3), c(1)))$list$to_struct(
         fields = fields, n_field_strategy = n_field_strategy))
+    Condition
+      Warning:
+      ! Legacy arguments of `<series>$list$to_struct()` are deprecated as of polars 1.16.0.
+      i Use an explicit character vector for `fields`.
     Output
       shape: (3, 1)
       ┌─────┐
@@ -122,6 +150,10 @@
     Code
       as_polars_df(as_polars_series(list(c(1, 2), c(1, 2, 3), c(1)))$list$to_struct(
         fields = fields, n_field_strategy = n_field_strategy))
+    Condition
+      Warning:
+      ! Legacy arguments of `<series>$list$to_struct()` are deprecated as of polars 1.16.0.
+      i Use an explicit character vector for `fields`.
     Output
       shape: (3, 4)
       ┌─────┬──────┬──────┬──────┐
@@ -133,4 +165,72 @@
       │ 1.0 ┆ 2.0  ┆ 3.0  ┆ null │
       │ 1.0 ┆ null ┆ null ┆ null │
       └─────┴──────┴──────┴──────┘
+
+# series list$to_struct accepts future-compatible fields
+
+    Code
+      as_polars_df(series$list$to_struct())
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! Legacy arguments of `<series>$list$to_struct()` are deprecated as of polars 1.16.0.
+      i Use an explicit character vector for `fields`.
+    Output
+      shape: (2, 2)
+      ┌─────────┬─────────┐
+      │ field_0 ┆ field_1 │
+      │ ---     ┆ ---     │
+      │ f64     ┆ f64     │
+      ╞═════════╪═════════╡
+      │ 1.0     ┆ 2.0     │
+      │ 1.0     ┆ 2.0     │
+      └─────────┴─────────┘
+
+---
+
+    Code
+      as_polars_df(series$list$to_struct("max_width"))
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! Legacy arguments of `<series>$list$to_struct()` are deprecated as of polars 1.16.0.
+      i Use an explicit character vector for `fields`.
+    Output
+      shape: (2, 3)
+      ┌─────────┬─────────┬─────────┐
+      │ field_0 ┆ field_1 ┆ field_2 │
+      │ ---     ┆ ---     ┆ ---     │
+      │ f64     ┆ f64     ┆ f64     │
+      ╞═════════╪═════════╪═════════╡
+      │ 1.0     ┆ 2.0     ┆ null    │
+      │ 1.0     ┆ 2.0     ┆ 3.0     │
+      └─────────┴─────────┴─────────┘
+
+---
+
+    Code
+      series$list$to_struct("first_non_null", c("a"), 2)
+    Condition
+      Error in `series$list$to_struct()`:
+      ! Evaluation failed in `$to_struct()`.
+      Caused by error in `parse_to_struct_args()`:
+      ! Too many positional arguments supplied to <series>$list$to_struct().
+
+---
+
+    Code
+      series$list$to_struct(fields = "a", "first_non_null", 2)
+    Condition
+      Error in `series$list$to_struct()`:
+      ! Evaluation failed in `$to_struct()`.
+      Caused by error in `parse_to_struct_args()`:
+      ! Arguments were supplied more than once to <series>$list$to_struct().
+
+---
+
+    Code
+      series$list$to_struct(upper_bound = 2)
+    Condition
+      Error in `series$list$to_struct()`:
+      ! Evaluation failed in `$to_struct()`.
+      Caused by error in `parse_to_struct_args()`:
+      ! `upper_bound` is not supported by <series>$list$to_struct().
 

--- a/tests/testthat/test-expr-array.R
+++ b/tests/testthat/test-expr-array.R
@@ -402,6 +402,40 @@ patrick::with_parameters_test_that(
   }
 )
 
+test_that("arr$to_struct deprecates dynamic field names", {
+  df <- pl$DataFrame(
+    values = list(c(1, 2), c(1, 1)),
+    .schema_overrides = list(values = pl$Array(pl$Int64, 2))
+  )
+
+  expect_no_warning(
+    df$select(pl$col("values")$arr$to_struct(fields = c("a", "b")))
+  )
+  expect_snapshot(
+    df$select(
+      pl$col("values")$arr$to_struct(fields = \(idx) paste0("field_", idx))
+    ),
+    cnd_class = TRUE
+  )
+})
+
+test_that("series arr$to_struct delegates to the expression API", {
+  series <- as_polars_series(
+    list(c(1, 2), c(1, 1)),
+    name = "values"
+  )$cast(pl$Array(pl$Int64, 2))
+  expect_no_warning(series$arr$to_struct())
+  expect_no_warning(series$arr$to_struct(fields = c("a", "b")))
+  expect_snapshot(
+    as_polars_df(series$arr$to_struct(fields = \(idx) paste0("field_", idx))),
+    cnd_class = TRUE
+  )
+  expect_snapshot(
+    as_polars_df(series$arr$to_struct(fields = ~ paste0("field_", .))),
+    cnd_class = TRUE
+  )
+})
+
 test_that("arr$eval()", {
   df <- pl$DataFrame(
     a = list(c(1, 1), c(8, 5), c(3, 2))

--- a/tests/testthat/test-expr-list.R
+++ b/tests/testthat/test-expr-list.R
@@ -756,6 +756,55 @@ test_that("list$to_struct's deprecated argument", {
     cnd_class = TRUE
   )
   expect_snapshot(pl$col("foo")$list$to_struct(), cnd_class = TRUE)
+  expect_snapshot(
+    pl$col("foo")$list$to_struct(fields = NULL),
+    cnd_class = TRUE
+  )
+  expect_snapshot(
+    pl$col("foo")$list$to_struct(
+      fields = \(idx) paste0("field_", idx),
+      upper_bound = 2
+    ),
+    cnd_class = TRUE
+  )
+  expect_snapshot(
+    pl$col("foo")$list$to_struct(fields = c("a"), upper_bound = 1),
+    cnd_class = TRUE
+  )
+})
+
+test_that("list$to_struct accepts future-compatible fields", {
+  expect_no_warning(pl$col("foo")$list$to_struct(c("a", "b")))
+  expect_no_warning(
+    pl$col("foo")$list$to_struct(fields = c("a", "b"))
+  )
+  expect_no_warning(
+    pl$col("foo")$list$to_struct(fields = "max_width")
+  )
+  expect_snapshot(
+    pl$col("foo")$list$to_struct("max_width"),
+    cnd_class = TRUE
+  )
+})
+
+test_that("list$to_struct preserves mixed legacy positional forms", {
+  df <- pl$DataFrame(values = list(c(1, 2), c(1, 2, 3)))
+
+  expect_snapshot(
+    df$select(
+      pl$col("values")$list$to_struct(c("a", "b"), upper_bound = 2)
+    ),
+    cnd_class = TRUE
+  )
+  expect_snapshot(
+    df$select(
+      pl$col("values")$list$to_struct(
+        n_field_strategy = "ignored",
+        c("a", "b")
+      )
+    ),
+    cnd_class = TRUE
+  )
 })
 
 patrick::with_parameters_test_that(

--- a/tests/testthat/test-series-list.R
+++ b/tests/testthat/test-series-list.R
@@ -32,3 +32,29 @@ patrick::with_parameters_test_that(
     )
   }
 )
+
+test_that("series list$to_struct accepts future-compatible fields", {
+  series <- as_polars_series(list(c(1, 2), c(1, 2, 3)))
+
+  expect_no_warning(series$list$to_struct(c("a", "b")))
+  expect_no_warning(series$list$to_struct(fields = c("a", "b")))
+  expect_no_warning(series$list$to_struct(fields = "max_width"))
+  expect_snapshot(as_polars_df(series$list$to_struct()), cnd_class = TRUE)
+  expect_snapshot(
+    as_polars_df(series$list$to_struct("max_width")),
+    cnd_class = TRUE
+  )
+  expect_snapshot(
+    series$list$to_struct("first_non_null", c("a"), 2),
+    error = TRUE
+  )
+  expect_snapshot(
+    series$list$to_struct(
+      fields = "a",
+      "first_non_null",
+      2
+    ),
+    error = TRUE
+  )
+  expect_snapshot(series$list$to_struct(upper_bound = 2), error = TRUE)
+})


### PR DESCRIPTION
## Summary

- add a transitional parser for list to_struct that preserves legacy positional calls while making explicit character field names warning-free
- deprecate omitted, NULL, and callable list fields, n_field_strategy, Expr upper_bound, and callable array fields
- keep fields itself as a supported argument: it becomes required for List in Polars 2.0 and remains optional for Array
- reject upper_bound for the Series API and document the two legacy strategy-name ambiguities
- update examples, generated documentation, NEWS, and warning snapshots

Part of #1852.

## Checks

- task test-filter FILTER=expr-list\|expr-array\|series-list (210 passed)
- task test-filter FILTER=series-list after the final Series upper_bound guard (17 passed)
- air format --check R/ tests/
- jarl check on changed R and test files
- git diff --check
- lintr package scan produced no findings

No pkgload or debug Rust build was used; tests reused the matching release archive.