### PR TITLE
fix: correct deprecation migration guidance

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,19 @@
 
 ### Deprecations
 
+* `<expr>$flatten()` is deprecated. Use
+  `$list$explode(empty_as_null = FALSE, keep_nulls = FALSE)` for Polars
+  2.0-compatible behavior, or set both arguments to `TRUE` to preserve the
+  legacy behavior.
+* `<expr>$str$concat()` is deprecated. Use `$str$join("-")` when the delimiter
+  is omitted, or pass the same delimiter to `$str$join()`.
+* The `allow_missing_columns` argument of Parquet readers is deprecated. Use
+  `missing_columns = "insert"` or `missing_columns = "raise"` instead.
+* `<lazyframe>$profile()` is deprecated. Starting with Polars 2.0,
+  `engine = "auto"` will use the streaming engine by default, which makes
+  profiling information from this method misleading.
+* `$dt$with_time_unit()` is deprecated. Cast to Int64 and then to the desired
+  Datetime or Duration dtype and time unit instead.
 * The `cache` argument of CSV and Arrow file readers is deprecated: Polars 2.0
   streaming readers do not use the file cache, and `cache` has no direct
   replacement. The deprecated `file_cache_ttl` argument of CSV, Arrow file,
@@ -129,8 +142,8 @@ This is an update that corresponds to Python Polars 1.43.2.
 * `<series>$cat$to_local()` is deprecated; Categoricals no longer have a local
   scope
   ([pola-rs/polars#28299](https://github.com/pola-rs/polars/pull/28299)).
-* `<lazyframe>$profile()` is deprecated. It was made for the older in-memory
-  engine, but Polars now uses a streaming engine by default, and the
+* `<lazyframe>$profile()` is deprecated. Starting with Polars 2.0,
+  `engine = "auto"` will use the streaming engine by default, and the
   profiling information from this method would be misleading
   ([pola-rs/polars#28275](https://github.com/pola-rs/polars/pull/28275)).
 
@@ -234,7 +247,10 @@ This is an update that corresponds to Python Polars 1.38.1.
   recommendation to use `file_cache_ttl` in `storage_options` has since been
   superseded: the file cache is no longer supported and has no direct
   replacement in Polars 2.0.
-- `<expr>$flatten()` is deprecated. Use `<expr>$list$explode()` instead (#1726).
+- `<expr>$flatten()` is deprecated. Use
+  `<expr>$list$explode(empty_as_null = FALSE, keep_nulls = FALSE)` for
+  Polars 2.0-compatible behavior, or set both arguments to `TRUE` to preserve
+  the legacy behavior (#1726).
 
 ### New features
 

--- a/R/expr-datetime.R
+++ b/R/expr-datetime.R
@@ -725,7 +725,8 @@ expr_dt_timestamp <- function(time_unit = c("us", "ns", "ms")) {
 #' Set time unit of a Series of dtype Datetime or Duration
 #' @description
 #' `r lifecycle::badge("deprecated")`
-#' Cast to Int64 and then to Datetime instead.
+#' Cast to Int64 and then to the desired Datetime or Duration dtype and time
+#' unit instead.
 #'
 #' @inheritParams expr_dt_timestamp
 #' @inherit as_polars_expr return
@@ -735,7 +736,10 @@ expr_dt_with_time_unit <- function(time_unit = c("ns", "us", "ms")) {
     deprecate_warn(
       c(
         `!` = "`$dt$with_time_unit()` is deprecated.",
-        i = "Cast to Int64 and then to Datetime with the desired time unit instead."
+        i = paste0(
+          "Cast to Int64 and then to the desired Datetime or Duration dtype ",
+          "and time unit instead."
+        )
       )
     )
     time_unit <- arg_match0(time_unit, values = c("ns", "us", "ms"))

--- a/R/expr-expr.R
+++ b/R/expr-expr.R
@@ -4044,7 +4044,10 @@ expr_arr_explode <- expr__explode
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `$flatten()` is deprecated. Use [$list$explode()][expr_list_explode] instead.
+#' `$flatten()` is deprecated. For Polars 2.0-compatible behavior, use
+#' `$list$explode(empty_as_null = FALSE, keep_nulls = FALSE)`. To preserve the
+#' legacy behavior exactly, use `$list$explode(empty_as_null = TRUE,
+#' keep_nulls = TRUE)`; the null handling differs between these forms.
 #'
 #' @inherit as_polars_expr return
 #' @examples
@@ -4062,7 +4065,12 @@ expr__flatten <- function() {
         format_fn("flatten"),
         format_pkg("polars")
       ),
-      i = sprintf("Use %s instead.", format_fn("list$explode"))
+      i = paste0(
+        "Use `$list$explode(empty_as_null = FALSE, keep_nulls = FALSE)` for ",
+        "Polars 2.0-compatible behavior. Use ",
+        "`$list$explode(empty_as_null = TRUE, keep_nulls = TRUE)` to preserve ",
+        "the legacy behavior exactly."
+      )
     )
   )
   wrap({

--- a/R/expr-string.R
+++ b/R/expr-string.R
@@ -285,10 +285,15 @@ expr_str_concat <- function(
   ...,
   ignore_nulls = TRUE
 ) {
+  replacement <- if (is.null(delimiter)) {
+    'Use `$str$join("-")` instead.'
+  } else {
+    "Use `$str$join()` with the same delimiter instead."
+  }
   deprecate_warn(
     c(
       `!` = "`$str$concat()` is deprecated.",
-      i = "Use `$str$join()` instead."
+      i = replacement
     )
   )
   delimiter <- delimiter %||% "-"

--- a/R/input-parquet-functions.R
+++ b/R/input-parquet-functions.R
@@ -24,7 +24,7 @@
 #' @param schema `r lifecycle::badge("experimental")`
 #'   Named list of [datatypes][DataType] of the columns. The datatypes must match
 #'   the datatypes in the file(s). If there are extra columns that are not in the
-#'   file(s), consider also enabling `allow_missing_columns`.
+#'   file(s), consider also setting `missing_columns = "insert"`.
 #' @param low_memory Reduce memory pressure at the expense of performance
 #' @param cache Cache the result after reading.
 #' @param missing_columns Configuration for behavior when columns defined in the schema
@@ -112,22 +112,17 @@ pl__scan_parquet <- function(
   )
 
   if (is_present(allow_missing_columns)) {
+    missing_columns <- if (allow_missing_columns) "insert" else "raise"
+    replacement <- sprintf('missing_columns = "%s"', missing_columns)
     deprecate_warn(
       c(
         `!` = sprintf(
-          "The argument %s of %s is deprecated.",
-          format_arg("allow_missing_columns"),
-          format_fn("scan_parquet")
+          "The argument %s is deprecated.",
+          format_arg("allow_missing_columns")
         ),
-        i = sprintf(
-          "Use the argument %s instead and pass one of %s.",
-          format_arg("missing_columns"),
-          format_code("('insert', 'raise')")
-        )
+        i = sprintf("Use %s instead.", format_code(replacement))
       )
     )
-
-    missing_columns <- if (allow_missing_columns) "insert" else "raise"
   }
 
   if (!is.null(hive_schema)) {

--- a/R/lazyframe-frame.R
+++ b/R/lazyframe-frame.R
@@ -335,10 +335,10 @@ lazyframe__collect <- function(
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `$profile()` is deprecated. It was made for the older in-memory engine, but
-#' Polars now uses a streaming engine by default. Due to the concurrent nature
-#' of the streaming engine, the profiling information from this method would
-#' be misleading.
+#' `$profile()` is deprecated. Starting with Polars 2.0, `engine = "auto"` will
+#' use the streaming engine by default. Due to the concurrent nature of the
+#' streaming engine, the profiling information from this method would be
+#' misleading.
 #'
 #' This will run the query and return a list containing the
 #' materialized DataFrame and a DataFrame that contains profiling information
@@ -395,7 +395,11 @@ lazyframe__profile <- function(
           format_fn("profile"),
           format_pkg("polars")
         ),
-        i = "It was made for the older in-memory engine, but Polars now uses a streaming engine by default. Due to the concurrent nature of the streaming engine, the profiling information from this method would be misleading." # nolint: line_length_linter
+        i = paste0(
+          "Starting with Polars 2.0, engine = \"auto\" will use the streaming ",
+          "engine by default. Due to the concurrent nature of the streaming ",
+          "engine, the profiling information from this method would be misleading."
+        )
       )
     )
     engine <- arg_match0(engine, c("auto", "in-memory", "streaming"))

--- a/man/expr__flatten.Rd
+++ b/man/expr__flatten.Rd
@@ -12,7 +12,9 @@ A polars \link{expression}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\verb{$flatten()} is deprecated. Use \link[=expr_list_explode]{$list$explode()} instead.
+\verb{$flatten()} is deprecated. For Polars 2.0-compatible behavior, use
+\verb{$list$explode(empty_as_null = FALSE, keep_nulls = FALSE)}. To preserve the
+legacy behavior exactly, use \verb{$list$explode(empty_as_null = TRUE, keep_nulls = TRUE)}; the null handling differs between these forms.
 }
 \examples{
 df <- pl$DataFrame(

--- a/man/expr_dt_with_time_unit.Rd
+++ b/man/expr_dt_with_time_unit.Rd
@@ -14,6 +14,7 @@ A polars \link{expression}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
-Cast to Int64 and then to Datetime instead.
+Cast to Int64 and then to the desired Datetime or Duration dtype and time
+unit instead.
 }
 \keyword{internal}

--- a/man/lazyframe__profile.Rd
+++ b/man/lazyframe__profile.Rd
@@ -90,10 +90,10 @@ also stored in the list.
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\verb{$profile()} is deprecated. It was made for the older in-memory engine, but
-Polars now uses a streaming engine by default. Due to the concurrent nature
-of the streaming engine, the profiling information from this method would
-be misleading.
+\verb{$profile()} is deprecated. Starting with Polars 2.0, \code{engine = "auto"} will
+use the streaming engine by default. Due to the concurrent nature of the
+streaming engine, the profiling information from this method would be
+misleading.
 
 This will run the query and return a list containing the
 materialized DataFrame and a DataFrame that contains profiling information

--- a/man/pl__read_parquet.Rd
+++ b/man/pl__read_parquet.Rd
@@ -68,7 +68,7 @@ enabled when a single directory is passed, and otherwise disabled.}
 \item{schema}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 Named list of \link[=DataType]{datatypes} of the columns. The datatypes must match
 the datatypes in the file(s). If there are extra columns that are not in the
-file(s), consider also enabling \code{allow_missing_columns}.}
+file(s), consider also setting \code{missing_columns = "insert"}.}
 
 \item{hive_schema}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 A list containing the column names and data types of the columns by

--- a/man/pl__scan_parquet.Rd
+++ b/man/pl__scan_parquet.Rd
@@ -68,7 +68,7 @@ enabled when a single directory is passed, and otherwise disabled.}
 \item{schema}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 Named list of \link[=DataType]{datatypes} of the columns. The datatypes must match
 the datatypes in the file(s). If there are extra columns that are not in the
-file(s), consider also enabling \code{allow_missing_columns}.}
+file(s), consider also setting \code{missing_columns = "insert"}.}
 
 \item{hive_schema}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 A list containing the column names and data types of the columns by

--- a/tests/testthat/_snaps/expr-datetime.md
+++ b/tests/testthat/_snaps/expr-datetime.md
@@ -204,7 +204,7 @@
     Condition
       Warning:
       ! `$dt$with_time_unit()` is deprecated.
-      i Cast to Int64 and then to Datetime with the desired time unit instead.
+      i Cast to Int64 and then to the desired Datetime or Duration dtype and time unit instead.
       Error in `as_polars_series(as.Date("2022-1-1"))$dt$with_time_unit()`:
       ! Evaluation failed in `$with_time_unit()`.
       Caused by error:
@@ -219,13 +219,33 @@
     Condition
       Warning:
       ! `$dt$with_time_unit()` is deprecated.
-      i Cast to Int64 and then to Datetime with the desired time unit instead.
+      i Cast to Int64 and then to the desired Datetime or Duration dtype and time unit instead.
       Error in `as_polars_series(as.Date("2022-1-1"))$dt$with_time_unit()`:
       ! Evaluation failed in `$with_time_unit()`.
       Caused by error:
       ! Evaluation failed.
       Caused by error:
       ! `time_unit` must be a string or character vector.
+
+# dt$with_time_unit supports Duration
+
+    Code
+      duration$select(pl$col("duration")$dt$with_time_unit("us"))
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! `$dt$with_time_unit()` is deprecated.
+      i Cast to Int64 and then to the desired Datetime or Duration dtype and time unit instead.
+    Output
+      shape: (3, 1)
+      ┌──────────────┐
+      │ duration     │
+      │ ---          │
+      │ duration[μs] │
+      ╞══════════════╡
+      │ 1µs          │
+      │ 2µs          │
+      │ 3µs          │
+      └──────────────┘
 
 # dt$add_business_days
 

--- a/tests/testthat/_snaps/expr-expr.md
+++ b/tests/testthat/_snaps/expr-expr.md
@@ -287,6 +287,34 @@
       Caused by error:
       ! -1.0 is out of range that can be safely converted to u8
 
+# explode/flatten
+
+    Code
+      pl$DataFrame(a = list(letters))$select(pl$col("a")$flatten())
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! `flatten()` is deprecated as of polars 1.9.0.
+      i Use `$list$explode(empty_as_null = FALSE, keep_nulls = FALSE)` for Polars 2.0-compatible behavior. Use `$list$explode(empty_as_null = TRUE, keep_nulls = TRUE)` to preserve the legacy behavior exactly.
+    Output
+      shape: (26, 1)
+      ┌─────┐
+      │ a   │
+      │ --- │
+      │ str │
+      ╞═════╡
+      │ a   │
+      │ b   │
+      │ c   │
+      │ d   │
+      │ e   │
+      │ …   │
+      │ v   │
+      │ w   │
+      │ x   │
+      │ y   │
+      │ z   │
+      └─────┘
+
 # is_between errors if wrong 'closed' arg
 
     Code

--- a/tests/testthat/_snaps/expr-string.md
+++ b/tests/testthat/_snaps/expr-string.md
@@ -149,6 +149,42 @@
       This error occurred in the following expression:
       	col("with_tz").str.strptime(["raise"])
 
+# str$concat
+
+    Code
+      df$select(pl$col("x")$str$concat())
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! `$str$concat()` is deprecated.
+      i Use `$str$join("-")` instead.
+    Output
+      shape: (1, 1)
+      ┌─────┐
+      │ x   │
+      │ --- │
+      │ str │
+      ╞═════╡
+      │ 1-a │
+      └─────┘
+
+---
+
+    Code
+      df$select(pl$col("x")$str$concat("|"))
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! `$str$concat()` is deprecated.
+      i Use `$str$join()` with the same delimiter instead.
+    Output
+      shape: (1, 1)
+      ┌─────┐
+      │ x   │
+      │ --- │
+      │ str │
+      ╞═════╡
+      │ 1|a │
+      └─────┘
+
 # zfill
 
     Code

--- a/tests/testthat/_snaps/input-parquet-functions.md
+++ b/tests/testthat/_snaps/input-parquet-functions.md
@@ -46,3 +46,81 @@
       Caused by error:
       ! Column(s) not found: did not find column c, consider passing `missing_columns='insert'`
 
+# read/scan: arg 'allow_missing_columns' is deprecated
+
+    Code
+      pl$scan_parquet(tmpf, allow_missing_columns = TRUE)
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! The argument `allow_missing_columns` is deprecated.
+      i Use `missing_columns = "insert"` instead.
+    Output
+      <polars_lazy_frame>
+    Code
+      NULL
+    Output
+      NULL
+
+---
+
+    Code
+      pl$scan_parquet(tmpf, allow_missing_columns = FALSE)
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! The argument `allow_missing_columns` is deprecated.
+      i Use `missing_columns = "raise"` instead.
+    Output
+      <polars_lazy_frame>
+    Code
+      NULL
+    Output
+      NULL
+
+---
+
+    Code
+      pl$read_parquet(tmpf, allow_missing_columns = TRUE)
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! The argument `allow_missing_columns` is deprecated.
+      i Use `missing_columns = "insert"` instead.
+    Output
+      shape: (3, 1)
+      ┌─────┐
+      │ a   │
+      │ --- │
+      │ i32 │
+      ╞═════╡
+      │ 1   │
+      │ 2   │
+      │ 3   │
+      └─────┘
+    Code
+      NULL
+    Output
+      NULL
+
+---
+
+    Code
+      pl$read_parquet(tmpf, allow_missing_columns = FALSE)
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! The argument `allow_missing_columns` is deprecated.
+      i Use `missing_columns = "raise"` instead.
+    Output
+      shape: (3, 1)
+      ┌─────┐
+      │ a   │
+      │ --- │
+      │ i32 │
+      ╞═════╡
+      │ 1   │
+      │ 2   │
+      │ 3   │
+      └─────┘
+    Code
+      NULL
+    Output
+      NULL
+

--- a/tests/testthat/_snaps/lazyframe-frame.md
+++ b/tests/testthat/_snaps/lazyframe-frame.md
@@ -128,6 +128,15 @@
         p1[label="TABLE\nπ 1/11"]
       }
 
+# $profile() is deprecated
+
+    Code
+      invisible(pl$LazyFrame(a = 1:3)$profile())
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! `profile()` is deprecated as of polars 1.14.0.
+      i Starting with Polars 2.0, engine = "auto" will use the streaming engine by default. Due to the concurrent nature of the streaming engine, the profiling information from this method would be misleading.
+
 # $unique's argument deprecation NULL
 
     Code

--- a/tests/testthat/test-expr-datetime.R
+++ b/tests/testthat/test-expr-datetime.R
@@ -602,6 +602,24 @@ test_that("dt$with_time_unit cast_time_unit", {
   )
 })
 
+test_that("dt$with_time_unit supports Duration", {
+  local_lifecycle_warnings()
+  duration <- pl$DataFrame(
+    duration = as_polars_series(1:3)$cast(pl$Duration("ms"))
+  )
+  expect_snapshot(
+    duration$select(pl$col("duration")$dt$with_time_unit("us")),
+    cnd_class = TRUE
+  )
+  local_lifecycle_silence()
+  expect_equal(
+    duration$select(pl$col("duration")$dt$with_time_unit("us")),
+    duration$select(
+      duration = pl$col("duration")$cast(pl$Int64)$cast(pl$Duration("us"))
+    )
+  )
+})
+
 test_that("$convert_time_zone() works", {
   df_time <- pl$select(
     date = pl$datetime_range(

--- a/tests/testthat/test-expr-expr.R
+++ b/tests/testthat/test-expr-expr.R
@@ -1465,26 +1465,44 @@ test_that("filter", {
 })
 
 test_that("explode/flatten", {
+  local_lifecycle_warnings()
   expect_equal(
     pl$DataFrame(a = list(letters))$select(pl$col("a")$explode(empty_as_null = TRUE)),
     pl$DataFrame(a = letters)
   )
-  expect_warning(
-    expect_equal(
-      pl$DataFrame(a = list(letters))$select(pl$col("a")$flatten()),
-      pl$DataFrame(a = letters)
-    ),
-    "is deprecated"
+  expect_snapshot(
+    pl$DataFrame(a = list(letters))$select(pl$col("a")$flatten()),
+    cnd_class = TRUE
   )
-
-  # default warns that empty_as_null will change to FALSE in 2.0
   expect_warning(
     pl$DataFrame(a = list(letters))$select(pl$col("a")$explode()),
     "will change"
   )
+  local_lifecycle_silence()
+  expect_equal(
+    pl$DataFrame(a = list(letters))$select(pl$col("a")$flatten()),
+    pl$DataFrame(a = list(letters))$select(
+      pl$col("a")$list$explode(empty_as_null = TRUE, keep_nulls = TRUE)
+    )
+  )
+  expect_equal(
+    pl$DataFrame(a = list(letters))$select(
+      pl$col("a")$list$explode(empty_as_null = FALSE, keep_nulls = FALSE)
+    ),
+    pl$DataFrame(a = letters)
+  )
 
   # empty and null handling
   df <- pl$DataFrame(a = list(NULL, list(NA), list()))
+  old_flatten <- df$select(pl$col("a")$flatten())
+  expect_equal(
+    old_flatten,
+    df$select(pl$col("a")$list$explode(empty_as_null = TRUE, keep_nulls = TRUE))
+  )
+  future_flatten <- df$select(
+    pl$col("a")$list$explode(empty_as_null = FALSE, keep_nulls = FALSE)
+  )
+  expect_gt(old_flatten$height, future_flatten$height)
   expect_equal(
     df$select(pl$col("a")$explode(empty_as_null = TRUE)),
     pl$DataFrame(a = list(NULL, NA, NULL))

--- a/tests/testthat/test-expr-string.R
+++ b/tests/testthat/test-expr-string.R
@@ -187,6 +187,7 @@ test_that("str$len_bytes str$len_chars", {
 })
 
 test_that("str$concat", {
+  local_lifecycle_warnings()
   df <- pl$DataFrame(x = c("1", "a", NA))
   expect_equal(
     df$select(pl$col("x")$str$join()),
@@ -201,12 +202,30 @@ test_that("str$concat", {
     pl$DataFrame(x = NA_character_)
   )
   # deprecated
-  expect_warning(
-    expect_equal(
-      df$select(pl$col("x")$str$concat()),
-      pl$DataFrame(x = "1-a")
-    ),
-    "deprecated"
+  expect_snapshot(
+    df$select(pl$col("x")$str$concat()),
+    cnd_class = TRUE
+  )
+  expect_snapshot(
+    df$select(pl$col("x")$str$concat("|")),
+    cnd_class = TRUE
+  )
+  local_lifecycle_silence()
+  expect_equal(
+    df$select(pl$col("x")$str$concat()),
+    pl$DataFrame(x = "1-a")
+  )
+  expect_equal(
+    df$select(pl$col("x")$str$concat("|")),
+    pl$DataFrame(x = "1|a")
+  )
+  expect_equal(
+    df$select(pl$col("x")$str$concat()),
+    df$select(pl$col("x")$str$join("-"))
+  )
+  expect_equal(
+    df$select(pl$col("x")$str$concat("|")),
+    df$select(pl$col("x")$str$join("|"))
   )
 
   df <- pl$DataFrame(x = list(c("a", "b", "c"), c("1", "2", "æ")))

--- a/tests/testthat/test-input-parquet-functions.R
+++ b/tests/testthat/test-input-parquet-functions.R
@@ -158,6 +158,59 @@ test_that("arg 'missing_columns' works", {
   )
 })
 
+test_that("read/scan: arg 'allow_missing_columns' is deprecated", {
+  local_lifecycle_warnings()
+  tmpf <- withr::local_tempfile(fileext = ".parquet")
+  pl$DataFrame(a = 1:3)$write_parquet(tmpf)
+
+  captured <- new.env(parent = emptyenv())
+  original <- get("PlRLazyFrame", asNamespace("polars"))$new_from_parquet
+  mock <- new.env(parent = emptyenv())
+  mock$new_from_parquet <- function(...) {
+    captured$args <- list(...)
+    original(...)
+  }
+  testthat::local_mocked_bindings(PlRLazyFrame = mock, .package = "polars")
+
+  expect_snapshot(
+    {
+      pl$scan_parquet(tmpf, allow_missing_columns = TRUE)
+      NULL
+    },
+    cnd_class = TRUE
+  )
+  expect_snapshot(
+    {
+      pl$scan_parquet(tmpf, allow_missing_columns = FALSE)
+      NULL
+    },
+    cnd_class = TRUE
+  )
+  expect_snapshot(
+    {
+      pl$read_parquet(tmpf, allow_missing_columns = TRUE)
+      NULL
+    },
+    cnd_class = TRUE
+  )
+  expect_snapshot(
+    {
+      pl$read_parquet(tmpf, allow_missing_columns = FALSE)
+      NULL
+    },
+    cnd_class = TRUE
+  )
+  local_lifecycle_silence()
+  pl$scan_parquet(tmpf, allow_missing_columns = TRUE)
+  expect_identical(captured$args$missing_columns, "insert")
+  pl$scan_parquet(tmpf, allow_missing_columns = FALSE)
+  expect_identical(captured$args$missing_columns, "raise")
+  pl$read_parquet(tmpf, allow_missing_columns = TRUE)
+  expect_identical(captured$args$missing_columns, "insert")
+  pl$read_parquet(tmpf, allow_missing_columns = FALSE)
+  expect_identical(captured$args$missing_columns, "raise")
+})
+
 test_that("read/scan: arg rechunk is deprecated", {
   tmpf <- withr::local_tempfile(fileext = ".parquet")
   pl$DataFrame(a = 1:3)$write_parquet(tmpf)

--- a/tests/testthat/test-lazyframe-frame.R
+++ b/tests/testthat/test-lazyframe-frame.R
@@ -390,6 +390,14 @@ test_that("$to_dot() works", {
   expect_snapshot(cat(lf$select("am")$to_dot()))
 })
 
+test_that("$profile() is deprecated", {
+  local_lifecycle_warnings()
+  expect_snapshot(
+    invisible(pl$LazyFrame(a = 1:3)$profile()),
+    cnd_class = TRUE
+  )
+})
+
 test_that("set_sorted works", {
   df1 <- pl$DataFrame(
     name = c("steve", "elise", "bob"),


### PR DESCRIPTION
## Summary

- correct deprecation guidance for `flatten()`, `str$concat()`, Parquet `allow_missing_columns`, `profile()`, and `with_time_unit()`
- distinguish Polars 2.0-compatible behavior from legacy-preserving behavior where they differ
- add warning snapshots and regression tests for the documented replacements

Part of #1852.

## Testing

- `task --force test-filter FILTER='(expr-(expr|string|datetime)|input-parquet-functions|lazyframe-frame)'`
- `jarl check` on changed R and test files
- `Rscript -e 'lintr::lint_package(cache = TRUE)'`
- `git diff --check`
