### PR TITLE
fix: fix deprecated query optimization flags

### DIFF
--- a/R/lazyframe-utils.R
+++ b/R/lazyframe-utils.R
@@ -184,21 +184,17 @@ forward_old_opt_flags <- function(
 
   if (is_present(collapse_joins)) {
     warn_func("collapse_joins")
-    # collapse_joins was merged to predicate_pushdown, so there is no flag anymore
+    # collapse_joins was merged into predicate_pushdown upstream.
+    if (isFALSE(collapse_joins)) {
+      prop(optimizations, "predicate_pushdown", check = FALSE) <- FALSE
+      need_validation <- TRUE
+    }
   }
 
   if (is_present(no_optimization)) {
     warn_func("no_optimization")
     if (isTRUE(no_optimization)) {
-      props(optimizations, check = FALSE) <- list(
-        predicate_pushdown = FALSE,
-        projection_pushdown = FALSE,
-        slice_pushdown = FALSE,
-        comm_subplan_elim = FALSE,
-        comm_subexpr_elim = FALSE,
-        cluster_with_columns = FALSE,
-        check_order_observe = FALSE
-      )
+      optimizations <- optimizations$no_optimizations()
     }
   }
 

--- a/tests/testthat/_snaps/lazyframe-utils.md
+++ b/tests/testthat/_snaps/lazyframe-utils.md
@@ -202,7 +202,34 @@
       <polars::QueryOptFlags>
        @ type_coercion       : logi TRUE
        @ type_check          : logi TRUE
-       @ predicate_pushdown  : logi TRUE
+       @ predicate_pushdown  : logi FALSE
+       @ projection_pushdown : logi TRUE
+       @ simplify_expression : logi TRUE
+       @ slice_pushdown      : logi TRUE
+       @ comm_subplan_elim   : logi TRUE
+       @ comm_subexpr_elim   : logi TRUE
+       @ cluster_with_columns: logi TRUE
+       @ check_order_observe : logi TRUE
+       @ fast_projection     : logi TRUE
+       @ eager               : logi FALSE
+       @ streaming           : logi FALSE
+
+---
+
+    Code
+      test_fn(predicate_pushdown = FALSE, collapse_joins = TRUE)
+    Condition
+      Warning:
+      ! `predicate_pushdown` is deprecated.
+      i Use `optimizations` instead.
+      Warning:
+      ! `collapse_joins` is deprecated.
+      i Use `optimizations` instead.
+    Output
+      <polars::QueryOptFlags>
+       @ type_coercion       : logi TRUE
+       @ type_check          : logi TRUE
+       @ predicate_pushdown  : logi FALSE
        @ projection_pushdown : logi TRUE
        @ simplify_expression : logi TRUE
        @ slice_pushdown      : logi TRUE
@@ -228,13 +255,13 @@
        @ type_check          : logi TRUE
        @ predicate_pushdown  : logi FALSE
        @ projection_pushdown : logi FALSE
-       @ simplify_expression : logi TRUE
+       @ simplify_expression : logi FALSE
        @ slice_pushdown      : logi FALSE
        @ comm_subplan_elim   : logi FALSE
        @ comm_subexpr_elim   : logi FALSE
        @ cluster_with_columns: logi FALSE
        @ check_order_observe : logi FALSE
-       @ fast_projection     : logi TRUE
+       @ fast_projection     : logi FALSE
        @ eager               : logi FALSE
        @ streaming           : logi FALSE
 

--- a/tests/testthat/test-lazyframe-utils.R
+++ b/tests/testthat/test-lazyframe-utils.R
@@ -18,5 +18,6 @@ test_that("forward_old_opt_flags", {
   expect_snapshot(test_fn(comm_subexpr_elim = FALSE))
   expect_snapshot(test_fn(cluster_with_columns = FALSE))
   expect_snapshot(test_fn(collapse_joins = FALSE))
+  expect_snapshot(test_fn(predicate_pushdown = FALSE, collapse_joins = TRUE))
   expect_snapshot(test_fn(no_optimization = TRUE))
 })


### PR DESCRIPTION
## Summary

- preserve predicate pushdown semantics for the deprecated `collapse_joins` flag
- reuse `QueryOptFlags$no_optimizations()` for the deprecated `no_optimization` flag
- cover the resulting flag values with snapshots

## Test

- `task --force test-filter FILTER=lazyframe-utils`
