### PR TITLE
docs: use Arrow IPC format terminology

### DIFF
--- a/R/output-ipc.R
+++ b/R/output-ipc.R
@@ -1,7 +1,7 @@
 # TODO: @2.0.0: Remove the migration warning branches and change the
 # default of compression to "uncompressed" in all Arrow file output functions.
 
-#' Evaluate the query in streaming mode and write to Arrow File Format
+#' Evaluate the query in streaming mode and write to Arrow IPC File Format
 #'
 #' @inherit lazyframe__sink_parquet description params return
 #' @inheritParams rlang::args_dots_empty
@@ -160,7 +160,7 @@ lazyframe__lazy_sink_ipc <- function(
   })
 }
 
-#' Write to Arrow File Format
+#' Write to Arrow IPC File Format
 #'
 #' @inheritParams rlang::args_dots_empty
 #' @inheritParams lazyframe__sink_ipc
@@ -208,7 +208,7 @@ dataframe__write_ipc <- function(
   invisible(NULL)
 }
 
-#' Write to Arrow Streaming Format
+#' Write to Arrow IPC Stream Format
 #'
 #' @inheritParams rlang::args_dots_empty
 #' @inheritParams lazyframe__sink_ipc

--- a/man/dataframe__write_ipc.Rd
+++ b/man/dataframe__write_ipc.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/output-ipc.R
 \name{dataframe__write_ipc}
 \alias{dataframe__write_ipc}
-\title{Write to Arrow File Format}
+\title{Write to Arrow IPC File Format}
 \usage{
 dataframe__write_ipc(
   path,
@@ -67,7 +67,7 @@ accessing a cloud instance fails. Specify \code{max_retries} in
 \code{NULL} invisibly.
 }
 \description{
-Write to Arrow File Format
+Write to Arrow IPC File Format
 }
 \examples{
 tmpf <- tempfile(fileext = ".arrow")

--- a/man/dataframe__write_ipc_stream.Rd
+++ b/man/dataframe__write_ipc_stream.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/output-ipc.R
 \name{dataframe__write_ipc_stream}
 \alias{dataframe__write_ipc_stream}
-\title{Write to Arrow Streaming Format}
+\title{Write to Arrow IPC Stream Format}
 \usage{
 dataframe__write_ipc_stream(
   path,
@@ -45,7 +45,7 @@ Use the highest level, currently same as
 \code{NULL} invisibly.
 }
 \description{
-Write to Arrow Streaming Format
+Write to Arrow IPC Stream Format
 }
 \examples{
 \dontshow{if (\{

--- a/man/lazyframe__sink_ipc.Rd
+++ b/man/lazyframe__sink_ipc.Rd
@@ -3,7 +3,7 @@
 \name{lazyframe__sink_ipc}
 \alias{lazyframe__sink_ipc}
 \alias{lazyframe__lazy_sink_ipc}
-\title{Evaluate the query in streaming mode and write to Arrow File Format}
+\title{Evaluate the query in streaming mode and write to Arrow IPC File Format}
 \usage{
 lazyframe__sink_ipc(
   path,


### PR DESCRIPTION
## Summary

- use “Arrow IPC File Format” for `sink_ipc()` and `write_ipc()`
- use “Arrow IPC Stream Format” for `write_ipc_stream()`
- regenerate the corresponding Rd files

This restores the IPC terminology used by the Apache Arrow format specification. It is a documentation-only follow-up to #1856.

Specification: https://arrow.apache.org/docs/format/Columnar.html#ipc-streaming-format

## Validation

- `task build-documents`
- `task format-r`
- `jarl check R/output-ipc.R`
- `lintr::lint_package(cache = TRUE)`
- `git diff --check`
