### PR TITLE
test: cover Polars 2.0 migration behavior

### DIFF
--- a/tests/testthat/_snaps/migration-polars-2.md
+++ b/tests/testthat/_snaps/migration-polars-2.md
@@ -129,7 +129,6 @@
     Condition <polars_deprecation_warning>
       Warning:
       `list.gather` with a flat datatype is deprecated. Please use `implode` to return to previous behavior.
-
       See https://github.com/pola-rs/polars/issues/22149 for more information.
     Output
       shape: (2, 1)
@@ -149,7 +148,6 @@
     Condition <polars_deprecation_warning>
       Warning:
       `is_in` with a collection of the same datatype is ambiguous and deprecated. Please use `implode` to return to previous behavior.
-
       See https://github.com/pola-rs/polars/issues/22149 for more information.
     Output
       shape: (3, 1)

--- a/tests/testthat/_snaps/migration-polars-2.md
+++ b/tests/testthat/_snaps/migration-polars-2.md
@@ -1,0 +1,255 @@
+# Duration statistics preserve current behavior
+
+    Code
+      input$select(pl$col("x")$var())
+    Condition
+      Error in `input$select()`:
+      ! Evaluation failed in `$select()`.
+      Caused by error:
+      ! Evaluation failed in `$collect()`.
+      Caused by error:
+      ! Invalid operation: operation `var` is not supported for `duration[ms]`
+
+---
+
+    Code
+      input$select(pl$col("x")$ewm_std(com = 1))
+    Output
+      shape: (3, 1)
+      ┌──────────┐
+      │ x        │
+      │ ---      │
+      │ f64      │
+      ╞══════════╡
+      │ null     │
+      │ 0.707107 │
+      │ 0.963624 │
+      └──────────┘
+
+---
+
+    Code
+      input$select(pl$col("x")$ewm_var(com = 1))
+    Condition
+      Error in `input$select()`:
+      ! Evaluation failed in `$select()`.
+      Caused by error:
+      ! Evaluation failed in `$collect()`.
+      Caused by error:
+      ! Invalid operation: operation `var` is not supported for `duration[ms]`
+
+# empty DataFrame transpose preserves the current error
+
+    Code
+      pl$DataFrame()$transpose()
+    Condition
+      Error:
+      ! Evaluation failed in `$transpose()`.
+      Caused by error:
+      ! no data: unable to transpose an empty DataFrame
+
+# Rust deprecation warnings are routed to R snapshots
+
+    Code
+      pl$DataFrame(x = 1:3)$select(pl$col("x")$cast(pl$List(pl$Int32)))
+    Condition <polars_deprecation_warning>
+      Warning:
+      casting from Int32 to list type is deprecated Hint: Use pl.list(expr) to turn the Int32 column into a column of single-element lists.
+    Output
+      shape: (3, 1)
+      ┌───────────┐
+      │ x         │
+      │ ---       │
+      │ list[i32] │
+      ╞═══════════╡
+      │ [1]       │
+      │ [2]       │
+      │ [3]       │
+      └───────────┘
+
+---
+
+    Code
+      pl$select(pl$lit(c(TRUE, FALSE)) & pl$lit(c(1L, 0L)))
+    Condition <polars_deprecation_warning>
+      Warning:
+      & on Boolean and Int32 is deprecated and will raise a ComputeError in Polars 2.0 Hint: cast the Boolean to Int32 using pl.Expr.cast().
+    Output
+      shape: (2, 1)
+      ┌─────────┐
+      │ literal │
+      │ ---     │
+      │ i32     │
+      ╞═════════╡
+      │ 1       │
+      │ 0       │
+      └─────────┘
+
+---
+
+    Code
+      pl$select(pl$lit(c(TRUE, FALSE)) | pl$lit(c(1L, 0L)))
+    Condition <polars_deprecation_warning>
+      Warning:
+      | on Boolean and Int32 is deprecated and will raise a ComputeError in Polars 2.0 Hint: cast the Boolean to Int32 using pl.Expr.cast().
+    Output
+      shape: (2, 1)
+      ┌─────────┐
+      │ literal │
+      │ ---     │
+      │ i32     │
+      ╞═════════╡
+      │ 1       │
+      │ 0       │
+      └─────────┘
+
+---
+
+    Code
+      pl$select(pl$lit(c(TRUE, FALSE))$xor(pl$lit(c(1L, 0L))))
+    Condition <polars_deprecation_warning>
+      Warning:
+      ^ on Boolean and Int32 is deprecated and will raise a ComputeError in Polars 2.0 Hint: cast the Boolean to Int32 using pl.Expr.cast().
+    Output
+      shape: (2, 1)
+      ┌─────────┐
+      │ literal │
+      │ ---     │
+      │ i32     │
+      ╞═════════╡
+      │ 0       │
+      │ 0       │
+      └─────────┘
+
+---
+
+    Code
+      pl$DataFrame(x = list(c(1L, 2L), c(3L, 4L)))$select(pl$col("x")$list$gather(c(
+        0L, 1L)))
+    Condition <polars_deprecation_warning>
+      Warning:
+      `list.gather` with a flat datatype is deprecated. Please use `implode` to return to previous behavior.
+
+      See https://github.com/pola-rs/polars/issues/22149 for more information.
+    Output
+      shape: (2, 1)
+      ┌───────────┐
+      │ x         │
+      │ ---       │
+      │ list[i32] │
+      ╞═══════════╡
+      │ [1, 2]    │
+      │ [3, 4]    │
+      └───────────┘
+
+---
+
+    Code
+      pl$DataFrame(x = 1:3)$select(pl$col("x")$is_in(pl$lit(1:3)))
+    Condition <polars_deprecation_warning>
+      Warning:
+      `is_in` with a collection of the same datatype is ambiguous and deprecated. Please use `implode` to return to previous behavior.
+
+      See https://github.com/pola-rs/polars/issues/22149 for more information.
+    Output
+      shape: (3, 1)
+      ┌──────┐
+      │ x    │
+      │ ---  │
+      │ bool │
+      ╞══════╡
+      │ true │
+      │ true │
+      │ true │
+      └──────┘
+
+---
+
+    Code
+      pl$DataFrame(x = 1:3)$select(pl$col("x")$shift(NULL))
+    Condition <polars_deprecation_warning>
+      Warning:
+      shift value 'n' is null, which currently returns a column of null values. This will become an error in the future.
+    Output
+      shape: (3, 1)
+      ┌──────┐
+      │ x    │
+      │ ---  │
+      │ i32  │
+      ╞══════╡
+      │ null │
+      │ null │
+      │ null │
+      └──────┘
+
+---
+
+    Code
+      categorical$select(pl$col("x")$cast(pl$UInt32))
+    Condition <polars_deprecation_warning>
+      Warning:
+      casting from Categorical to UInt32 is deprecated. Instead of `.cast(UInt32)`, use `.cat.physical()`.
+    Output
+      shape: (2, 1)
+      ┌─────┐
+      │ x   │
+      │ --- │
+      │ u32 │
+      ╞═════╡
+      │ 0   │
+      │ 1   │
+      └─────┘
+
+---
+
+    Code
+      enum$select(pl$col("x")$cast(pl$UInt32))
+    Condition <polars_deprecation_warning>
+      Warning:
+      casting from Enum([...]) to UInt32 is deprecated. Instead of `.cast(UInt32)`, use `.cat.physical()`.
+    Output
+      shape: (2, 1)
+      ┌─────┐
+      │ x   │
+      │ --- │
+      │ u32 │
+      ╞═════╡
+      │ 0   │
+      │ 1   │
+      └─────┘
+
+---
+
+    Code
+      pl$DataFrame(x = 0:1)$select(pl$col("x")$cast(pl$Categorical()))
+    Condition <polars_deprecation_warning>
+      Warning:
+      casting from Int32 to Categorical is deprecated. Instead of `.cast(Categorical`, use `.cat.to(Categorical)`.
+    Output
+      shape: (2, 1)
+      ┌─────┐
+      │ x   │
+      │ --- │
+      │ cat │
+      ╞═════╡
+      │ a   │
+      │ b   │
+      └─────┘
+
+---
+
+    Code
+      pl$DataFrame(x = 0:1)$select(pl$col("x")$cast(pl$Enum(c("a", "b"))))
+    Condition <polars_deprecation_warning>
+      Warning:
+      casting from Int32 to Enum([...]) is deprecated. Instead of `.cast(Enum([...])`, use `.cat.to(Enum([...]))`.
+    Output
+      shape: (2, 1)
+      ┌──────┐
+      │ x    │
+      │ ---  │
+      │ enum │
+      ╞══════╡
+      │ a    │
+      │ b    │
+      └──────┘

--- a/tests/testthat/test-input-csv-functions.R
+++ b/tests/testthat/test-input-csv-functions.R
@@ -418,6 +418,23 @@ test_that("read/scan: arg 'schema' works", {
   )
 })
 
+test_that("read/scan: schema currently matches columns positionally", {
+  tmpf <- withr::local_tempfile()
+  writeLines("a,b\nA,B", tmpf)
+  schema <- list(b = pl$String, a = pl$String)
+
+  # TODO: @2.0: schema fields will match by name, so expect b = "B" and a = "A".
+  expected <- pl$DataFrame(b = "A", a = "B")
+  expect_equal(
+    pl$scan_csv(tmpf, schema = schema, infer_schema_files = NULL)$collect(),
+    expected
+  )
+  expect_equal(
+    pl$read_csv(tmpf, schema = schema, infer_schema_files = NULL),
+    expected
+  )
+})
+
 # TODO: can't check if it actually works
 test_that("read/scan: arg 'storage_options' throws basic errors", {
   tmpf <- withr::local_tempfile()

--- a/tests/testthat/test-input-csv-functions.R
+++ b/tests/testthat/test-input-csv-functions.R
@@ -379,6 +379,8 @@ test_that("read/scan: arg 'schema_overrides' works", {
     pl$read_csv(tmpf, schema_overrides = list(pl$Categorical()), infer_schema_files = NULL),
     pl$DataFrame(a = c(1.5, 2), factor(c("a", NA)), c = c(2L, NA))$cast(c = pl$Int64)
   )
+  # TODO: @2.0: require unnamed schema overrides to cover every column; use
+  # a named list for partial overrides.
 })
 
 test_that("read/scan: arg 'schema' works", {

--- a/tests/testthat/test-input-ipc-functions.R
+++ b/tests/testthat/test-input-ipc-functions.R
@@ -12,6 +12,10 @@ test_that("Test reading data from Apache Arrow file", {
     as_polars_df(iris)
   )
   expect_equal(
+    pl$read_ipc(tmpf),
+    pl$scan_ipc(tmpf)$collect()
+  )
+  expect_equal(
     pl$scan_ipc(tmpf, n_rows = read_limit)$collect(),
     as_polars_df(droplevels(head(iris, read_limit)))
   )

--- a/tests/testthat/test-lazyframe-frame.R
+++ b/tests/testthat/test-lazyframe-frame.R
@@ -299,17 +299,17 @@ test_that("with_columns_seq can create list variables", {
 test_that("bottom_k works", {
   df <- pl$DataFrame(
     a = c("a", "b", "a", "b", "b", "c"),
-    b = c(2, 1, 1, 3, 2, 1)
+    b = c(2, 1, 4, 3, 5, 6)
   )
   expect_query_equal(
-    .input$bottom_k(4, by = "b"),
+    .input$bottom_k(4, by = "b")$sort("b"),
     df,
-    pl$DataFrame(a = c("b", "a", "c", "a"), b = c(1, 1, 1, 2))
+    pl$DataFrame(a = c("b", "a", "b", "a"), b = c(1, 2, 3, 4))
   )
   expect_query_equal(
-    .input$bottom_k(4, by = c("a", "b")),
+    .input$bottom_k(4, by = c("a", "b"))$sort(c("a", "b")),
     df,
-    pl$DataFrame(a = c("a", "a", "b", "b"), b = c(1, 2, 1, 2))
+    pl$DataFrame(a = c("a", "a", "b", "b"), b = c(2, 4, 1, 3))
   )
   expect_query_error(
     .input$bottom_k(4, by = 1),
@@ -321,17 +321,17 @@ test_that("bottom_k works", {
 test_that("top_k works", {
   df <- pl$DataFrame(
     a = c("a", "b", "a", "b", "b", "c"),
-    b = c(2, 1, 1, 3, 2, 1)
+    b = c(2, 1, 4, 3, 5, 6)
   )
   expect_query_equal(
-    .input$top_k(4, by = "b"),
+    .input$top_k(4, by = "b")$sort("b", descending = TRUE),
     df,
-    pl$DataFrame(a = c("b", "a", "b", "b"), b = c(3, 2, 2, 1))
+    pl$DataFrame(a = c("c", "b", "a", "b"), b = c(6, 5, 4, 3))
   )
   expect_query_equal(
-    .input$top_k(4, by = c("a", "b")),
+    .input$top_k(4, by = c("a", "b"))$sort(c("a", "b")),
     df,
-    pl$DataFrame(a = c("c", "b", "b", "b"), b = c(1, 3, 2, 1))
+    pl$DataFrame(a = c("b", "b", "b", "c"), b = c(1, 3, 5, 6))
   )
   expect_query_error(
     .input$top_k(4, by = 1),
@@ -505,7 +505,7 @@ test_that("join: basic usage", {
 
   # inner default
   expect_query_equal(
-    .input$join(.input2, on = "ham"),
+    .input$join(.input2, on = "ham", maintain_order = "left"),
     .input = df,
     .input2 = other_df,
     pl$DataFrame(
@@ -518,7 +518,7 @@ test_that("join: basic usage", {
 
   # outer
   expect_query_equal(
-    .input$join(.input2, on = "ham", how = "full"),
+    .input$join(.input2, on = "ham", how = "full", maintain_order = "right_left"),
     .input = df,
     .input2 = other_df,
     pl$DataFrame(
@@ -550,7 +550,7 @@ test_that("right join works", {
   a <- pl$DataFrame(a = c(1, 2, 3), b = c(1, 2, 4))
   b <- pl$DataFrame(a = c(1, 3), b = c(1, 3), c = c(1, 3))
   expect_query_equal(
-    .input$join(.input2, on = "a", how = "right", coalesce = TRUE),
+    .input$join(.input2, on = "a", how = "right", coalesce = TRUE, maintain_order = "right"),
     .input = a,
     .input2 = b,
     pl$DataFrame(
@@ -561,7 +561,7 @@ test_that("right join works", {
     )
   )
   expect_query_equal(
-    .input$join(.input2, on = "a", how = "right", coalesce = FALSE),
+    .input$join(.input2, on = "a", how = "right", coalesce = FALSE, maintain_order = "right"),
     .input = a,
     .input2 = b,
     pl$DataFrame(
@@ -579,7 +579,7 @@ test_that("semi and anti join", {
   df_b <- pl$DataFrame(key = c(3L, 4L, 5L, NA))
 
   expect_query_equal(
-    .input$join(.input2, on = "key", how = "anti"),
+    .input$join(.input2, on = "key", how = "anti", maintain_order = "left"),
     .input = df_a,
     .input2 = df_b,
     pl$DataFrame(key = 1:2, payload = c("f", "i"))
@@ -595,7 +595,7 @@ test_that("semi and anti join", {
   df_b <- pl$DataFrame(a = c(3L, 3L, 4L, 5L), b = c("c", "c", "d", "e"))
 
   expect_query_equal(
-    .input$join(.input2, on = c("a", "b"), how = "anti"),
+    .input$join(.input2, on = c("a", "b"), how = "anti", maintain_order = "left"),
     .input = df_a,
     .input2 = df_b,
     pl$DataFrame(a = c(1:2, 1L), b = c("a", "b", "a"), payload = c(10L, 20L, 40L))
@@ -613,7 +613,7 @@ test_that("cross join", {
   dat2 <- pl$DataFrame(y = 1:4)
 
   expect_query_equal(
-    .input$join(.input2, how = "cross"),
+    .input$join(.input2, how = "cross", maintain_order = "left_right"),
     .input = dat,
     .input2 = dat2,
     pl$DataFrame(
@@ -647,7 +647,7 @@ test_that("cross join", {
 
   # suffix works
   expect_query_equal(
-    .input$join(.input, how = "cross"),
+    .input$join(.input, how = "cross", maintain_order = "left_right"),
     .input = dat,
     pl$DataFrame(
       x = rep(letters[1:3], each = 3),
@@ -692,7 +692,7 @@ test_that("argument 'nulls_equal' works", {
 
   # consider nulls as a valid key
   expect_query_equal(
-    .input$join(.input2, on = "x", nulls_equal = TRUE),
+    .input$join(.input2, on = "x", nulls_equal = TRUE, maintain_order = "left"),
     .input = df1,
     .input2 = df2,
     pl$DataFrame(x = c(NA, "b"), y = c(1L, 3L), y2 = c(4L, 5L))
@@ -701,7 +701,7 @@ test_that("argument 'nulls_equal' works", {
   # several nulls
   df3 <- pl$DataFrame(x = c(NA, letters[2:3], NA), y2 = 4:7)
   expect_query_equal(
-    .input$join(.input2, on = "x", nulls_equal = TRUE),
+    .input$join(.input2, on = "x", nulls_equal = TRUE, maintain_order = "right"),
     .input = df1,
     .input2 = df3,
     pl$DataFrame(x = c(NA, "b", NA), y = c(1L, 3L, 1L), y2 = c(4L, 5L, 7L))
@@ -1802,7 +1802,7 @@ test_that("inequality joins work", {
       .input2,
       pl$col("dur") < pl$col("time"),
       pl$col("rev") < pl$col("cost")
-    ),
+    )$sort("id", "t_id"),
     .input = east,
     .input2 = west,
     pl$DataFrame(
@@ -1814,7 +1814,7 @@ test_that("inequality joins work", {
       time = c(130, 150, 170, 150, 170),
       cost = c(13, 15, 16, 15, 16),
       cores_right = c(2, 1, 4, 1, 4)
-    )
+    )$sort("id", "t_id")
   )
 
   expect_query_error(
@@ -1908,7 +1908,7 @@ test_that("inequality joins require suffix when identical column names", {
       .input2,
       pl$col("dur") < pl$col("dur_right"),
       pl$col("rev") < pl$col("rev_right")
-    ),
+    )$sort("id", "t_id"),
     .input = east,
     .input2 = west,
     pl$DataFrame(
@@ -1920,7 +1920,7 @@ test_that("inequality joins require suffix when identical column names", {
       dur_right = c(130, 150, 170, 150, 170),
       rev_right = c(13, 15, 16, 15, 16),
       cores_right = c(2, 1, 4, 1, 4)
-    )
+    )$sort("id", "t_id")
   )
 })
 
@@ -2009,26 +2009,26 @@ test_that("unpivot() works", {
   )
 
   expect_query_equal(
-    .input$unpivot(index = "a", on = c("b", "c")),
+    .input$unpivot(index = "a", on = c("b", "c"))$sort("a", "variable"),
     .input = df,
     pl$DataFrame(
       a = c("x", "y", "z", "x", "y", "z"),
       variable = c("b", "b", "b", "c", "c", "c"),
       value = c(1, 3, 5, 2, 4, 6)
-    )
+    )$sort("a", "variable")
   )
   # value_name = "c" conflicts with existing column "c" in lazy path
   # (upstream fix pola-rs/polars#26606: proper duplicate name check for unpivot)
   # Eager path succeeds because the column is consumed before value_name is applied
   expect_eager_equal_lazy_error(
-    .input$unpivot(index = c("a", "b"), value_name = "c"),
+    .input$unpivot(index = c("a", "b"), value_name = "c")$sort("a", "b", "variable"),
     input = df,
     expected = pl$DataFrame(
       a = c("x", "y", "z"),
       b = c(1, 3, 5),
       variable = rep("c", 3),
       c = c(2, 4, 6)
-    ),
+    )$sort("a", "b", "variable"),
     "duplicate",
     fixed = TRUE
   )
@@ -2038,14 +2038,14 @@ test_that("unpivot() works", {
       on = "c",
       value_name = "alice",
       variable_name = "bob"
-    ),
+    )$sort("a", "b", "bob"),
     .input = df,
     pl$DataFrame(
       a = c("x", "y", "z"),
       b = c(1, 3, 5),
       bob = rep("c", 3),
       alice = c(2, 4, 6)
-    )
+    )$sort("a", "b", "bob")
   )
   expect_query_equal(
     .input$unpivot(
@@ -2053,14 +2053,14 @@ test_that("unpivot() works", {
       on = cs$by_name("c"), # single selector is allowed
       value_name = "alice",
       variable_name = "bob"
-    ),
+    )$sort("a", "b", "bob"),
     .input = df,
     df$unpivot(
       index = c("a", "b"),
       on = "c",
       value_name = "alice",
       variable_name = "bob"
-    )
+    )$sort("a", "b", "bob")
   )
 
   expect_query_error(
@@ -2247,7 +2247,7 @@ test_that("rolling: argument 'group_by' works", {
       pl$sum("a")$alias("sum_a"),
       pl$min("a")$alias("min_a"),
       pl$max("a")$alias("max_a")
-    )$select("sum_a", "min_a", "max_a"),
+    )$sort("grp", "index")$select("sum_a", "min_a", "max_a"),
     .input = df,
     pl$DataFrame(
       sum_a = c(3, 10, 5, 14, 2, 3),
@@ -2260,11 +2260,11 @@ test_that("rolling: argument 'group_by' works", {
   expect_query_equal(
     .input$rolling(index_column = "index", period = "2i", group_by = "grp")$agg(
       pl$sum("a")$alias("sum_a")
-    ),
+    )$sort("grp", "index"),
     .input = df,
     df$rolling(index_column = "index", period = "2i", group_by = pl$col("grp"))$agg(
       pl$sum("a")$alias("sum_a")
-    )
+    )$sort("grp", "index")
   )
 })
 
@@ -2541,7 +2541,7 @@ test_that("group_by_dynamic: argument 'by' works", {
   expect_query_equal(
     .input$group_by_dynamic(index_column = "dt", every = "2h", group_by = pl$col("grp"))$agg(
       pl$col("n")$mean()
-    ),
+    )$sort("grp", "dt"),
     .input = df,
     pl$DataFrame(
       grp = c("a", "a", "b", "b"),
@@ -2554,14 +2554,14 @@ test_that("group_by_dynamic: argument 'by' works", {
         )
       ),
       n = c(1, 5.5, 3, 4)
-    )
+    )$sort("grp", "dt")
   )
 
   # string is parsed as column name in "by"
   expect_query_equal(
     .input$group_by_dynamic(index_column = "dt", every = "2h", group_by = "grp")$agg(
       pl$col("n")$mean()
-    ),
+    )$sort("grp", "dt"),
     .input = df,
     pl$DataFrame(
       grp = c("a", "a", "b", "b"),
@@ -2574,7 +2574,7 @@ test_that("group_by_dynamic: argument 'by' works", {
         )
       ),
       n = c(1, 5.5, 3, 4)
-    )
+    )$sort("grp", "dt")
   )
 })
 

--- a/tests/testthat/test-migration-polars-2.R
+++ b/tests/testthat/test-migration-polars-2.R
@@ -1,0 +1,195 @@
+test_that("CSV preserves the current ragged-line default", {
+  tmpf <- withr::local_tempfile(fileext = ".csv")
+  writeLines(c("a,b", "1,2,3", "4,5"), tmpf)
+
+  expect_error(
+    pl$read_csv(tmpf, infer_schema_files = NULL),
+    "found more fields than defined"
+  )
+  expect_error(
+    pl$read_csv(tmpf, truncate_ragged_lines = FALSE, infer_schema_files = NULL),
+    "found more fields than defined"
+  )
+  expect_equal(
+    pl$read_csv(tmpf, truncate_ragged_lines = TRUE, infer_schema_files = NULL),
+    pl$DataFrame(a = c(1L, 4L), b = c(2L, 5L))$cast(pl$Int64)
+  )
+
+  # TODO: @2.0: update the omitted default to Polars 2.0's `extra_columns`
+  # behavior and retain the explicit TRUE regression test.
+})
+
+test_that("CSV preserves current generated names for headerless input", {
+  tmpf <- withr::local_tempfile(fileext = ".csv")
+  writeLines(c("1,2", "3,4"), tmpf)
+
+  out <- pl$read_csv(tmpf, has_header = FALSE, infer_schema_files = NULL)
+  expect_named(out, c("column_1", "column_2"))
+
+  # TODO: @2.0: update the expected generated names to `column_0`, `column_1`.
+})
+
+test_that("datetime and repeat retain current generated names", {
+  datetime_from_columns <- pl$DataFrame(
+    year = 2024L,
+    month = 1L,
+    day = 2L
+  )$select(pl$datetime(pl$col("year"), pl$col("month"), pl$col("day")))
+  repeated <- pl$select(pl$repeat_("x", n = 2))
+
+  expect_named(datetime_from_columns, "datetime")
+  expect_named(repeated, "repeat")
+
+  # TODO: @2.0: update the datetime expectations to the leftmost argument
+  # name (`year`) and the repeat expectation to `literal`; prefer `$alias()`
+  # for names that are part of a user contract.
+})
+
+test_that("signed integer and UInt64 retain the current supertype", {
+  uint64 <- pl$Series("uint64", c("1", "2"))$cast(pl$UInt64)
+  out <- pl$select(pl$lit(-1L) + pl$lit(uint64))
+
+  expect_equal(out$schema, list(literal = pl$Float64))
+  expect_equal(out$to_series()$to_r_vector(), c(0, 1))
+
+  # TODO: @2.0: update the expected supertype to Int128.
+})
+
+test_that("numeric is_in preserves the current lossy comparison", {
+  input <- pl$DataFrame(value = 1L)$cast(value = pl$Int64)
+
+  expect_equal(
+    input$select(pl$col("value")$is_in(list(1.99))),
+    pl$DataFrame(value = FALSE)
+  )
+
+  # TODO: @2.0: expect this lossy Int64-to-Float64 coercion to raise an error.
+})
+
+test_that("strict Struct casts preserve current behavior", {
+  input <- pl$DataFrame(a = 1:2, b = c("x", "y"))$select(s = pl$struct("a", "b"))
+  target <- pl$Struct(a = pl$Int64, b = pl$String, c = pl$Int64)
+
+  out <- input$select(pl$col("s")$cast(target, strict = TRUE))
+  expect_equal(
+    out$unnest("s"),
+    pl$DataFrame(a = c(1, 2), b = c("x", "y"), c = c(NA_real_, NA_real_))$cast(
+      a = pl$Int64,
+      c = pl$Int64
+    )
+  )
+  expect_equal(
+    out$schema,
+    list(s = target)
+  )
+
+  # TODO: @2.0: expect strict = TRUE to reject the extra field instead of
+  # silently inserting a null field.
+})
+
+test_that("Duration statistics preserve current behavior", {
+  input <- pl$DataFrame(x = as_polars_series(1:3)$cast(pl$Duration("ms")))
+
+  expect_equal(input$select(pl$col("x")$std())$schema, list(x = pl$Duration("ms")))
+  expect_snapshot(input$select(pl$col("x")$var()), error = TRUE)
+  expect_snapshot(input$select(pl$col("x")$ewm_std(com = 1)))
+  expect_snapshot(input$select(pl$col("x")$ewm_var(com = 1)), error = TRUE)
+
+  # TODO: @2.0: expect all four operations (std(), var(), ewm_std(), and
+  # ewm_var()) to raise an error; var() and ewm_var() already do so today.
+})
+
+test_that("empty DataFrame transpose preserves the current error", {
+  expect_snapshot(pl$DataFrame()$transpose(), error = TRUE)
+
+  # TODO: @2.0: replace this error snapshot with the supported empty-frame
+  # transpose result.
+})
+
+test_that("selecting no columns preserves the current zero-width height", {
+  out <- pl$DataFrame(a = 1:3, b = 4:6)$select()
+
+  expect_equal(dim(out), c(0L, 0L))
+
+  # TODO: @2.0: expect zero-width frames to preserve their input height, so
+  # this result should have dimensions c(3L, 0L).
+})
+
+test_that("list and array to_struct preserve outer nulls", {
+  list_input <- pl$DataFrame(x = list(NULL, c(1L, 2L)))
+  array_input <- pl$DataFrame(x = list(c(1L, 2L), NULL))$cast(
+    x = pl$Array(pl$Int32, 2)
+  )
+
+  expect_equal(
+    list_input$select(pl$col("x")$list$to_struct(fields = c("a", "b")))$unnest("x"),
+    pl$DataFrame(a = c(NA_integer_, 1L), b = c(NA_integer_, 2L))
+  )
+  expect_equal(
+    array_input$select(pl$col("x")$arr$to_struct(fields = c("a", "b")))$unnest("x"),
+    pl$DataFrame(a = c(1L, NA_integer_), b = c(2L, NA_integer_))
+  )
+  expect_equal(
+    list_input$select(pl$col("x")$list$to_struct(fields = c("a", "b")))$select(
+      pl$col("x")$is_null()
+    ),
+    pl$DataFrame(x = c(FALSE, FALSE))
+  )
+  expect_equal(
+    array_input$select(pl$col("x")$arr$to_struct(fields = c("a", "b")))$select(
+      pl$col("x")$is_null()
+    ),
+    pl$DataFrame(x = c(FALSE, FALSE))
+  )
+
+  # TODO: @2.0: update the null masks to c(TRUE, FALSE) and c(FALSE, TRUE)
+  # when an outer null remains a null Struct.
+})
+
+test_that("Rust deprecation warnings are routed to R snapshots", {
+  local_lifecycle_warnings()
+
+  expect_snapshot(
+    pl$DataFrame(x = 1:3)$select(pl$col("x")$cast(pl$List(pl$Int32))),
+    cnd_class = TRUE
+  )
+  expect_snapshot(
+    pl$select(pl$lit(c(TRUE, FALSE)) & pl$lit(c(1L, 0L))),
+    cnd_class = TRUE
+  )
+  expect_snapshot(
+    pl$select(pl$lit(c(TRUE, FALSE)) | pl$lit(c(1L, 0L))),
+    cnd_class = TRUE
+  )
+  expect_snapshot(
+    pl$select(pl$lit(c(TRUE, FALSE))$xor(pl$lit(c(1L, 0L)))),
+    cnd_class = TRUE
+  )
+  expect_snapshot(
+    pl$DataFrame(x = list(c(1L, 2L), c(3L, 4L)))$select(
+      pl$col("x")$list$gather(c(0L, 1L))
+    ),
+    cnd_class = TRUE
+  )
+  expect_snapshot(
+    pl$DataFrame(x = 1:3)$select(pl$col("x")$is_in(pl$lit(1:3))),
+    cnd_class = TRUE
+  )
+  expect_snapshot(
+    pl$DataFrame(x = 1:3)$select(pl$col("x")$shift(NULL)),
+    cnd_class = TRUE
+  )
+
+  categorical <- pl$DataFrame(x = c("a", "b"))$cast(x = pl$Categorical())
+  enum <- pl$DataFrame(x = c("a", "b"))$cast(x = pl$Enum(c("a", "b")))
+  expect_snapshot(categorical$select(pl$col("x")$cast(pl$UInt32)), cnd_class = TRUE)
+  expect_snapshot(enum$select(pl$col("x")$cast(pl$UInt32)), cnd_class = TRUE)
+  expect_snapshot(
+    pl$DataFrame(x = 0:1)$select(pl$col("x")$cast(pl$Categorical())),
+    cnd_class = TRUE
+  )
+  expect_snapshot(
+    pl$DataFrame(x = 0:1)$select(pl$col("x")$cast(pl$Enum(c("a", "b")))),
+    cnd_class = TRUE
+  )
+})

--- a/tests/testthat/test-migration-polars-2.R
+++ b/tests/testthat/test-migration-polars-2.R
@@ -1,3 +1,9 @@
+normalize_warning_snapshot <- function(lines) {
+  # Drop platform-specific blank warning lines after normalizing line endings.
+  lines <- sub("\\r$", "", lines)
+  lines[!grepl("^[[:blank:]]*$", lines)]
+}
+
 test_that("CSV preserves the current ragged-line default", {
   tmpf <- withr::local_tempfile(fileext = ".csv")
   writeLines(c("a,b", "1,2,3", "4,5"), tmpf)
@@ -169,10 +175,12 @@ test_that("Rust deprecation warnings are routed to R snapshots", {
     pl$DataFrame(x = list(c(1L, 2L), c(3L, 4L)))$select(
       pl$col("x")$list$gather(c(0L, 1L))
     ),
+    transform = normalize_warning_snapshot,
     cnd_class = TRUE
   )
   expect_snapshot(
     pl$DataFrame(x = 1:3)$select(pl$col("x")$is_in(pl$lit(1:3))),
+    transform = normalize_warning_snapshot,
     cnd_class = TRUE
   )
   expect_snapshot(


### PR DESCRIPTION
## Summary

- add regression coverage for semantic changes planned for Polars 2.0
- snapshot Rust-side migration warnings that already reach R
- make ordering-sensitive tests explicit or order-independent
- verify eager CSV and Arrow IPC readers remain aligned with their lazy reader paths

## Tests

- `task test-filter FILTER=migration-polars-2`
- `task test-filter FILTER=lazyframe-frame`
- `task test-filter FILTER=input-csv-functions`
- `task test-filter FILTER=input-ipc-functions`
- `task jarl`
- `task air-format-check`
- changed-file `lintr`
