### PR TITLE
fix: preserve vertical aggregation dtype lists

### DIFF
--- a/R/functions-aggregation-vertical.R
+++ b/R/functions-aggregation-vertical.R
@@ -12,6 +12,10 @@ parse_vertical_agg_input <- function(...) {
     return(unlist(dots, use.names = FALSE))
   }
 
+  if (length(dots) == 1L) {
+    return(dots[[1L]])
+  }
+
   dots
 }
 

--- a/tests/testthat/test-functions-aggregation-vertical.R
+++ b/tests/testthat/test-functions-aggregation-vertical.R
@@ -83,6 +83,18 @@ test_that("vertical aggregation helpers accept vector and spliced names", {
   expect_no_warning(df$select(pl$sum(names)))
   expect_no_warning(df$select(pl$cum_sum(!!!names)))
 
+  dtypes <- list(pl$Int64, pl$Float64)
+  df_dtypes <- pl$DataFrame(
+    int = as.integer(c(1, 2, 3)),
+    dbl = c(1, 2, 3)
+  )
+  expect_no_warning({
+    expect_equal(
+      df_dtypes$select(pl$sum(dtypes)),
+      df_dtypes$select(pl$sum(pl$Int64, pl$Float64))
+    )
+  })
+
   expect_error(
     pl$all(a = "a"),
     "Arguments in `...` must be passed by position, not name"


### PR DESCRIPTION
## Summary

- preserve a single non-character input when normalizing vertical aggregation arguments
- keep a list of Polars data types from being nested before it reaches `pl$col(names = ...)`
- add regression coverage for the single dtype-list form

This is a follow-up to #1867 based on review feedback.

## Testing

- `task test-filter FILTER='functions-aggregation-vertical'` (18 passed, 0 warnings)
- `jarl check R/functions-aggregation-vertical.R tests/testthat/test-functions-aggregation-vertical.R`
- `lintr::lint()` on both changed files
- `git diff --check`
