### PR TITLE
feat: deprecate reader cache arguments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,10 +4,11 @@
 
 ### Deprecations
 
-* The deprecated `file_cache_ttl` argument of the CSV, IPC, and NDJSON
-  readers now warns that the file cache is no longer supported and has no
-  direct replacement in Polars 2.0. It is no longer translated into
-  `storage_options`.
+* The `cache` argument of CSV and Arrow file readers is deprecated: Polars 2.0
+  streaming readers do not use the file cache, and `cache` has no direct
+  replacement. The deprecated `file_cache_ttl` argument of CSV, Arrow file,
+  and NDJSON readers now has the same guidance and is no longer translated
+  into `storage_options`.
 * Omitting `compression` in Arrow file output functions now warns that the
   default will change from `"zstd"` to `"uncompressed"` in Polars 2.0. Pass
   `compression = "zstd"` to keep the current behavior or

--- a/R/input-csv-functions.R
+++ b/R/input-csv-functions.R
@@ -37,6 +37,9 @@
 #' @param ignore_errors Keep reading the file even if some lines yield errors.
 #' You can also use `infer_schema = FALSE` to read all columns as UTF8 to
 #' check which values might cause an issue.
+#' @param cache `r lifecycle::badge("deprecated")` The Polars 2.0 streaming
+#' readers do not use the file cache, and this argument has no direct
+#' replacement.
 #  TODO: enable this parameter
 #  @param with_column_names Apply a function over the column names just in time
 #  (when they are determined). This function will receive (and should return) a
@@ -95,7 +98,7 @@ pl__scan_csv <- function(
   null_values = NULL,
   empty_string_is_null = TRUE,
   ignore_errors = FALSE,
-  cache = FALSE,
+  cache = deprecated(),
   infer_schema = TRUE,
   infer_schema_length = 100,
   infer_schema_files = NULL,
@@ -131,6 +134,12 @@ pl__scan_csv <- function(
   check_number_whole(infer_schema_files, min = 1, allow_null = TRUE)
   encoding <- arg_match0(encoding, values = c("utf8", "utf8-lossy"))
   missing_columns <- arg_match0(missing_columns, values = c("insert", "raise"))
+
+  if (is_present(cache)) {
+    warn_deprecated_file_cache()
+  } else {
+    cache <- FALSE
+  }
 
   if (is_present(missing_utf8_is_empty_string)) {
     deprecate_warn(
@@ -244,7 +253,7 @@ pl__read_csv <- function(
   null_values = NULL,
   empty_string_is_null = TRUE,
   ignore_errors = FALSE,
-  cache = FALSE,
+  cache = deprecated(),
   infer_schema = TRUE,
   infer_schema_length = 100,
   infer_schema_files = NULL,

--- a/R/input-ipc-functions.R
+++ b/R/input-ipc-functions.R
@@ -12,7 +12,9 @@
 #' @param source Path(s) to a file or directory. When needing to authenticate
 #'   for scanning cloud locations, see the `storage_options` parameter.
 #' @param n_rows Stop reading from the source after reading `n_rows`.
-#' @param cache Cache the result after reading.
+#' @param cache `r lifecycle::badge("deprecated")` The Polars 2.0 streaming
+#' readers do not use the file cache, and this argument has no direct
+#' replacement.
 #' @param rechunk `r lifecycle::badge("deprecated")` Reallocate to contiguous
 #'   memory when all chunks/files are parsed. Call `$rechunk()` on the output
 #'   instead.
@@ -38,8 +40,8 @@
 #'   accessing a cloud instance fails. Specify `max_retries` in
 #'   `storage_options` instead.
 #' @param file_cache_ttl `r lifecycle::badge("deprecated")` Deprecated and
-#'   ignored. The file cache is no longer supported and has no direct
-#'   replacement in Polars 2.0.
+#'   ignored. The Polars 2.0 streaming readers do not use the file cache, and
+#'   this argument has no direct replacement.
 #' @param hive_partitioning Infer statistics and schema from Hive partitioned
 #' sources and use them to prune reads. If `NULL` (default), it is automatically
 #' enabled when a single directory is passed, and otherwise disabled.
@@ -73,7 +75,7 @@ pl__scan_ipc <- function(
   source,
   ...,
   n_rows = NULL,
-  cache = TRUE,
+  cache = deprecated(),
   rechunk = deprecated(),
   row_index_name = NULL,
   row_index_offset = 0L,
@@ -88,6 +90,12 @@ pl__scan_ipc <- function(
   check_dots_empty0(...)
   check_list_of_polars_dtype(hive_schema, allow_null = TRUE)
   check_character(storage_options, allow_null = TRUE)
+
+  if (is_present(cache)) {
+    warn_deprecated_file_cache()
+  } else {
+    cache <- TRUE
+  }
 
   if (is_present(retries)) {
     deprecate_warn(
@@ -165,7 +173,7 @@ pl__read_ipc <- function(
   source,
   ...,
   n_rows = NULL,
-  cache = TRUE,
+  cache = deprecated(),
   rechunk = deprecated(),
   row_index_name = NULL,
   row_index_offset = 0L,

--- a/R/input-parquet-functions.R
+++ b/R/input-parquet-functions.R
@@ -26,6 +26,7 @@
 #'   the datatypes in the file(s). If there are extra columns that are not in the
 #'   file(s), consider also enabling `allow_missing_columns`.
 #' @param low_memory Reduce memory pressure at the expense of performance
+#' @param cache Cache the result after reading.
 #' @param missing_columns Configuration for behavior when columns defined in the schema
 #'   are missing from the data:
 #'   - `"raise"` (default): Raises an error.

--- a/R/utils-deprecation.R
+++ b/R/utils-deprecation.R
@@ -29,7 +29,8 @@ warn_deprecated_rechunk <- function(user_env = caller_env(2)) {
   )
 }
 
-# The file cache was removed upstream and has no replacement in Polars 2.0.
+# Polars 2.0 streaming readers do not use the file cache, and this argument
+# has no direct replacement.
 # Keep accepting this argument in the 1.x migration release, but do not pass it
 # on as a storage option.
 warn_deprecated_file_cache_ttl <- function(user_env = caller_env(2)) {
@@ -40,7 +41,25 @@ warn_deprecated_file_cache_ttl <- function(user_env = caller_env(2)) {
         format_arg("file_cache_ttl"),
         format_pkg("polars")
       ),
-      i = "The file cache is no longer supported and has no direct replacement in polars 2.0."
+      i = "The Polars 2.0 streaming readers do not use the file cache, and this argument has no direct replacement."
+    ),
+    user_env = user_env
+  )
+}
+
+# Polars 2.0 streaming readers do not use the file cache, and this argument
+# has no direct replacement.
+# Keep accepting this argument in the 1.x migration release, but do not pass it
+# on to the Rust API as a storage option.
+warn_deprecated_file_cache <- function(user_env = caller_env(2)) {
+  deprecate_warn(
+    c(
+      `!` = sprintf(
+        "The %s argument is deprecated as of %s 1.16.0.",
+        format_arg("cache"),
+        format_pkg("polars")
+      ),
+      i = "The Polars 2.0 streaming readers do not use the file cache, and this argument has no direct replacement."
     ),
     user_env = user_env
   )

--- a/R/utils-deprecation.R
+++ b/R/utils-deprecation.R
@@ -41,7 +41,10 @@ warn_deprecated_file_cache_ttl <- function(user_env = caller_env(2)) {
         format_arg("file_cache_ttl"),
         format_pkg("polars")
       ),
-      i = "The Polars 2.0 streaming readers do not use the file cache, and this argument has no direct replacement."
+      i = paste0(
+        "The Polars 2.0 streaming readers do not use the file cache, ",
+        "and this argument has no direct replacement."
+      )
     ),
     user_env = user_env
   )
@@ -59,7 +62,10 @@ warn_deprecated_file_cache <- function(user_env = caller_env(2)) {
         format_arg("cache"),
         format_pkg("polars")
       ),
-      i = "The Polars 2.0 streaming readers do not use the file cache, and this argument has no direct replacement."
+      i = paste0(
+        "The Polars 2.0 streaming readers do not use the file cache, ",
+        "and this argument has no direct replacement."
+      )
     ),
     user_env = user_env
   )

--- a/man/pl__read_csv.Rd
+++ b/man/pl__read_csv.Rd
@@ -17,7 +17,7 @@ pl__read_csv(
   null_values = NULL,
   empty_string_is_null = TRUE,
   ignore_errors = FALSE,
-  cache = FALSE,
+  cache = deprecated(),
   infer_schema = TRUE,
   infer_schema_length = 100,
   infer_schema_files = NULL,
@@ -85,7 +85,9 @@ missing string values as an empty character instead.}
 You can also use \code{infer_schema = FALSE} to read all columns as UTF8 to
 check which values might cause an issue.}
 
-\item{cache}{Cache the result after reading.}
+\item{cache}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} The Polars 2.0 streaming
+readers do not use the file cache, and this argument has no direct
+replacement.}
 
 \item{infer_schema}{If \code{TRUE} (default), the schema is inferred from the
 data using the first \code{infer_schema_length} rows. When \code{FALSE}, the schema is
@@ -160,8 +162,8 @@ accessing a cloud instance fails. Specify \code{max_retries} in
 \code{storage_options} instead.}
 
 \item{file_cache_ttl}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Deprecated and
-ignored. The file cache is no longer supported and has no direct
-replacement in Polars 2.0.}
+ignored. The Polars 2.0 streaming readers do not use the file cache, and
+this argument has no direct replacement.}
 
 \item{include_file_paths}{Include the path of the source file(s) as a column
 with this name.}

--- a/man/pl__read_ipc.Rd
+++ b/man/pl__read_ipc.Rd
@@ -8,7 +8,7 @@ pl__read_ipc(
   source,
   ...,
   n_rows = NULL,
-  cache = TRUE,
+  cache = deprecated(),
   rechunk = deprecated(),
   row_index_name = NULL,
   row_index_offset = 0L,
@@ -29,7 +29,9 @@ for scanning cloud locations, see the \code{storage_options} parameter.}
 
 \item{n_rows}{Stop reading from the source after reading \code{n_rows}.}
 
-\item{cache}{Cache the result after reading.}
+\item{cache}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} The Polars 2.0 streaming
+readers do not use the file cache, and this argument has no direct
+replacement.}
 
 \item{rechunk}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Reallocate to contiguous
 memory when all chunks/files are parsed. Call \verb{$rechunk()} on the output
@@ -62,8 +64,8 @@ accessing a cloud instance fails. Specify \code{max_retries} in
 \code{storage_options} instead.}
 
 \item{file_cache_ttl}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Deprecated and
-ignored. The file cache is no longer supported and has no direct
-replacement in Polars 2.0.}
+ignored. The Polars 2.0 streaming readers do not use the file cache, and
+this argument has no direct replacement.}
 
 \item{hive_partitioning}{Infer statistics and schema from Hive partitioned
 sources and use them to prune reads. If \code{NULL} (default), it is automatically

--- a/man/pl__read_ndjson.Rd
+++ b/man/pl__read_ndjson.Rd
@@ -83,8 +83,8 @@ accessing a cloud instance fails. Specify \code{max_retries} in
 \code{storage_options} instead.}
 
 \item{file_cache_ttl}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Deprecated and
-ignored. The file cache is no longer supported and has no direct
-replacement in Polars 2.0.}
+ignored. The Polars 2.0 streaming readers do not use the file cache, and
+this argument has no direct replacement.}
 
 \item{include_file_paths}{Include the path of the source file(s) as a column
 with this name.}

--- a/man/pl__scan_csv.Rd
+++ b/man/pl__scan_csv.Rd
@@ -17,7 +17,7 @@ pl__scan_csv(
   null_values = NULL,
   empty_string_is_null = TRUE,
   ignore_errors = FALSE,
-  cache = FALSE,
+  cache = deprecated(),
   infer_schema = TRUE,
   infer_schema_length = 100,
   infer_schema_files = NULL,
@@ -85,7 +85,9 @@ missing string values as an empty character instead.}
 You can also use \code{infer_schema = FALSE} to read all columns as UTF8 to
 check which values might cause an issue.}
 
-\item{cache}{Cache the result after reading.}
+\item{cache}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} The Polars 2.0 streaming
+readers do not use the file cache, and this argument has no direct
+replacement.}
 
 \item{infer_schema}{If \code{TRUE} (default), the schema is inferred from the
 data using the first \code{infer_schema_length} rows. When \code{FALSE}, the schema is
@@ -160,8 +162,8 @@ accessing a cloud instance fails. Specify \code{max_retries} in
 \code{storage_options} instead.}
 
 \item{file_cache_ttl}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Deprecated and
-ignored. The file cache is no longer supported and has no direct
-replacement in Polars 2.0.}
+ignored. The Polars 2.0 streaming readers do not use the file cache, and
+this argument has no direct replacement.}
 
 \item{include_file_paths}{Include the path of the source file(s) as a column
 with this name.}

--- a/man/pl__scan_ipc.Rd
+++ b/man/pl__scan_ipc.Rd
@@ -9,7 +9,7 @@ pl__scan_ipc(
   source,
   ...,
   n_rows = NULL,
-  cache = TRUE,
+  cache = deprecated(),
   rechunk = deprecated(),
   row_index_name = NULL,
   row_index_offset = 0L,
@@ -30,7 +30,9 @@ for scanning cloud locations, see the \code{storage_options} parameter.}
 
 \item{n_rows}{Stop reading from the source after reading \code{n_rows}.}
 
-\item{cache}{Cache the result after reading.}
+\item{cache}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} The Polars 2.0 streaming
+readers do not use the file cache, and this argument has no direct
+replacement.}
 
 \item{rechunk}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Reallocate to contiguous
 memory when all chunks/files are parsed. Call \verb{$rechunk()} on the output
@@ -63,8 +65,8 @@ accessing a cloud instance fails. Specify \code{max_retries} in
 \code{storage_options} instead.}
 
 \item{file_cache_ttl}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Deprecated and
-ignored. The file cache is no longer supported and has no direct
-replacement in Polars 2.0.}
+ignored. The Polars 2.0 streaming readers do not use the file cache, and
+this argument has no direct replacement.}
 
 \item{hive_partitioning}{Infer statistics and schema from Hive partitioned
 sources and use them to prune reads. If \code{NULL} (default), it is automatically

--- a/man/pl__scan_ndjson.Rd
+++ b/man/pl__scan_ndjson.Rd
@@ -83,8 +83,8 @@ accessing a cloud instance fails. Specify \code{max_retries} in
 \code{storage_options} instead.}
 
 \item{file_cache_ttl}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Deprecated and
-ignored. The file cache is no longer supported and has no direct
-replacement in Polars 2.0.}
+ignored. The Polars 2.0 streaming readers do not use the file cache, and
+this argument has no direct replacement.}
 
 \item{include_file_paths}{Include the path of the source file(s) as a column
 with this name.}

--- a/tests/testthat/_snaps/input-csv-functions.md
+++ b/tests/testthat/_snaps/input-csv-functions.md
@@ -107,6 +107,43 @@
       Caused by error:
       ! `storage_options` must be a character vector or `NULL`, not a list.
 
+# read/scan: arg 'cache' is deprecated
+
+    Code
+      pl$scan_csv(tmpf, cache = TRUE)
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! The `cache` argument is deprecated as of polars 1.16.0.
+      i The Polars 2.0 streaming readers do not use the file cache, and this argument has no direct replacement.
+    Output
+      <polars_lazy_frame>
+    Code
+      NULL
+    Output
+      NULL
+
+---
+
+    Code
+      pl$read_csv(tmpf, cache = TRUE)
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! The `cache` argument is deprecated as of polars 1.16.0.
+      i The Polars 2.0 streaming readers do not use the file cache, and this argument has no direct replacement.
+    Output
+      shape: (1, 1)
+      ┌─────┐
+      │ a   │
+      │ --- │
+      │ i64 │
+      ╞═════╡
+      │ 1   │
+      └─────┘
+    Code
+      NULL
+    Output
+      NULL
+
 # arg 'missing_columns' works
 
     Code

--- a/tests/testthat/_snaps/input-ipc-functions.md
+++ b/tests/testthat/_snaps/input-ipc-functions.md
@@ -42,7 +42,11 @@
 
     Code
       pl$scan_ipc(tmpf, cache = 0L)
-    Condition
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! The `cache` argument is deprecated as of polars 1.16.0.
+      i The Polars 2.0 streaming readers do not use the file cache, and this argument has no direct replacement.
+    Condition <rlang_error>
       Error in `pl$scan_ipc()`:
       ! Evaluation failed in `$scan_ipc()`.
       Caused by error:
@@ -90,6 +94,45 @@
       ! Evaluation failed in `$scan_ipc()`.
       Caused by error:
       ! Argument `row_index_offset` must be numeric, not list
+
+# read/scan: arg 'cache' is deprecated
+
+    Code
+      pl$scan_ipc(tmpf, cache = FALSE)
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! The `cache` argument is deprecated as of polars 1.16.0.
+      i The Polars 2.0 streaming readers do not use the file cache, and this argument has no direct replacement.
+    Output
+      <polars_lazy_frame>
+    Code
+      NULL
+    Output
+      NULL
+
+---
+
+    Code
+      pl$read_ipc(tmpf, cache = FALSE)
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! The `cache` argument is deprecated as of polars 1.16.0.
+      i The Polars 2.0 streaming readers do not use the file cache, and this argument has no direct replacement.
+    Output
+      shape: (3, 1)
+      ┌─────┐
+      │ a   │
+      │ --- │
+      │ i32 │
+      ╞═════╡
+      │ 1   │
+      │ 2   │
+      │ 3   │
+      └─────┘
+    Code
+      NULL
+    Output
+      NULL
 
 # scanning from hive partition works
 

--- a/tests/testthat/test-input-csv-functions.R
+++ b/tests/testthat/test-input-csv-functions.R
@@ -312,12 +312,12 @@ test_that("read/scan: arg 'file_cache_ttl' is deprecated", {
 
   expect_warning(
     pl$scan_csv(tmpf, file_cache_ttl = 10),
-    "file cache is no longer supported",
+    "do not use the file cache",
     class = "polars_deprecation_warning"
   )
   expect_warning(
     pl$read_csv(tmpf, file_cache_ttl = 10),
-    "file cache is no longer supported",
+    "do not use the file cache",
     class = "polars_deprecation_warning"
   )
   expect_no_condition(pl$scan_csv(tmpf))
@@ -341,13 +341,52 @@ test_that("read/scan: arg 'file_cache_ttl' is deprecated", {
         file_cache_ttl = "60"
       )
     ),
-    "file cache is no longer supported",
+    "do not use the file cache",
     class = "polars_deprecation_warning"
   )
   expect_identical(
     captured$storage_options,
     c(endpoint_url = "https://example.com", file_cache_ttl = "60")
   )
+})
+
+test_that("read/scan: arg 'cache' is deprecated", {
+  local_lifecycle_warnings()
+  tmpf <- withr::local_tempfile()
+  writeLines("a\n1", tmpf)
+
+  captured <- new.env(parent = emptyenv())
+  original <- get("PlRLazyFrame", asNamespace("polars"))$new_from_csv
+  mock <- new.env(parent = emptyenv())
+  mock$new_from_csv <- function(...) {
+    captured$args <- list(...)
+    original(...)
+  }
+  testthat::local_mocked_bindings(PlRLazyFrame = mock, .package = "polars")
+
+  expect_no_condition(pl$scan_csv(tmpf))
+  expect_false(captured$args$cache)
+
+  expect_snapshot(
+    {
+      pl$scan_csv(tmpf, cache = TRUE)
+      NULL
+    },
+    cnd_class = TRUE
+  )
+  expect_true(captured$args$cache)
+
+  expect_no_condition(pl$read_csv(tmpf))
+  expect_false(captured$args$cache)
+
+  expect_snapshot(
+    {
+      pl$read_csv(tmpf, cache = TRUE)
+      NULL
+    },
+    cnd_class = TRUE
+  )
+  expect_true(captured$args$cache)
 })
 
 test_that("read/scan: arg 'decimal_comma' works", {

--- a/tests/testthat/test-input-ipc-functions.R
+++ b/tests/testthat/test-input-ipc-functions.R
@@ -1,4 +1,5 @@
 test_that("Test reading data from Apache Arrow file", {
+  local_lifecycle_warnings()
   skip_if_not_installed("arrow")
 
   tmpf <- withr::local_tempfile()
@@ -29,7 +30,7 @@ test_that("Test reading data from Apache Arrow file", {
   expect_snapshot(pl$scan_ipc(0), error = TRUE)
   expect_snapshot(pl$scan_ipc(c("foo", NA_character_, "bar")), error = TRUE)
   expect_snapshot(pl$scan_ipc(tmpf, n_rows = "?"), error = TRUE)
-  expect_snapshot(pl$scan_ipc(tmpf, cache = 0L), error = TRUE)
+  expect_snapshot(pl$scan_ipc(tmpf, cache = 0L), error = TRUE, cnd_class = TRUE)
   expect_snapshot(pl$scan_ipc(tmpf, rechunk = list()), error = TRUE)
   expect_snapshot(pl$scan_ipc(tmpf, storage_options = c("foo", "bar")), error = TRUE)
   expect_snapshot(
@@ -55,12 +56,12 @@ test_that("read/scan: arg 'file_cache_ttl' is deprecated", {
 
   expect_warning(
     pl$scan_ipc(tmpf, file_cache_ttl = 10),
-    "file cache is no longer supported",
+    "do not use the file cache",
     class = "polars_deprecation_warning"
   )
   expect_warning(
     pl$read_ipc(tmpf, file_cache_ttl = 10),
-    "file cache is no longer supported",
+    "do not use the file cache",
     class = "polars_deprecation_warning"
   )
   expect_no_condition(pl$scan_ipc(tmpf))
@@ -84,13 +85,52 @@ test_that("read/scan: arg 'file_cache_ttl' is deprecated", {
         file_cache_ttl = "60"
       )
     ),
-    "file cache is no longer supported",
+    "do not use the file cache",
     class = "polars_deprecation_warning"
   )
   expect_identical(
     captured$storage_options,
     c(endpoint_url = "https://example.com", file_cache_ttl = "60")
   )
+})
+
+test_that("read/scan: arg 'cache' is deprecated", {
+  local_lifecycle_warnings()
+  tmpf <- withr::local_tempfile(fileext = ".arrow")
+  pl$DataFrame(a = 1:3)$write_ipc(tmpf, compression = "uncompressed")
+
+  captured <- new.env(parent = emptyenv())
+  original <- get("PlRLazyFrame", asNamespace("polars"))$new_from_ipc
+  mock <- new.env(parent = emptyenv())
+  mock$new_from_ipc <- function(...) {
+    captured$args <- list(...)
+    original(...)
+  }
+  testthat::local_mocked_bindings(PlRLazyFrame = mock, .package = "polars")
+
+  expect_no_condition(pl$scan_ipc(tmpf))
+  expect_true(captured$args$cache)
+
+  expect_snapshot(
+    {
+      pl$scan_ipc(tmpf, cache = FALSE)
+      NULL
+    },
+    cnd_class = TRUE
+  )
+  expect_false(captured$args$cache)
+
+  expect_no_condition(pl$read_ipc(tmpf))
+  expect_true(captured$args$cache)
+
+  expect_snapshot(
+    {
+      pl$read_ipc(tmpf, cache = FALSE)
+      NULL
+    },
+    cnd_class = TRUE
+  )
+  expect_false(captured$args$cache)
 })
 
 test_that("scanning from hive partition works", {

--- a/tests/testthat/test-input-json-functions.R
+++ b/tests/testthat/test-input-json-functions.R
@@ -98,12 +98,12 @@ test_that("read/scan: arg 'file_cache_ttl' is deprecated", {
 
   expect_warning(
     pl$scan_ndjson(tmpf, file_cache_ttl = 10),
-    "file cache is no longer supported",
+    "do not use the file cache",
     class = "polars_deprecation_warning"
   )
   expect_warning(
     pl$read_ndjson(tmpf, file_cache_ttl = 10),
-    "file cache is no longer supported",
+    "do not use the file cache",
     class = "polars_deprecation_warning"
   )
   expect_no_condition(pl$scan_ndjson(tmpf))
@@ -127,7 +127,7 @@ test_that("read/scan: arg 'file_cache_ttl' is deprecated", {
         file_cache_ttl = "60"
       )
     ),
-    "file cache is no longer supported",
+    "do not use the file cache",
     class = "polars_deprecation_warning"
   )
   expect_identical(


### PR DESCRIPTION
## Summary

- deprecate the `cache` argument for CSV and Arrow file readers while preserving the R Polars 1.x defaults and explicit values
- clarify that the Polars 2.0 streaming readers do not use the file cache and that the argument has no direct replacement
- keep Parquet caching supported and cover scan/read warnings and Rust-bound values with snapshots

## Test

- `task --force test-filter FILTER='input-(csv|ipc|json)-functions'`
- `jarl check R/input-csv-functions.R R/input-ipc-functions.R R/input-parquet-functions.R R/utils-deprecation.R tests/testthat/test-input-csv-functions.R tests/testthat/test-input-ipc-functions.R tests/testthat/test-input-json-functions.R`
- `Rscript -e 'lintr::lint_package(cache = TRUE)'`
