### PR TITLE
feat: prepare CSV defaults for Polars 2.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,11 @@
   `list(c(...))`.
 * The `...` arguments of `pl$col()`, `cs$by_name()`, and `cs$by_dtype()`
   are deprecated. Pass column names or data types as one vector or list.
+* Omitting `infer_schema_files` in CSV readers now warns because the default
+  will change to `10` in Polars 2.0. Pass `10` to opt into the new default or
+  `NULL` to continue using all files. The conditional Polars 2.0 default of
+  `raise_if_empty` is documented; pass an explicit value when `has_header = FALSE`
+  and `schema` is supplied.
 * The `seed_1`, `seed_2`, and `seed_3` arguments of `<expr>$hash()` and
   `<dataframe>$hash_rows()` are deprecated. Use `seed` instead.
 * `<expr>$agg_groups()`, `<series>$cat$is_local()`, and

--- a/R/input-csv-functions.R
+++ b/R/input-csv-functions.R
@@ -53,8 +53,10 @@
 #' `infer_schema_files`. If `NULL`, the full data may be scanned (this is
 #' slow). Set `infer_schema = FALSE` to read all columns as `pl$String`.
 #' @param infer_schema_files `r lifecycle::badge("experimental")` How many
-#' files to use when inferring the schema. If `NULL` (default), all files are
-#' used.
+#' files to use when inferring the schema. In Polars 1.16, omitting this
+#' argument and setting it to `NULL` uses all files. Starting with Polars 2.0,
+#' the default will be 10 files. Use `infer_schema_files = 10` to opt into the
+#' new default or `infer_schema_files = NULL` to keep using all files.
 #' @param encoding Either `"utf8"` or `"utf8-lossy"`. Lossy means that invalid
 #' UTF8 values are replaced with "?" characters.
 #' @param low_memory Reduce memory pressure at the expense of performance.
@@ -74,15 +76,20 @@
 #  their original name.
 #'
 #' @param raise_if_empty If `FALSE`, parsing an empty file returns an empty
-#' DataFrame or LazyFrame.
+#' DataFrame or LazyFrame. In Polars 1.16, the default is `TRUE`. Starting with
+#' Polars 2.0, the default will be conditional: it will be `FALSE` when
+#' `has_header = FALSE` and `schema` is supplied, and `TRUE` otherwise. Pass an
+#' explicit value to select the desired behavior.
 #' @param truncate_ragged_lines Truncate lines that are longer than the schema.
+#' Its default is unchanged in Polars 1.16. In Polars 2.0, the default will be
+#' determined together with the `extra_columns` CSV option.
 #' @param decimal_comma Parse floats using a comma as the decimal separator
 #' instead of a period.
 #' @param glob Expand path given via globbing rules.
 #' @examples
 #' my_file <- tempfile()
 #' write.csv(iris, my_file)
-#' lazy_frame <- pl$scan_csv(my_file)
+#' lazy_frame <- pl$scan_csv(my_file, infer_schema_files = 10)
 #' lazy_frame$collect()
 #' unlink(my_file)
 pl__scan_csv <- function(
@@ -123,6 +130,8 @@ pl__scan_csv <- function(
   missing_utf8_is_empty_string = deprecated()
 ) {
   check_dots_empty0(...)
+  infer_schema_files_missing <- missing(infer_schema_files)
+  raise_if_empty_missing <- missing(raise_if_empty)
   check_character(source, allow_na = FALSE)
   if (length(source) == 0) {
     abort("`source` must have length > 0.")
@@ -134,6 +143,20 @@ pl__scan_csv <- function(
   check_number_whole(infer_schema_files, min = 1, allow_null = TRUE)
   encoding <- arg_match0(encoding, values = c("utf8", "utf8-lossy"))
   missing_columns <- arg_match0(missing_columns, values = c("insert", "raise"))
+
+  if (infer_schema_files_missing) {
+    # TODO: @2.0: default omitted values to 10 and remove this migration path.
+    warn_csv_infer_schema_files()
+  }
+
+  if (
+    raise_if_empty_missing &&
+      isFALSE(has_header) &&
+      !is.null(schema)
+  ) {
+    # TODO: @2.0: resolve omission as `is.null(schema) || isTRUE(has_header)`.
+    warn_csv_raise_if_empty()
+  }
 
   if (is_present(cache)) {
     warn_deprecated_file_cache()
@@ -212,6 +235,8 @@ pl__scan_csv <- function(
     try_parse_dates = try_parse_dates,
     eol_char = eol_char,
     raise_if_empty = raise_if_empty,
+    # TODO: @2.0: derive omission from `extra_columns == "ignore"` and reject
+    # an explicit `FALSE` when that option requests truncation.
     truncate_ragged_lines = truncate_ragged_lines,
     decimal_comma = decimal_comma,
     glob = glob,
@@ -238,7 +263,7 @@ pl__scan_csv <- function(
 #' @examples
 #' my_file <- tempfile()
 #' write.csv(iris, my_file)
-#' pl$read_csv(my_file)
+#' pl$read_csv(my_file, infer_schema_files = 10)
 #' unlink(my_file)
 pl__read_csv <- function(
   source,
@@ -279,6 +304,18 @@ pl__read_csv <- function(
 ) {
   check_dots_empty0(...)
   .args <- as.list(environment())
+  if (missing(infer_schema_files)) {
+    # TODO: @2.0: remove when the formal default changes to 10.
+    .args$infer_schema_files <- missing_arg()
+  }
+  if (missing(raise_if_empty)) {
+    # TODO: @2.0: retain for the conditional default.
+    .args$raise_if_empty <- missing_arg()
+  }
+  if (missing(truncate_ragged_lines)) {
+    # TODO: @2.0: retain for the `extra_columns`-dependent default.
+    .args$truncate_ragged_lines <- missing_arg()
+  }
   do.call(pl$scan_csv, .args)$collect() |>
     wrap()
 }

--- a/R/output-batches.R
+++ b/R/output-batches.R
@@ -64,7 +64,7 @@
 #'   cat(list.files("."))
 #'   cat("\n\n")
 #'
-#'   pl$read_csv(".")
+#'   pl$read_csv(".", infer_schema_files = NULL)
 #' })
 #'
 #' # The number of rows in each chunk can be adjusted with `chunk_size`.

--- a/R/output-csv.R
+++ b/R/output-csv.R
@@ -50,7 +50,7 @@
 #'
 #' # Create a query that can be run in streaming end-to-end
 #' tmpf2 <- tempfile(fileext = ".csv")
-#' lf <- pl$scan_csv(tmpf)$select(pl$col("cyl") * 2)$lazy_sink_csv(tmpf2)
+#' lf <- pl$scan_csv(tmpf, infer_schema_files = 10)$select(pl$col("cyl") * 2)$lazy_sink_csv(tmpf2)
 #' lf$explain() |>
 #'   cat()
 #'
@@ -58,7 +58,7 @@
 #' lf$collect()
 #'
 #' # Load CSV directly into a DataFrame / memory
-#' pl$read_csv(tmpf2)
+#' pl$read_csv(tmpf2, infer_schema_files = 10)
 lazyframe__sink_csv <- function(
   path,
   ...,
@@ -236,10 +236,10 @@ lazyframe__lazy_sink_csv <- function(
 #' @examples
 #' tmpf <- tempfile()
 #' as_polars_df(mtcars)$write_csv(tmpf)
-#' pl$read_csv(tmpf)
+#' pl$read_csv(tmpf, infer_schema_files = 10)
 #'
 #' as_polars_df(mtcars)$write_csv(tmpf, separator = "|")
-#' pl$read_csv(tmpf, separator = "|")
+#' pl$read_csv(tmpf, separator = "|", infer_schema_files = 10)
 dataframe__write_csv <- function(
   file,
   ...,

--- a/R/utils-deprecation.R
+++ b/R/utils-deprecation.R
@@ -71,6 +71,42 @@ warn_deprecated_file_cache <- function(user_env = caller_env(2)) {
   )
 }
 
+warn_csv_infer_schema_files <- function(user_env = caller_env(2)) {
+  deprecate_warn(
+    c(
+      `!` = sprintf(
+        "The default value of %s will change in %s 2.0.",
+        format_arg("infer_schema_files"),
+        format_pkg("polars")
+      ),
+      i = paste0(
+        "The default will change from using all files to 10 files in Polars 2.0. ",
+        "Use `infer_schema_files = 10` to opt into the new default or ",
+        "`infer_schema_files = NULL` to keep using all files."
+      )
+    ),
+    user_env = user_env
+  )
+}
+
+warn_csv_raise_if_empty <- function(user_env = caller_env(2)) {
+  deprecate_warn(
+    c(
+      `!` = sprintf(
+        "The default value of %s will change in %s 2.0.",
+        format_arg("raise_if_empty"),
+        format_pkg("polars")
+      ),
+      i = paste0(
+        "When `has_header = FALSE` and `schema` is supplied, the default will ",
+        "change from `TRUE` to `FALSE` in Polars 2.0. Use ",
+        "`raise_if_empty = TRUE` to keep the current behavior."
+      )
+    ),
+    user_env = user_env
+  )
+}
+
 warn_arrow_compression_default <- function(user_env = caller_env(2)) {
   deprecate_warn(
     c(

--- a/README.Rmd
+++ b/README.Rmd
@@ -83,7 +83,7 @@ csv_file <- tempfile(fileext = ".csv")
 write.csv(iris, csv_file, row.names = FALSE)
 
 # Create a query plan (LazyFrame) with filtering and group aggregation
-q <- pl$scan_csv(csv_file)$filter(pl$col("Sepal.Length") > 5)$group_by(
+q <- pl$scan_csv(csv_file, infer_schema_files = 10)$filter(pl$col("Sepal.Length") > 5)$group_by(
   "Species",
   .maintain_order = TRUE
 )$agg(pl$all()$sum())

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ csv_file <- tempfile(fileext = ".csv")
 write.csv(iris, csv_file, row.names = FALSE)
 
 # Create a query plan (LazyFrame) with filtering and group aggregation
-q <- pl$scan_csv(csv_file)$filter(pl$col("Sepal.Length") > 5)$group_by(
+q <- pl$scan_csv(csv_file, infer_schema_files = 10)$filter(pl$col("Sepal.Length") > 5)$group_by(
   "Species",
   .maintain_order = TRUE
 )$agg(pl$all()$sum())

--- a/man/dataframe__write_csv.Rd
+++ b/man/dataframe__write_csv.Rd
@@ -127,8 +127,8 @@ Write to comma-separated values (CSV) file
 \examples{
 tmpf <- tempfile()
 as_polars_df(mtcars)$write_csv(tmpf)
-pl$read_csv(tmpf)
+pl$read_csv(tmpf, infer_schema_files = 10)
 
 as_polars_df(mtcars)$write_csv(tmpf, separator = "|")
-pl$read_csv(tmpf, separator = "|")
+pl$read_csv(tmpf, separator = "|", infer_schema_files = 10)
 }

--- a/man/lazyframe__sink_batches.Rd
+++ b/man/lazyframe__sink_batches.Rd
@@ -106,7 +106,7 @@ withr::with_tempdir(\{
   cat(list.files("."))
   cat("\\n\\n")
 
-  pl$read_csv(".")
+  pl$read_csv(".", infer_schema_files = NULL)
 \})
 
 # The number of rows in each chunk can be adjusted with `chunk_size`.

--- a/man/lazyframe__sink_csv.Rd
+++ b/man/lazyframe__sink_csv.Rd
@@ -235,7 +235,7 @@ as_polars_lf(mtcars)$sink_csv(tmpf)
 
 # Create a query that can be run in streaming end-to-end
 tmpf2 <- tempfile(fileext = ".csv")
-lf <- pl$scan_csv(tmpf)$select(pl$col("cyl") * 2)$lazy_sink_csv(tmpf2)
+lf <- pl$scan_csv(tmpf, infer_schema_files = 10)$select(pl$col("cyl") * 2)$lazy_sink_csv(tmpf2)
 lf$explain() |>
   cat()
 
@@ -243,5 +243,5 @@ lf$explain() |>
 lf$collect()
 
 # Load CSV directly into a DataFrame / memory
-pl$read_csv(tmpf2)
+pl$read_csv(tmpf2, infer_schema_files = 10)
 }

--- a/man/pl__read_csv.Rd
+++ b/man/pl__read_csv.Rd
@@ -100,8 +100,10 @@ inference. This applies individually to each file included according to
 slow). Set \code{infer_schema = FALSE} to read all columns as \code{pl$String}.}
 
 \item{infer_schema_files}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}} How many
-files to use when inferring the schema. If \code{NULL} (default), all files are
-used.}
+files to use when inferring the schema. In Polars 1.16, omitting this
+argument and setting it to \code{NULL} uses all files. Starting with Polars 2.0,
+the default will be 10 files. Use \code{infer_schema_files = 10} to opt into the
+new default or \code{infer_schema_files = NULL} to keep using all files.}
 
 \item{n_rows}{Stop reading from the source after reading \code{n_rows}.}
 
@@ -132,9 +134,14 @@ encountering a file with Windows line endings (\code{"\\r\\n"}), one can go with
 default \code{"\\n"}. The extra \code{"\\r"} will be removed when processed.}
 
 \item{raise_if_empty}{If \code{FALSE}, parsing an empty file returns an empty
-DataFrame or LazyFrame.}
+DataFrame or LazyFrame. In Polars 1.16, the default is \code{TRUE}. Starting with
+Polars 2.0, the default will be conditional: it will be \code{FALSE} when
+\code{has_header = FALSE} and \code{schema} is supplied, and \code{TRUE} otherwise. Pass an
+explicit value to select the desired behavior.}
 
-\item{truncate_ragged_lines}{Truncate lines that are longer than the schema.}
+\item{truncate_ragged_lines}{Truncate lines that are longer than the schema.
+Its default is unchanged in Polars 1.16. In Polars 2.0, the default will be
+determined together with the \code{extra_columns} CSV option.}
 
 \item{decimal_comma}{Parse floats using a comma as the decimal separator
 instead of a period.}
@@ -187,6 +194,6 @@ New DataFrame from CSV
 \examples{
 my_file <- tempfile()
 write.csv(iris, my_file)
-pl$read_csv(my_file)
+pl$read_csv(my_file, infer_schema_files = 10)
 unlink(my_file)
 }

--- a/man/pl__scan_csv.Rd
+++ b/man/pl__scan_csv.Rd
@@ -100,8 +100,10 @@ inference. This applies individually to each file included according to
 slow). Set \code{infer_schema = FALSE} to read all columns as \code{pl$String}.}
 
 \item{infer_schema_files}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}} How many
-files to use when inferring the schema. If \code{NULL} (default), all files are
-used.}
+files to use when inferring the schema. In Polars 1.16, omitting this
+argument and setting it to \code{NULL} uses all files. Starting with Polars 2.0,
+the default will be 10 files. Use \code{infer_schema_files = 10} to opt into the
+new default or \code{infer_schema_files = NULL} to keep using all files.}
 
 \item{n_rows}{Stop reading from the source after reading \code{n_rows}.}
 
@@ -132,9 +134,14 @@ encountering a file with Windows line endings (\code{"\\r\\n"}), one can go with
 default \code{"\\n"}. The extra \code{"\\r"} will be removed when processed.}
 
 \item{raise_if_empty}{If \code{FALSE}, parsing an empty file returns an empty
-DataFrame or LazyFrame.}
+DataFrame or LazyFrame. In Polars 1.16, the default is \code{TRUE}. Starting with
+Polars 2.0, the default will be conditional: it will be \code{FALSE} when
+\code{has_header = FALSE} and \code{schema} is supplied, and \code{TRUE} otherwise. Pass an
+explicit value to select the desired behavior.}
 
-\item{truncate_ragged_lines}{Truncate lines that are longer than the schema.}
+\item{truncate_ragged_lines}{Truncate lines that are longer than the schema.
+Its default is unchanged in Polars 1.16. In Polars 2.0, the default will be
+determined together with the \code{extra_columns} CSV option.}
 
 \item{decimal_comma}{Parse floats using a comma as the decimal separator
 instead of a period.}
@@ -188,7 +195,7 @@ the scan level, thereby potentially reducing memory overhead.
 \examples{
 my_file <- tempfile()
 write.csv(iris, my_file)
-lazy_frame <- pl$scan_csv(my_file)
+lazy_frame <- pl$scan_csv(my_file, infer_schema_files = 10)
 lazy_frame$collect()
 unlink(my_file)
 }

--- a/tests/testthat/_snaps/input-csv-functions.md
+++ b/tests/testthat/_snaps/input-csv-functions.md
@@ -1,8 +1,93 @@
 # read/scan: arg raise_if_empty works
 
     Code
-      pl$read_csv(tmpf)
+      pl$read_csv(tmpf, infer_schema_files = NULL)
     Condition
+      Error in `pl$read_csv()`:
+      ! Evaluation failed in `$read_csv()`.
+      Caused by error in `do.call(pl$scan_csv, .args)$collect()`:
+      ! Evaluation failed in `$collect()`.
+      Caused by error:
+      ! no data: empty CSV
+
+# read/scan: CSV default migrations preserve missingness
+
+    Code
+      pl$scan_csv(tmpf)
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! The default value of `infer_schema_files` will change in polars 2.0.
+      i The default will change from using all files to 10 files in Polars 2.0. Use `infer_schema_files = 10` to opt into the new default or `infer_schema_files = NULL` to keep using all files.
+    Output
+      <polars_lazy_frame>
+
+---
+
+    Code
+      pl$read_csv(tmpf)
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! The default value of `infer_schema_files` will change in polars 2.0.
+      i The default will change from using all files to 10 files in Polars 2.0. Use `infer_schema_files = 10` to opt into the new default or `infer_schema_files = NULL` to keep using all files.
+    Output
+      shape: (1, 1)
+      ┌─────┐
+      │ a   │
+      │ --- │
+      │ i64 │
+      ╞═════╡
+      │ 1   │
+      └─────┘
+
+---
+
+    Code
+      pl$scan_csv(empty, has_header = FALSE, schema = list(a = pl$Int64),
+      infer_schema_files = NULL)$collect()
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! The default value of `raise_if_empty` will change in polars 2.0.
+      i When `has_header = FALSE` and `schema` is supplied, the default will change from `TRUE` to `FALSE` in Polars 2.0. Use `raise_if_empty = TRUE` to keep the current behavior.
+    Condition <rlang_error>
+      Error:
+      ! Evaluation failed in `$collect()`.
+      Caused by error:
+      ! no data: empty CSV
+
+---
+
+    Code
+      pl$scan_csv(empty, has_header = FALSE, schema = list(a = pl$Int64),
+      raise_if_empty = TRUE, infer_schema_files = NULL)$collect()
+    Condition <rlang_error>
+      Error:
+      ! Evaluation failed in `$collect()`.
+      Caused by error:
+      ! no data: empty CSV
+
+---
+
+    Code
+      pl$read_csv(empty, has_header = FALSE, schema = list(a = pl$Int64),
+      infer_schema_files = NULL)
+    Condition <lifecycle_warning_deprecated>
+      Warning:
+      ! The default value of `raise_if_empty` will change in polars 2.0.
+      i When `has_header = FALSE` and `schema` is supplied, the default will change from `TRUE` to `FALSE` in Polars 2.0. Use `raise_if_empty = TRUE` to keep the current behavior.
+    Condition <rlang_error>
+      Error in `pl$read_csv()`:
+      ! Evaluation failed in `$read_csv()`.
+      Caused by error in `do.call(pl$scan_csv, .args)$collect()`:
+      ! Evaluation failed in `$collect()`.
+      Caused by error:
+      ! no data: empty CSV
+
+---
+
+    Code
+      pl$read_csv(empty, has_header = FALSE, schema = list(a = pl$Int64),
+      raise_if_empty = TRUE, infer_schema_files = NULL)
+    Condition <rlang_error>
       Error in `pl$read_csv()`:
       ! Evaluation failed in `$read_csv()`.
       Caused by error in `do.call(pl$scan_csv, .args)$collect()`:
@@ -13,7 +98,7 @@
 # read/scan: arg null_values works
 
     Code
-      pl$read_csv(tmpf, null_values = 1:2)
+      pl$read_csv(tmpf, null_values = 1:2, infer_schema_files = NULL)
     Condition
       Error in `pl$read_csv()`:
       ! Evaluation failed in `$read_csv()`.
@@ -23,7 +108,7 @@
 # read/scan: arg encoding works
 
     Code
-      pl$read_csv(tmpf, encoding = "foo")
+      pl$read_csv(tmpf, encoding = "foo", infer_schema_files = NULL)
     Condition
       Error in `pl$read_csv()`:
       ! Evaluation failed in `$read_csv()`.
@@ -33,7 +118,7 @@
 # read/scan: multiple files errors if different schema
 
     Code
-      pl$read_csv(c(tmpf1, tmpf2))
+      pl$read_csv(c(tmpf1, tmpf2), infer_schema_files = NULL)
     Condition
       Error in `pl$read_csv()`:
       ! Evaluation failed in `$read_csv()`.
@@ -45,7 +130,7 @@
 # read/scan: bad paths
 
     Code
-      pl$read_csv(character())
+      pl$read_csv(character(), infer_schema_files = NULL)
     Condition
       Error in `pl$read_csv()`:
       ! Evaluation failed in `$read_csv()`.
@@ -55,7 +140,8 @@
 # read/scan: arg 'schema_overrides' works
 
     Code
-      pl$read_csv(tmpf, schema_overrides = list(b = 1, c = pl$Int32))
+      pl$read_csv(tmpf, schema_overrides = list(b = 1, c = pl$Int32),
+      infer_schema_files = NULL)
     Condition
       Error in `pl$read_csv()`:
       ! Evaluation failed in `$read_csv()`.
@@ -65,7 +151,8 @@
 # read/scan: arg 'schema' works
 
     Code
-      pl$read_csv(tmpf, schema = list(b = pl$Categorical(), c = pl$Int32))
+      pl$read_csv(tmpf, schema = list(b = pl$Categorical(), c = pl$Int32),
+      infer_schema_files = NULL)
     Condition
       Error in `pl$read_csv()`:
       ! Evaluation failed in `$read_csv()`.
@@ -78,7 +165,7 @@
 
     Code
       pl$read_csv(tmpf, schema = list(a = pl$Binary, b = pl$Categorical(), c = pl$
-        Int32))
+        Int32), infer_schema_files = NULL)
     Condition
       Error in `pl$read_csv()`:
       ! Evaluation failed in `$read_csv()`.
@@ -90,7 +177,7 @@
 # read/scan: arg 'storage_options' throws basic errors
 
     Code
-      pl$read_csv(tmpf, storage_options = 1)
+      pl$read_csv(tmpf, storage_options = 1, infer_schema_files = NULL)
     Condition
       Error in `pl$read_csv()`:
       ! Evaluation failed in `$read_csv()`.
@@ -100,7 +187,7 @@
 ---
 
     Code
-      pl$read_csv(tmpf, storage_options = list(a = "b", c = 1))
+      pl$read_csv(tmpf, storage_options = list(a = "b", c = 1), infer_schema_files = NULL)
     Condition
       Error in `pl$read_csv()`:
       ! Evaluation failed in `$read_csv()`.
@@ -110,7 +197,7 @@
 # read/scan: arg 'cache' is deprecated
 
     Code
-      pl$scan_csv(tmpf, cache = TRUE)
+      pl$scan_csv(tmpf, cache = TRUE, infer_schema_files = NULL)
     Condition <lifecycle_warning_deprecated>
       Warning:
       ! The `cache` argument is deprecated as of polars 1.16.0.
@@ -125,7 +212,7 @@
 ---
 
     Code
-      pl$read_csv(tmpf, cache = TRUE)
+      pl$read_csv(tmpf, cache = TRUE, infer_schema_files = NULL)
     Condition <lifecycle_warning_deprecated>
       Warning:
       ! The `cache` argument is deprecated as of polars 1.16.0.
@@ -147,7 +234,7 @@
 # arg 'missing_columns' works
 
     Code
-      pl$read_csv(c(tmpf, tmpf2))
+      pl$read_csv(c(tmpf, tmpf2), infer_schema_files = NULL)
     Condition
       Error in `pl$read_csv()`:
       ! Evaluation failed in `$read_csv()`.

--- a/tests/testthat/test-input-csv-functions.R
+++ b/tests/testthat/test-input-csv-functions.R
@@ -1,8 +1,8 @@
 test_that("read/scan: basic test", {
   tmpf <- withr::local_tempfile()
   write.csv(iris, tmpf, row.names = FALSE)
-  lf <- pl$scan_csv(tmpf)
-  df <- pl$read_csv(tmpf)
+  lf <- pl$scan_csv(tmpf, infer_schema_files = NULL)
+  df <- pl$read_csv(tmpf, infer_schema_files = NULL)
 
   iris_char <- iris
   iris_char$Species <- as.character(iris$Species)
@@ -22,7 +22,8 @@ test_that("read/scan: works with URLs", {
   skip_if_offline()
   # single URL
   out <- pl$read_csv(
-    "https://vincentarelbundock.github.io/Rdatasets/csv/AER/BenderlyZwick.csv"
+    "https://vincentarelbundock.github.io/Rdatasets/csv/AER/BenderlyZwick.csv",
+    infer_schema_files = NULL
   )
   expect_equal(dim(out), c(31, 6))
 
@@ -31,7 +32,8 @@ test_that("read/scan: works with URLs", {
     c(
       "https://vincentarelbundock.github.io/Rdatasets/csv/AER/BenderlyZwick.csv",
       "https://vincentarelbundock.github.io/Rdatasets/csv/AER/BenderlyZwick.csv"
-    )
+    ),
+    infer_schema_files = NULL
   )
   expect_equal(dim(out), c(62, 6))
 })
@@ -41,7 +43,12 @@ test_that("read/scan: args separator and eol work", {
   tmpf <- tempfile(fileext = ".csv")
   write.table(dat, tmpf, row.names = FALSE, sep = "|", eol = "#")
 
-  out <- pl$read_csv(tmpf, separator = "|", eol_char = "#")$with_columns(pl$col(
+  out <- pl$read_csv(
+    tmpf,
+    separator = "|",
+    eol_char = "#",
+    infer_schema_files = NULL
+  )$with_columns(pl$col(
     "Species"
   )$cast(pl$Categorical()))
   expect_equal(out, as_polars_df(iris))
@@ -52,11 +59,11 @@ test_that("read/scan: args skip_rows and skip_rows_after_header work", {
   tmpf <- withr::local_tempfile()
   write.csv(dat, tmpf, row.names = FALSE)
 
-  out <- pl$read_csv(tmpf, skip_rows = 25)
+  out <- pl$read_csv(tmpf, skip_rows = 25, infer_schema_files = NULL)
   expect_equal(nrow(out), 125L)
   expect_named(out, c("4.8", "3.4", "1.9", "0.2", "setosa"))
 
-  out <- pl$read_csv(tmpf, skip_rows_after_header = 25)
+  out <- pl$read_csv(tmpf, skip_rows_after_header = 25, infer_schema_files = NULL)
   expect_equal(nrow(out), 125L)
   expect_named(out, names(iris))
 })
@@ -66,10 +73,10 @@ test_that("read/scan: arg try_parse_date work", {
   tmpf <- withr::local_tempfile()
   write.csv(dat, tmpf, row.names = FALSE)
 
-  out <- pl$read_csv(tmpf)
+  out <- pl$read_csv(tmpf, infer_schema_files = NULL)
   expect_equal(out$schema, list(foo = pl$String))
 
-  out <- pl$read_csv(tmpf, try_parse_dates = TRUE)
+  out <- pl$read_csv(tmpf, try_parse_dates = TRUE, infer_schema_files = NULL)
   expect_equal(out$schema, list(foo = pl$Date))
 })
 
@@ -77,9 +84,98 @@ test_that("read/scan: arg raise_if_empty works", {
   tmpf <- withr::local_tempfile()
   writeLines("", tmpf)
 
-  expect_snapshot(pl$read_csv(tmpf), error = TRUE)
-  out <- pl$read_csv(tmpf, raise_if_empty = FALSE)
+  expect_snapshot(
+    pl$read_csv(tmpf, infer_schema_files = NULL),
+    error = TRUE
+  )
+  out <- pl$read_csv(tmpf, raise_if_empty = FALSE, infer_schema_files = NULL)
   expect_equal(dim(out), c(0L, 0L))
+})
+
+test_that("read/scan: CSV default migrations preserve missingness", {
+  local_lifecycle_warnings()
+  tmpf <- withr::local_tempfile()
+  writeLines("a\n1", tmpf)
+
+  expect_snapshot(
+    pl$scan_csv(tmpf),
+    cnd_class = TRUE
+  )
+  expect_no_condition(pl$scan_csv(tmpf, infer_schema_files = NULL))
+  expect_no_condition(pl$scan_csv(tmpf, infer_schema_files = 10))
+
+  expect_snapshot(
+    pl$read_csv(tmpf),
+    cnd_class = TRUE
+  )
+  expect_no_condition(pl$read_csv(tmpf, infer_schema_files = NULL))
+
+  empty <- withr::local_tempfile()
+  file.create(empty)
+  expect_snapshot(
+    pl$scan_csv(
+      empty,
+      has_header = FALSE,
+      schema = list(a = pl$Int64),
+      infer_schema_files = NULL
+    )$collect(),
+    error = TRUE,
+    cnd_class = TRUE
+  )
+  expect_snapshot(
+    pl$scan_csv(
+      empty,
+      has_header = FALSE,
+      schema = list(a = pl$Int64),
+      raise_if_empty = TRUE,
+      infer_schema_files = NULL
+    )$collect(),
+    error = TRUE,
+    cnd_class = TRUE
+  )
+  scan_out <- expect_no_condition(
+    pl$scan_csv(
+      empty,
+      has_header = FALSE,
+      schema = list(a = pl$Int64),
+      raise_if_empty = FALSE,
+      infer_schema_files = NULL
+    )$collect()
+  )
+  expect_equal(dim(scan_out), c(0L, 1L))
+  expect_equal(scan_out$schema, list(a = pl$Int64))
+  expect_snapshot(
+    pl$read_csv(
+      empty,
+      has_header = FALSE,
+      schema = list(a = pl$Int64),
+      infer_schema_files = NULL
+    ),
+    error = TRUE,
+    cnd_class = TRUE
+  )
+  expect_snapshot(
+    pl$read_csv(
+      empty,
+      has_header = FALSE,
+      schema = list(a = pl$Int64),
+      raise_if_empty = TRUE,
+      infer_schema_files = NULL
+    ),
+    error = TRUE,
+    cnd_class = TRUE
+  )
+  out <- expect_no_condition(
+    pl$read_csv(
+      empty,
+      has_header = FALSE,
+      schema = list(a = pl$Int64),
+      raise_if_empty = FALSE,
+      infer_schema_files = NULL
+    )
+  )
+  expect_equal(dim(out), c(0L, 1L))
+  expect_equal(out$schema, list(a = pl$Int64))
 })
 
 test_that("read/scan: arg glob works", {
@@ -91,14 +187,14 @@ test_that("read/scan: arg glob works", {
   writeLines("a\n2", file2)
 
   expect_equal(
-    pl$read_csv(paste0(tmpdir, "/*.csv"))$sort("a"),
+    pl$read_csv(paste0(tmpdir, "/*.csv"), infer_schema_files = NULL)$sort("a"),
     pl$DataFrame(a = 1:2)$cast(pl$Int64)
   )
   # Don't use snapshot because path printed in error message changes every time
   # and, on Windows, '*' is not a valid character in a path so the error message
   # is different
   expect_error(
-    pl$read_csv(paste0(tmpdir, "/*.csv"), glob = FALSE),
+    pl$read_csv(paste0(tmpdir, "/*.csv"), glob = FALSE, infer_schema_files = NULL),
     "os error"
   )
 })
@@ -107,13 +203,13 @@ test_that("read/scan: arg empty_string_is_null works", {
   tmpf <- withr::local_tempfile()
   writeLines("a,b\n1,a\n2,", tmpf)
 
-  out <- pl$read_csv(tmpf)
+  out <- pl$read_csv(tmpf, infer_schema_files = NULL)
   expect_equal(
     out$select("b"),
     pl$DataFrame(b = c("a", NA))
   )
 
-  out <- pl$read_csv(tmpf, empty_string_is_null = FALSE)
+  out <- pl$read_csv(tmpf, empty_string_is_null = FALSE, infer_schema_files = NULL)
   expect_equal(
     out$select("b"),
     pl$DataFrame(b = c("a", ""))
@@ -125,11 +221,11 @@ test_that("read/scan: arg missing_utf8_is_empty_string is deprecated", {
   writeLines("a,b\n1,a\n2,", tmpf)
 
   expect_deprecated(
-    pl$read_csv(tmpf, missing_utf8_is_empty_string = TRUE)
+    pl$read_csv(tmpf, missing_utf8_is_empty_string = TRUE, infer_schema_files = NULL)
   )
 
   local_lifecycle_silence()
-  out <- pl$read_csv(tmpf, missing_utf8_is_empty_string = TRUE)
+  out <- pl$read_csv(tmpf, missing_utf8_is_empty_string = TRUE, infer_schema_files = NULL)
   expect_equal(
     out$select("b"),
     pl$DataFrame(b = c("a", ""))
@@ -140,7 +236,7 @@ test_that("read/scan: arg null_values works", {
   tmpf <- withr::local_tempfile()
   writeLines("a,b,c\n1.5,a,2\n2,,", tmpf)
 
-  out <- pl$read_csv(tmpf, null_values = c("a", "2"))
+  out <- pl$read_csv(tmpf, null_values = c("a", "2"), infer_schema_files = NULL)
   expect_equal(
     out,
     pl$DataFrame(
@@ -150,7 +246,7 @@ test_that("read/scan: arg null_values works", {
     )
   )
   expect_snapshot(
-    pl$read_csv(tmpf, null_values = 1:2),
+    pl$read_csv(tmpf, null_values = 1:2, infer_schema_files = NULL),
     error = TRUE
   )
 
@@ -163,11 +259,11 @@ test_that("read/scan: arg null_values works", {
     c = c(NA_character_, NA_character_)
   )
   expect_equal(
-    pl$read_csv(tmpf, null_values = c(b = "a", c = "2")),
+    pl$read_csv(tmpf, null_values = c(b = "a", c = "2"), infer_schema_files = NULL),
     expected
   )
   expect_equal(
-    pl$read_csv(tmpf, null_values = c(b = "a", c = 2)),
+    pl$read_csv(tmpf, null_values = c(b = "a", c = 2), infer_schema_files = NULL),
     expected
   )
 })
@@ -177,12 +273,17 @@ test_that("read/scan: args row_index_* work", {
   tmpf <- withr::local_tempfile()
   write.csv(dat, tmpf, row.names = FALSE)
 
-  out <- pl$read_csv(tmpf, row_index_name = "foo")$select("foo")
+  out <- pl$read_csv(tmpf, row_index_name = "foo", infer_schema_files = NULL)$select("foo")
   expect_equal(
     out,
     pl$DataFrame(foo = 0:31)$cast(pl$UInt32)
   )
-  out <- pl$read_csv(tmpf, row_index_name = "foo", row_index_offset = 1)$select("foo")
+  out <- pl$read_csv(
+    tmpf,
+    row_index_name = "foo",
+    row_index_offset = 1,
+    infer_schema_files = NULL
+  )$select("foo")
   expect_equal(
     out,
     pl$DataFrame(foo = 1:32)$cast(pl$UInt32)
@@ -195,7 +296,7 @@ test_that("read/scan: arg encoding works", {
   write.csv(dat, tmpf, row.names = FALSE)
 
   expect_snapshot(
-    pl$read_csv(tmpf, encoding = "foo"),
+    pl$read_csv(tmpf, encoding = "foo", infer_schema_files = NULL),
     error = TRUE
   )
 })
@@ -208,7 +309,9 @@ test_that("read/scan: multiple files works correctly if same schema", {
   write.csv(dat1, tmpf1, row.names = FALSE)
   write.csv(dat2, tmpf2, row.names = FALSE)
 
-  read <- pl$read_csv(c(tmpf1, tmpf2))$with_columns(pl$col("Species")$cast(pl$Categorical()))
+  read <- pl$read_csv(c(tmpf1, tmpf2), infer_schema_files = NULL)$with_columns(pl$col(
+    "Species"
+  )$cast(pl$Categorical()))
   expect_equal(read, as_polars_df(iris))
 })
 
@@ -221,15 +324,15 @@ test_that("read/scan: multiple files errors if different schema", {
   write.csv(dat2, tmpf2, row.names = FALSE)
 
   expect_snapshot(
-    pl$read_csv(c(tmpf1, tmpf2)),
+    pl$read_csv(c(tmpf1, tmpf2), infer_schema_files = NULL),
     error = TRUE
   )
 })
 
 test_that("read/scan: bad paths", {
-  expect_snapshot(pl$read_csv(character()), error = TRUE)
+  expect_snapshot(pl$read_csv(character(), infer_schema_files = NULL), error = TRUE)
   # Error message is platform dependent
-  expect_error(pl$read_csv("some invalid path"), "os error 2")
+  expect_error(pl$read_csv("some invalid path", infer_schema_files = NULL), "os error 2")
 })
 
 test_that("read/scan: scan_csv can include file path", {
@@ -238,7 +341,11 @@ test_that("read/scan: scan_csv can include file path", {
   write.csv(mtcars, temp_file_1)
   write.csv(mtcars, temp_file_2)
 
-  df <- pl$scan_csv(c(temp_file_1, temp_file_2), include_file_paths = "file_paths")$collect()
+  df <- pl$scan_csv(
+    c(temp_file_1, temp_file_2),
+    include_file_paths = "file_paths",
+    infer_schema_files = NULL
+  )$collect()
 
   # Due to https://github.com/pola-rs/polars/pull/26052,
   # the former uses `C:/Users/...`, but the latter `C:\\Users\\...`
@@ -254,18 +361,22 @@ test_that("read/scan: arg 'schema_overrides' works", {
   tmpf <- withr::local_tempfile()
   writeLines("a,b,c\n1.5,a,2\n2,,", tmpf)
   expect_equal(
-    pl$read_csv(tmpf, schema_overrides = list(b = pl$Categorical(), c = pl$Int32)),
+    pl$read_csv(
+      tmpf,
+      schema_overrides = list(b = pl$Categorical(), c = pl$Int32),
+      infer_schema_files = NULL
+    ),
     pl$DataFrame(a = c(1.5, 2), b = factor(c("a", NA)), c = c(2L, NA))
   )
   expect_snapshot(
-    pl$read_csv(tmpf, schema_overrides = list(b = 1, c = pl$Int32)),
+    pl$read_csv(tmpf, schema_overrides = list(b = 1, c = pl$Int32), infer_schema_files = NULL),
     error = TRUE
   )
 
   # works with unnamed elements
   writeLines("a,,c\n1.5,a,2\n2,,", tmpf)
   expect_equal(
-    pl$read_csv(tmpf, schema_overrides = list(pl$Categorical())),
+    pl$read_csv(tmpf, schema_overrides = list(pl$Categorical()), infer_schema_files = NULL),
     pl$DataFrame(a = c(1.5, 2), factor(c("a", NA)), c = c(2L, NA))$cast(c = pl$Int64)
   )
 })
@@ -274,21 +385,33 @@ test_that("read/scan: arg 'schema' works", {
   tmpf <- withr::local_tempfile()
   writeLines("a,b,c\n1.5,a,2\n2,,", tmpf)
   expect_equal(
-    pl$read_csv(tmpf, schema = list(a = pl$Float32, b = pl$Categorical(), c = pl$Int32)),
+    pl$read_csv(
+      tmpf,
+      schema = list(a = pl$Float32, b = pl$Categorical(), c = pl$Int32),
+      infer_schema_files = NULL
+    ),
     pl$DataFrame(a = c(1.5, 2), b = factor(c("a", NA)), c = c(2L, NA))$cast(a = pl$Float32)
   )
 
   # works with unnamed elements
   expect_equal(
-    pl$read_csv(tmpf, schema = list(a = pl$Float64, pl$Categorical(), c = pl$Int32)),
+    pl$read_csv(
+      tmpf,
+      schema = list(a = pl$Float64, pl$Categorical(), c = pl$Int32),
+      infer_schema_files = NULL
+    ),
     pl$DataFrame(a = c(1.5, 2), factor(c("a", NA)), c = c(2L, NA))
   )
   expect_snapshot(
-    pl$read_csv(tmpf, schema = list(b = pl$Categorical(), c = pl$Int32)),
+    pl$read_csv(tmpf, schema = list(b = pl$Categorical(), c = pl$Int32), infer_schema_files = NULL),
     error = TRUE
   )
   expect_snapshot(
-    pl$read_csv(tmpf, schema = list(a = pl$Binary, b = pl$Categorical(), c = pl$Int32)),
+    pl$read_csv(
+      tmpf,
+      schema = list(a = pl$Binary, b = pl$Categorical(), c = pl$Int32),
+      infer_schema_files = NULL
+    ),
     error = TRUE
   )
 })
@@ -297,11 +420,11 @@ test_that("read/scan: arg 'schema' works", {
 test_that("read/scan: arg 'storage_options' throws basic errors", {
   tmpf <- withr::local_tempfile()
   expect_snapshot(
-    pl$read_csv(tmpf, storage_options = 1),
+    pl$read_csv(tmpf, storage_options = 1, infer_schema_files = NULL),
     error = TRUE
   )
   expect_snapshot(
-    pl$read_csv(tmpf, storage_options = list(a = "b", c = 1)),
+    pl$read_csv(tmpf, storage_options = list(a = "b", c = 1), infer_schema_files = NULL),
     error = TRUE
   )
 })
@@ -311,17 +434,17 @@ test_that("read/scan: arg 'file_cache_ttl' is deprecated", {
   writeLines("a\n1", tmpf)
 
   expect_warning(
-    pl$scan_csv(tmpf, file_cache_ttl = 10),
+    pl$scan_csv(tmpf, file_cache_ttl = 10, infer_schema_files = NULL),
     "do not use the file cache",
     class = "polars_deprecation_warning"
   )
   expect_warning(
-    pl$read_csv(tmpf, file_cache_ttl = 10),
+    pl$read_csv(tmpf, file_cache_ttl = 10, infer_schema_files = NULL),
     "do not use the file cache",
     class = "polars_deprecation_warning"
   )
-  expect_no_condition(pl$scan_csv(tmpf))
-  expect_no_condition(pl$read_csv(tmpf))
+  expect_no_condition(pl$scan_csv(tmpf, infer_schema_files = NULL))
+  expect_no_condition(pl$read_csv(tmpf, infer_schema_files = NULL))
 
   captured <- NULL
   original <- get("PlRLazyFrame", asNamespace("polars"))$new_from_csv
@@ -336,6 +459,7 @@ test_that("read/scan: arg 'file_cache_ttl' is deprecated", {
     pl$scan_csv(
       tmpf,
       file_cache_ttl = 10,
+      infer_schema_files = NULL,
       storage_options = c(
         endpoint_url = "https://example.com",
         file_cache_ttl = "60"
@@ -364,24 +488,24 @@ test_that("read/scan: arg 'cache' is deprecated", {
   }
   testthat::local_mocked_bindings(PlRLazyFrame = mock, .package = "polars")
 
-  expect_no_condition(pl$scan_csv(tmpf))
+  expect_no_condition(pl$scan_csv(tmpf, infer_schema_files = NULL))
   expect_false(captured$args$cache)
 
   expect_snapshot(
     {
-      pl$scan_csv(tmpf, cache = TRUE)
+      pl$scan_csv(tmpf, cache = TRUE, infer_schema_files = NULL)
       NULL
     },
     cnd_class = TRUE
   )
   expect_true(captured$args$cache)
 
-  expect_no_condition(pl$read_csv(tmpf))
+  expect_no_condition(pl$read_csv(tmpf, infer_schema_files = NULL))
   expect_false(captured$args$cache)
 
   expect_snapshot(
     {
-      pl$read_csv(tmpf, cache = TRUE)
+      pl$read_csv(tmpf, cache = TRUE, infer_schema_files = NULL)
       NULL
     },
     cnd_class = TRUE
@@ -393,11 +517,11 @@ test_that("read/scan: arg 'decimal_comma' works", {
   tmpf <- withr::local_tempfile()
   writeLines("a|b|c\n1,5|a|2\n2||", tmpf)
   expect_equal(
-    pl$read_csv(tmpf, separator = "|"),
+    pl$read_csv(tmpf, separator = "|", infer_schema_files = NULL),
     pl$DataFrame(a = c("1,5", "2"), b = c("a", NA), c = c(2L, NA))$cast(c = pl$Int64)
   )
   expect_equal(
-    pl$read_csv(tmpf, separator = "|", decimal_comma = TRUE),
+    pl$read_csv(tmpf, separator = "|", decimal_comma = TRUE, infer_schema_files = NULL),
     pl$DataFrame(a = c(1.5, 2), b = c("a", NA), c = c(2L, NA))$cast(c = pl$Int64)
   )
 })
@@ -411,7 +535,7 @@ test_that("can read compressed CSV files", {
   data.table::fwrite(df, path, compress = "gzip")
 
   expect_equal(
-    pl$read_csv(path)$cast(col2 = pl$Int32),
+    pl$read_csv(path, infer_schema_files = NULL)$cast(col2 = pl$Int32),
     df_pl
   )
 })
@@ -424,13 +548,13 @@ test_that("arg 'missing_columns' works", {
 
   # default with different schemas is to error
   expect_snapshot(
-    pl$read_csv(c(tmpf, tmpf2)),
+    pl$read_csv(c(tmpf, tmpf2), infer_schema_files = NULL),
     error = TRUE
   )
 
   # can combine schemas
   expect_equal(
-    pl$read_csv(c(tmpf, tmpf2), missing_columns = "insert"),
+    pl$read_csv(c(tmpf, tmpf2), missing_columns = "insert", infer_schema_files = NULL),
     pl$DataFrame(a = c(1L, 1L), b = c(2L, 2L), c = c(3L, NA))$cast(pl$Int64)
   )
 })
@@ -439,35 +563,48 @@ test_that("read/scan: arg rechunk is deprecated", {
   tmpf <- withr::local_tempfile()
   writeLines("a,b\n1,a\n2,b", tmpf)
 
-  expect_deprecated(pl$read_csv(tmpf, rechunk = TRUE))
-  expect_deprecated(pl$scan_csv(tmpf, rechunk = TRUE))
+  expect_deprecated(pl$read_csv(tmpf, rechunk = TRUE, infer_schema_files = NULL))
+  expect_deprecated(pl$scan_csv(tmpf, rechunk = TRUE, infer_schema_files = NULL))
 
   # not deprecated when not passed
-  expect_no_condition(pl$read_csv(tmpf))
+  expect_no_condition(pl$read_csv(tmpf, infer_schema_files = NULL))
 
   local_lifecycle_silence()
   expect_equal(
-    pl$read_csv(tmpf, rechunk = TRUE),
+    pl$read_csv(tmpf, rechunk = TRUE, infer_schema_files = NULL),
     pl$DataFrame(a = 1:2, b = c("a", "b"), .schema_overrides = list(a = pl$Int64))
   )
 })
 
 test_that("read/scan: arg infer_schema_files works", {
   tmpdir <- withr::local_tempdir()
-  writeLines("a\n1\n2", file.path(tmpdir, "1.csv"))
-  writeLines("a\nx\ny", file.path(tmpdir, "2.csv"))
+  for (i in seq_len(10)) {
+    writeLines(c("a", "1", "2"), file.path(tmpdir, sprintf("%02d.csv", i)))
+  }
+  writeLines(c("a", "x", "y"), file.path(tmpdir, "11.csv"))
   glob <- file.path(tmpdir, "*.csv")
 
-  # by default all files are used for inference, so the common type is String
+  # The 1.16 default uses all files for inference, so the common type is String.
+  local_lifecycle_silence()
   expect_equal(
     pl$scan_csv(glob)$collect_schema(),
     list(a = pl$String)
   )
 
-  # only using the first file infers Int64
   expect_equal(
-    pl$scan_csv(glob, infer_schema_files = 1)$collect_schema(),
+    pl$scan_csv(glob, infer_schema_files = NULL)$collect_schema(),
+    list(a = pl$String)
+  )
+
+  # Only using the first 10 files infers Int64.
+  expect_equal(
+    pl$scan_csv(glob, infer_schema_files = 10)$collect_schema(),
     list(a = pl$Int64)
+  )
+
+  expect_equal(
+    pl$scan_csv(glob, infer_schema_files = 11)$collect_schema(),
+    list(a = pl$String)
   )
 
   expect_error(

--- a/tests/testthat/test-lazyframe-s3-nanoarrow.R
+++ b/tests/testthat/test-lazyframe-s3-nanoarrow.R
@@ -51,7 +51,7 @@ test_that("test lazy scan", {
   writeLines("a\n1", tmpf)
 
   # create array stream
-  stream <- pl$scan_csv(tmpf) |>
+  stream <- pl$scan_csv(tmpf, infer_schema_files = 10) |>
     nanoarrow::as_nanoarrow_array_stream()
 
   # write more rows after creating the stream
@@ -62,7 +62,7 @@ test_that("test lazy scan", {
   expect_shape(df, dim = c(2L, 1L))
 
   # create array stream again
-  stream <- pl$scan_csv(tmpf) |>
+  stream <- pl$scan_csv(tmpf, infer_schema_files = 10) |>
     nanoarrow::as_nanoarrow_array_stream()
 
   # overwrite the file having another schema

--- a/tests/testthat/test-output-csv.R
+++ b/tests/testthat/test-output-csv.R
@@ -2,7 +2,7 @@ test_that("sink_csv works", {
   lf <- as_polars_lf(mtcars)
   temp_out <- withr::local_tempfile(fileext = ".csv")
   expect_null(lf$sink_csv(temp_out))
-  expect_equal(pl$read_csv(temp_out), lf$collect())
+  expect_equal(pl$read_csv(temp_out, infer_schema_files = 10), lf$collect())
 })
 
 test_that("lazy_sink_csv works", {
@@ -11,7 +11,7 @@ test_that("lazy_sink_csv works", {
 
   expect_snapshot(lf$explain() |> cat())
   expect_snapshot(lf$collect())
-  expect_equal(pl$read_csv(temp_out), as_polars_df(mtcars))
+  expect_equal(pl$read_csv(temp_out, infer_schema_files = 10), as_polars_df(mtcars))
 })
 
 test_that("sink_csv: null_value works", {
@@ -25,7 +25,10 @@ test_that("sink_csv: null_value works", {
   )
   lf$sink_csv(temp_out, null_value = "hello")
   expect_equal(
-    pl$read_csv(temp_out)$select("disp", "hp")$slice(offset = 0, length = 1),
+    pl$read_csv(temp_out, infer_schema_files = 10)$select("disp", "hp")$slice(
+      offset = 0,
+      length = 1
+    ),
     pl$DataFrame(disp = "hello", hp = "hello")
   )
 })
@@ -36,7 +39,7 @@ test_that("sink_csv: separator works", {
 
   lf$sink_csv(temp_out, separator = "|")
   expect_equal(
-    pl$read_csv(temp_out, separator = "|"),
+    pl$read_csv(temp_out, separator = "|", infer_schema_files = 10),
     lf$collect()
   )
   expect_error(
@@ -97,12 +100,14 @@ test_that("sink_csv: date_format works", {
   dat$sink_csv(temp_out, date_format = "%Y")
 
   expect_equal(
-    pl$read_csv(temp_out)$with_columns(pl$col("date"))$sort("date")$cast(pl$Int32),
+    pl$read_csv(temp_out, infer_schema_files = 10)$with_columns(pl$col("date"))$sort("date")$cast(
+      pl$Int32
+    ),
     pl$DataFrame(date = 2020:2023)
   )
   dat$sink_csv(temp_out, date_format = "%d/%m/%Y")
   expect_equal(
-    pl$read_csv(temp_out)$sort("date"),
+    pl$read_csv(temp_out, infer_schema_files = 10)$sort("date"),
     pl$DataFrame(date = paste0("01/01/", 2020:2023))
   )
 })
@@ -119,7 +124,7 @@ test_that("sink_csv: datetime_format works", {
   dat$sink_csv(temp_out, datetime_format = "%Hh%Mm - %d/%m/%Y")
 
   expect_equal(
-    pl$read_csv(temp_out)$sort("date"),
+    pl$read_csv(temp_out, infer_schema_files = 10)$sort("date"),
     pl$DataFrame(
       date = c(
         "00h00m - 01/01/2020",
@@ -142,7 +147,7 @@ test_that("sink_csv: time_format works", {
   dat$sink_csv(temp_out, time_format = "%Hh%Mm%Ss")
 
   expect_equal(
-    pl$read_csv(temp_out)$sort("date"),
+    pl$read_csv(temp_out, infer_schema_files = 10)$sort("date"),
     pl$DataFrame(date = paste0(c("00", "00", "08", "16"), "h00m00s"))
   )
 })
@@ -153,13 +158,13 @@ test_that("sink_csv: float_precision works", {
   dat$sink_csv(temp_out, float_precision = 1)
 
   expect_equal(
-    pl$read_csv(temp_out)$sort("x"),
+    pl$read_csv(temp_out, infer_schema_files = 10)$sort("x"),
     pl$DataFrame(x = c(1.2, 5.6))
   )
 
   dat$sink_csv(temp_out, float_precision = 3)
   expect_equal(
-    pl$read_csv(temp_out)$sort("x"),
+    pl$read_csv(temp_out, infer_schema_files = 10)$sort("x"),
     pl$DataFrame(x = c(1.234, 5.600))
   )
 })
@@ -185,7 +190,7 @@ test_that("write_csv works", {
   df <- as_polars_df(mtcars)
   temp_out <- withr::local_tempfile(fileext = ".csv")
   expect_null(df$write_csv(temp_out))
-  expect_equal(pl$read_csv(temp_out), df)
+  expect_equal(pl$read_csv(temp_out, infer_schema_files = 10), df)
 })
 
 test_that("write_csv: null_value works", {
@@ -199,7 +204,10 @@ test_that("write_csv: null_value works", {
   )
   df$write_csv(temp_out, null_value = "hello")
   expect_equal(
-    pl$read_csv(temp_out)$select("disp", "hp")$slice(offset = 0, length = 1),
+    pl$read_csv(temp_out, infer_schema_files = 10)$select("disp", "hp")$slice(
+      offset = 0,
+      length = 1
+    ),
     pl$DataFrame(disp = "hello", hp = "hello")
   )
 })
@@ -210,7 +218,7 @@ test_that("write_csv: separator works", {
 
   df$write_csv(temp_out, separator = "|")
   expect_equal(
-    pl$read_csv(temp_out, separator = "|"),
+    pl$read_csv(temp_out, separator = "|", infer_schema_files = 10),
     df
   )
   expect_error(
@@ -271,12 +279,14 @@ test_that("write_csv: date_format works", {
   dat$write_csv(temp_out, date_format = "%Y")
 
   expect_equal(
-    pl$read_csv(temp_out)$with_columns(pl$col("date"))$sort("date")$cast(pl$Int32),
+    pl$read_csv(temp_out, infer_schema_files = 10)$with_columns(pl$col("date"))$sort("date")$cast(
+      pl$Int32
+    ),
     pl$DataFrame(date = 2020:2023)
   )
   dat$write_csv(temp_out, date_format = "%d/%m/%Y")
   expect_equal(
-    pl$read_csv(temp_out)$sort("date"),
+    pl$read_csv(temp_out, infer_schema_files = 10)$sort("date"),
     pl$DataFrame(date = paste0("01/01/", 2020:2023))
   )
 })
@@ -293,7 +303,7 @@ test_that("write_csv: datetime_format works", {
   dat$write_csv(temp_out, datetime_format = "%Hh%Mm - %d/%m/%Y")
 
   expect_equal(
-    pl$read_csv(temp_out)$sort("date"),
+    pl$read_csv(temp_out, infer_schema_files = 10)$sort("date"),
     pl$DataFrame(
       date = c(
         "00h00m - 01/01/2020",
@@ -316,7 +326,7 @@ test_that("write_csv: time_format works", {
   dat$write_csv(temp_out, time_format = "%Hh%Mm%Ss")
 
   expect_equal(
-    pl$read_csv(temp_out)$sort("date"),
+    pl$read_csv(temp_out, infer_schema_files = 10)$sort("date"),
     pl$DataFrame(date = paste0(c("00", "00", "08", "16"), "h00m00s"))
   )
 })
@@ -327,13 +337,13 @@ test_that("write_csv: float_precision works", {
   dat$write_csv(temp_out, float_precision = 1)
 
   expect_equal(
-    pl$read_csv(temp_out)$sort("x"),
+    pl$read_csv(temp_out, infer_schema_files = 10)$sort("x"),
     pl$DataFrame(x = c(1.2, 5.6))
   )
 
   dat$write_csv(temp_out, float_precision = 3)
   expect_equal(
-    pl$read_csv(temp_out)$sort("x"),
+    pl$read_csv(temp_out, infer_schema_files = 10)$sort("x"),
     pl$DataFrame(x = c(1.234, 5.600))
   )
 })
@@ -360,11 +370,11 @@ test_that("write_csv can export compressed data", {
 
   tmpf <- withr::local_tempfile(fileext = ".csv.zst")
   dat$write_csv(tmpf, compression = "zstd")
-  expect_equal(dat, pl$read_csv(tmpf))
+  expect_equal(dat, pl$read_csv(tmpf, infer_schema_files = 10))
 
   tmpf <- withr::local_tempfile(fileext = ".csv.gz")
   dat$write_csv(tmpf, compression = "gzip")
-  expect_equal(dat, pl$read_csv(tmpf))
+  expect_equal(dat, pl$read_csv(tmpf, infer_schema_files = 10))
 
   expect_snapshot(
     dat$write_csv(tmpf, compression = "foo"),
@@ -377,11 +387,11 @@ test_that("sink_csv can export compressed data", {
 
   tmpf <- withr::local_tempfile(fileext = ".csv.zst")
   dat$sink_csv(tmpf, compression = "zstd")
-  expect_equal(dat$collect(), pl$read_csv(tmpf))
+  expect_equal(dat$collect(), pl$read_csv(tmpf, infer_schema_files = 10))
 
   tmpf <- withr::local_tempfile(fileext = ".csv.gz")
   dat$sink_csv(tmpf, compression = "gzip")
-  expect_equal(dat$collect(), pl$read_csv(tmpf))
+  expect_equal(dat$collect(), pl$read_csv(tmpf, infer_schema_files = 10))
 })
 
 test_that("error if wrong compression extension", {
@@ -409,8 +419,8 @@ test_that("arg check_extension works", {
   tmpf <- withr::local_tempfile(fileext = ".foo")
 
   dat$sink_csv(tmpf, compression = "zstd", check_extension = FALSE)
-  expect_equal(dat$collect(), pl$read_csv(tmpf))
+  expect_equal(dat$collect(), pl$read_csv(tmpf, infer_schema_files = 10))
 
   dat$sink_csv(tmpf, compression = "gzip", check_extension = FALSE)
-  expect_equal(dat$collect(), pl$read_csv(tmpf))
+  expect_equal(dat$collect(), pl$read_csv(tmpf, infer_schema_files = 10))
 })

--- a/vignettes/polars.Rmd
+++ b/vignettes/polars.Rmd
@@ -455,13 +455,13 @@ demonstrate using the `airquality` dataset that also comes bundled with base R.
 ```{r}
 write.csv(airquality, "airquality.csv", row.names = FALSE)
 
-pl$read_csv("airquality.csv")
+pl$read_csv("airquality.csv", infer_schema_files = 10)
 ```
 
 Again, however, the package works best if we take the lazy approach.
 
 ```{r}
-pl$scan_csv("airquality.csv")
+pl$scan_csv("airquality.csv", infer_schema_files = 10)
 ```
 
 We could obviously append a set of query operators to the above LazyFrame and


### PR DESCRIPTION
## Summary

- preserve the Polars 1.x CSV defaults while warning about the Polars 2.0 changes
- preserve omitted CSV arguments when `read_csv()` forwards to `scan_csv()`
- document the migration and update examples/tests to use explicit warning-free values

## Behavior

- omitted `infer_schema_files` warns that the default will change to `10`, while 1.16 continues to inspect all files
- explicit `infer_schema_files = 10` and `NULL` remain warning-free
- omitted `raise_if_empty` warns only when `has_header = FALSE` and `schema` is supplied, where the 2.0 default will differ
- `truncate_ragged_lines` remains unchanged in 1.16; TODOs record its future `extra_columns`-dependent default

CSV `extra_columns` was introduced upstream together with the broader 2.0 schema semantics in pola-rs/polars#28377, so it is intentionally deferred until the 2.0 dependency bump.

Refs #1852

## Tests

- `task test-filter FILTER=csv` (`FAIL 0`, `WARN 0`, `PASS 140`)
- `task test-filter FILTER=input-csv-functions` (`FAIL 0`, `WARN 0`, `PASS 83`)
- `task test-filter FILTER=lazyframe-s3-nanoarrow` (`FAIL 0`, `WARN 0`, `PASS 7`)
- `jarl check .`
- `lintr::lint_package(cache = FALSE)` without pkgload; no new findings in changed files
