### PR TITLE
docs: add Polars 2.0 migration guidance

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,60 @@
 
 ## polars (development version)
 
+### Preparing for Polars 2.0
+
+R Polars 1.16 is the migration bridge: it preserves 1.x behavior while
+warning about detectable old forms. R Polars 2.0 is the semantic/API cutover.
+First make code warning-free under 1.16, then review the semantic changes below
+that cannot be detected reliably at the R call site.
+
+Warning-free migration forms include:
+
+* Use one vector/list argument: `pl$col(c("a", "b"))`,
+  `cs$by_name(c("a", "b"))`, and
+  `cs$by_dtype(c(pl$Int32, pl$Float64))`.
+* Use `cs$by_name()` for selector set operations, or
+  `<selector>$as_expr()` for element-wise operations.
+* Use `pl$lit(...)$implode()` for literal string patterns and `pl$col()` for
+  column patterns.
+* Pass explicit character fields to `to_struct()`.
+* Use one `seed` for hash functions. `seed_1`, `seed_2`, and `seed_3` will be
+  removed in Polars 2.0; only `seed` will remain, and hash values may change.
+* Pass `infer_schema_files = 10`, explicit Arrow IPC compression, and
+  `missing_columns = "insert"` or `"raise"` instead of
+  `allow_missing_columns`.
+* Use the current forms of `unique()`, `$list$explode()`, `$str$join()`, and
+  explicit casts instead of the deprecated compatibility forms. See the help
+  for `<expr>$agg_groups()`, `<series>$cat$is_local()`,
+  `<series>$cat$uses_lexical_ordering()`, and `<Enum>$union()` for their
+  replacements.
+* Remove `cache` and `file_cache_ttl`; Polars 2.0 has no direct replacement.
+
+Important semantic changes do not produce broad R warnings:
+
+* `engine = "auto"` uses streaming in Polars 2.0. Use
+  `engine = "in-memory"` as an escape hatch and sort results when order
+  matters.
+* Headerless CSV names change from `column_1` to `column_0`; CSV schema fields
+  match by name; partial `schema_overrides` should use a named list; and the
+  defaults for `raise_if_empty` and `truncate_ragged_lines` change.
+  `extra_columns` is a new Polars 2.0-only CSV API.
+* A signed integer with `UInt64` has supertype `Int128`; lossy numeric
+  coercion in `is_in()` becomes an error; and strict Struct casts reject
+  mismatched fields.
+* Duration `std()`, `var()`, `ewm_std()`, and `ewm_var()` become errors.
+  `pl$datetime()` and `pl$repeat_()` output names change, null
+  `list/array` values remain outer nulls in `to_struct()`, zero-width frames
+  retain their height, and empty DataFrames can be transposed.
+
+Eager `read_csv()` and `read_ipc()` already use `scan_csv()` and `scan_ipc()`
+followed by `collect()`, so no user change is needed for that migration.
+
+Before upgrading, run the full test suite on 1.16, replace detectable
+deprecated forms, make ordering requirements explicit, review the CSV and
+semantic cases above, remove cache arguments, then rerun application tests on
+2.0.
+
 ### Deprecations
 
 * `<expr>$flatten()` is deprecated. Use
@@ -17,15 +71,16 @@
   profiling information from this method misleading.
 * `$dt$with_time_unit()` is deprecated. Cast to Int64 and then to the desired
   Datetime or Duration dtype and time unit instead.
-* The `cache` argument of CSV and Arrow file readers is deprecated: Polars 2.0
-  streaming readers do not use the file cache, and `cache` has no direct
-  replacement. The deprecated `file_cache_ttl` argument of CSV, Arrow file,
-  and NDJSON readers now has the same guidance and is no longer translated
-  into `storage_options`.
-* Omitting `compression` in Arrow file output functions now warns that the
-  default will change from `"zstd"` to `"uncompressed"` in Polars 2.0. Pass
-  `compression = "zstd"` to keep the current behavior or
-  `compression = "uncompressed"` to opt into the new default.
+* The `cache` argument of CSV and Arrow IPC File Format readers is deprecated:
+  Polars 2.0 streaming readers do not use the file cache, and `cache` has no
+  direct replacement. The deprecated `file_cache_ttl` argument of CSV, Arrow
+  IPC File Format, and NDJSON readers now has the same guidance and is no
+  longer translated into `storage_options`.
+* Omitting `compression` in Arrow IPC File Format and Arrow IPC Stream Format
+  output functions now warns that the default will change from `"zstd"` to
+  `"uncompressed"` in Polars 2.0. Pass `compression = "zstd"` to keep the
+  current behavior or `compression = "uncompressed"` to opt into the new
+  default.
 * Bare character vectors passed to `<expr>$str$contains_any()` and
   `<expr>$str$replace_many()` will be interpreted as column names in Polars
   2.0. Use `pl$lit(...)$implode()` for literal patterns or `pl$col()` for
@@ -39,7 +94,8 @@
   `raise_if_empty` is documented; pass an explicit value when `has_header = FALSE`
   and `schema` is supplied.
 * The `seed_1`, `seed_2`, and `seed_3` arguments of `<expr>$hash()` and
-  `<dataframe>$hash_rows()` are deprecated. Use `seed` instead.
+  `<dataframe>$hash_rows()` will be removed in Polars 2.0; only `seed` will
+  remain, and hash values may change.
 * `<expr>$agg_groups()`, `<series>$cat$is_local()`, and
   `<series>$cat$uses_lexical_ordering()` are deprecated. Use the documented
   row-index aggregation pattern for `agg_groups()`; categoricals no longer

--- a/R/dataframe-frame.R
+++ b/R/dataframe-frame.R
@@ -2129,7 +2129,8 @@ dataframe__group_by_dynamic <- function(
 #'
 #' @param seed Random seed parameter. Defaults to 0.
 #' @param seed_1,seed_2,seed_3 `r lifecycle::badge("deprecated")` Random seed
-#' parameters. Defaults to `seed` if not set.
+#' parameters. Defaults to `seed` if not set. These arguments will be removed
+#' in Polars 2.0; only `seed` will remain, and hash values may change.
 #'
 #' @details
 #' This implementation does not guarantee stable results across different

--- a/R/expr-expr.R
+++ b/R/expr-expr.R
@@ -2064,7 +2064,9 @@ expr__log1p <- function() {
 #'
 #' @param seed Integer, random seed parameter. Defaults to 0.
 #' @param seed_1,seed_2,seed_3 `r lifecycle::badge("deprecated")` Integer,
-#' random seed parameters. Default to `seed` if not set.
+#' random seed parameters. Default to `seed` if not set. These arguments will
+#' be removed in Polars 2.0; only `seed` will remain, and hash values may
+#' change.
 #' @inherit as_polars_expr return
 #'
 #' @details

--- a/R/lazyframe-frame.R
+++ b/R/lazyframe-frame.R
@@ -237,9 +237,12 @@ lazyframe__group_by <- function(..., .maintain_order = FALSE) {
 #' @param engine The engine name to use for processing the query.
 #'   One of the followings:
 #'   - `"auto"` (default): Select the engine automatically.
-#'     The `"in-memory"` engine will be selected for most cases.
-#'   - `"in-memory"`: Use the in-memory engine.
-#'   - `"streaming"`: `r lifecycle::badge("experimental")` Use the (new) streaming engine.
+#'     In Polars 1.16, the `"in-memory"` engine is selected for most cases.
+#'     Starting with Polars 2.0, the streaming engine is selected instead.
+#'     Use `"in-memory"` to keep the current execution engine explicitly.
+#'   - `"in-memory"`: Use the in-memory engine. This is an escape hatch for
+#'     queries whose incidental row order differs under streaming.
+#'   - `"streaming"`: Use the streaming engine.
 #' @param optimizations `r lifecycle::badge("experimental")`
 #'   A [QueryOptFlags] object to indicate optimization passes done during query optimization.
 #' @param type_coercion `r lifecycle::badge("deprecated")`
@@ -1779,6 +1782,9 @@ lazyframe__pivot <- function(
 #' the melted columns. Defaults to `"variable"`.
 #' @param value_name Name to give to the new column containing the values of
 #' the melted columns. Defaults to `"value"`.
+#'
+#' The row order of the result is not guaranteed; use `$sort()` when a stable
+#' order is required.
 #'
 #' @inherit as_polars_lf return
 #'

--- a/R/utils-deprecation.R
+++ b/R/utils-deprecation.R
@@ -138,7 +138,10 @@ warn_deprecated_hash_seeds <- function(fn, user_env = caller_env(2)) {
         format_fn(fn),
         format_pkg("polars")
       ),
-      i = sprintf("Use the %s argument instead.", format_arg("seed"))
+      i = paste0(
+        "The `seed_1`, `seed_2`, and `seed_3` arguments will be removed in ",
+        "Polars 2.0; only `seed` will remain. Hash values may change."
+      )
     ),
     user_env = user_env
   )

--- a/man/as_polars_df.Rd
+++ b/man/as_polars_df.Rd
@@ -61,9 +61,12 @@ from the struct \link{Series}. In this case, the \code{column_name} argument is 
 One of the followings:
 \itemize{
 \item \code{"auto"} (default): Select the engine automatically.
-The \code{"in-memory"} engine will be selected for most cases.
-\item \code{"in-memory"}: Use the in-memory engine.
-\item \code{"streaming"}: \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}} Use the (new) streaming engine.
+In Polars 1.16, the \code{"in-memory"} engine is selected for most cases.
+Starting with Polars 2.0, the streaming engine is selected instead.
+Use \code{"in-memory"} to keep the current execution engine explicitly.
+\item \code{"in-memory"}: Use the in-memory engine. This is an escape hatch for
+queries whose incidental row order differs under streaming.
+\item \code{"streaming"}: Use the streaming engine.
 }}
 
 \item{optimizations}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}

--- a/man/dataframe__hash_rows.Rd
+++ b/man/dataframe__hash_rows.Rd
@@ -15,7 +15,8 @@ dataframe__hash_rows(
 \item{seed}{Random seed parameter. Defaults to 0.}
 
 \item{seed_1, seed_2, seed_3}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Random seed
-parameters. Defaults to \code{seed} if not set.}
+parameters. Defaults to \code{seed} if not set. These arguments will be removed
+in Polars 2.0; only \code{seed} will remain, and hash values may change.}
 }
 \value{
 A \link[=Series]{polars Series}

--- a/man/dataframe__unpivot.Rd
+++ b/man/dataframe__unpivot.Rd
@@ -25,7 +25,10 @@ If set to \code{NULL} (default), all columns that are not in \code{index} will b
 the melted columns. Defaults to \code{"variable"}.}
 
 \item{value_name}{Name to give to the new column containing the values of
-the melted columns. Defaults to \code{"value"}.}
+the melted columns. Defaults to \code{"value"}.
+
+The row order of the result is not guaranteed; use \verb{$sort()} when a stable
+order is required.}
 }
 \value{
 A polars \link{LazyFrame}

--- a/man/expr__hash.Rd
+++ b/man/expr__hash.Rd
@@ -15,7 +15,9 @@ expr__hash(
 \item{seed}{Integer, random seed parameter. Defaults to 0.}
 
 \item{seed_1, seed_2, seed_3}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Integer,
-random seed parameters. Default to \code{seed} if not set.}
+random seed parameters. Default to \code{seed} if not set. These arguments will
+be removed in Polars 2.0; only \code{seed} will remain, and hash values may
+change.}
 }
 \value{
 A polars \link{expression}

--- a/man/lazyframe__collect.Rd
+++ b/man/lazyframe__collect.Rd
@@ -27,9 +27,12 @@ lazyframe__collect(
 One of the followings:
 \itemize{
 \item \code{"auto"} (default): Select the engine automatically.
-The \code{"in-memory"} engine will be selected for most cases.
-\item \code{"in-memory"}: Use the in-memory engine.
-\item \code{"streaming"}: \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}} Use the (new) streaming engine.
+In Polars 1.16, the \code{"in-memory"} engine is selected for most cases.
+Starting with Polars 2.0, the streaming engine is selected instead.
+Use \code{"in-memory"} to keep the current execution engine explicitly.
+\item \code{"in-memory"}: Use the in-memory engine. This is an escape hatch for
+queries whose incidental row order differs under streaming.
+\item \code{"streaming"}: Use the streaming engine.
 }}
 
 \item{optimizations}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}

--- a/man/lazyframe__explain.Rd
+++ b/man/lazyframe__explain.Rd
@@ -31,9 +31,12 @@ either \code{"plain"} (default) or \code{"tree"}.}
 One of the followings:
 \itemize{
 \item \code{"auto"} (default): Select the engine automatically.
-The \code{"in-memory"} engine will be selected for most cases.
-\item \code{"in-memory"}: Use the in-memory engine.
-\item \code{"streaming"}: \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}} Use the (new) streaming engine.
+In Polars 1.16, the \code{"in-memory"} engine is selected for most cases.
+Starting with Polars 2.0, the streaming engine is selected instead.
+Use \code{"in-memory"} to keep the current execution engine explicitly.
+\item \code{"in-memory"}: Use the in-memory engine. This is an escape hatch for
+queries whose incidental row order differs under streaming.
+\item \code{"streaming"}: Use the streaming engine.
 }}
 
 \item{optimized}{Return an optimized query plan. If \code{TRUE} (default), the

--- a/man/lazyframe__profile.Rd
+++ b/man/lazyframe__profile.Rd
@@ -34,9 +34,12 @@ number of characters. If \code{0} (default), do not truncate.}
 One of the followings:
 \itemize{
 \item \code{"auto"} (default): Select the engine automatically.
-The \code{"in-memory"} engine will be selected for most cases.
-\item \code{"in-memory"}: Use the in-memory engine.
-\item \code{"streaming"}: \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}} Use the (new) streaming engine.
+In Polars 1.16, the \code{"in-memory"} engine is selected for most cases.
+Starting with Polars 2.0, the streaming engine is selected instead.
+Use \code{"in-memory"} to keep the current execution engine explicitly.
+\item \code{"in-memory"}: Use the in-memory engine. This is an escape hatch for
+queries whose incidental row order differs under streaming.
+\item \code{"streaming"}: Use the streaming engine.
 }}
 
 \item{optimizations}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}

--- a/man/lazyframe__sink_batches.Rd
+++ b/man/lazyframe__sink_batches.Rd
@@ -39,9 +39,12 @@ this to \code{FALSE} will be slightly faster.}
 One of the followings:
 \itemize{
 \item \code{"auto"} (default): Select the engine automatically.
-The \code{"in-memory"} engine will be selected for most cases.
-\item \code{"in-memory"}: Use the in-memory engine.
-\item \code{"streaming"}: \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}} Use the (new) streaming engine.
+In Polars 1.16, the \code{"in-memory"} engine is selected for most cases.
+Starting with Polars 2.0, the streaming engine is selected instead.
+Use \code{"in-memory"} to keep the current execution engine explicitly.
+\item \code{"in-memory"}: Use the in-memory engine. This is an escape hatch for
+queries whose incidental row order differs under streaming.
+\item \code{"streaming"}: Use the streaming engine.
 }}
 
 \item{optimizations}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}

--- a/man/lazyframe__sink_csv.Rd
+++ b/man/lazyframe__sink_csv.Rd
@@ -174,9 +174,12 @@ accessing a cloud instance fails. Specify \code{max_retries} in
 One of the followings:
 \itemize{
 \item \code{"auto"} (default): Select the engine automatically.
-The \code{"in-memory"} engine will be selected for most cases.
-\item \code{"in-memory"}: Use the in-memory engine.
-\item \code{"streaming"}: \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}} Use the (new) streaming engine.
+In Polars 1.16, the \code{"in-memory"} engine is selected for most cases.
+Starting with Polars 2.0, the streaming engine is selected instead.
+Use \code{"in-memory"} to keep the current execution engine explicitly.
+\item \code{"in-memory"}: Use the in-memory engine. This is an escape hatch for
+queries whose incidental row order differs under streaming.
+\item \code{"streaming"}: Use the streaming engine.
 }}
 
 \item{optimizations}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}

--- a/man/lazyframe__sink_ipc.Rd
+++ b/man/lazyframe__sink_ipc.Rd
@@ -104,9 +104,12 @@ accessing a cloud instance fails. Specify \code{max_retries} in
 One of the followings:
 \itemize{
 \item \code{"auto"} (default): Select the engine automatically.
-The \code{"in-memory"} engine will be selected for most cases.
-\item \code{"in-memory"}: Use the in-memory engine.
-\item \code{"streaming"}: \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}} Use the (new) streaming engine.
+In Polars 1.16, the \code{"in-memory"} engine is selected for most cases.
+Starting with Polars 2.0, the streaming engine is selected instead.
+Use \code{"in-memory"} to keep the current execution engine explicitly.
+\item \code{"in-memory"}: Use the in-memory engine. This is an escape hatch for
+queries whose incidental row order differs under streaming.
+\item \code{"streaming"}: Use the streaming engine.
 }}
 
 \item{optimizations}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}

--- a/man/lazyframe__sink_ndjson.Rd
+++ b/man/lazyframe__sink_ndjson.Rd
@@ -93,9 +93,12 @@ accessing a cloud instance fails. Specify \code{max_retries} in
 One of the followings:
 \itemize{
 \item \code{"auto"} (default): Select the engine automatically.
-The \code{"in-memory"} engine will be selected for most cases.
-\item \code{"in-memory"}: Use the in-memory engine.
-\item \code{"streaming"}: \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}} Use the (new) streaming engine.
+In Polars 1.16, the \code{"in-memory"} engine is selected for most cases.
+Starting with Polars 2.0, the streaming engine is selected instead.
+Use \code{"in-memory"} to keep the current execution engine explicitly.
+\item \code{"in-memory"}: Use the in-memory engine. This is an escape hatch for
+queries whose incidental row order differs under streaming.
+\item \code{"streaming"}: Use the streaming engine.
 }}
 
 \item{optimizations}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}

--- a/man/lazyframe__sink_parquet.Rd
+++ b/man/lazyframe__sink_parquet.Rd
@@ -141,9 +141,12 @@ accessing a cloud instance fails. Specify \code{max_retries} in
 One of the followings:
 \itemize{
 \item \code{"auto"} (default): Select the engine automatically.
-The \code{"in-memory"} engine will be selected for most cases.
-\item \code{"in-memory"}: Use the in-memory engine.
-\item \code{"streaming"}: \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}} Use the (new) streaming engine.
+In Polars 1.16, the \code{"in-memory"} engine is selected for most cases.
+Starting with Polars 2.0, the streaming engine is selected instead.
+Use \code{"in-memory"} to keep the current execution engine explicitly.
+\item \code{"in-memory"}: Use the in-memory engine. This is an escape hatch for
+queries whose incidental row order differs under streaming.
+\item \code{"streaming"}: Use the streaming engine.
 }}
 
 \item{optimizations}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}

--- a/man/lazyframe__unpivot.Rd
+++ b/man/lazyframe__unpivot.Rd
@@ -25,7 +25,10 @@ If set to \code{NULL} (default), all columns that are not in \code{index} will b
 the melted columns. Defaults to \code{"variable"}.}
 
 \item{value_name}{Name to give to the new column containing the values of
-the melted columns. Defaults to \code{"value"}.}
+the melted columns. Defaults to \code{"value"}.
+
+The row order of the result is not guaranteed; use \verb{$sort()} when a stable
+order is required.}
 }
 \value{
 A polars \link{LazyFrame}

--- a/man/pl__collect_all.Rd
+++ b/man/pl__collect_all.Rd
@@ -20,9 +20,12 @@ pl__collect_all(
 One of the followings:
 \itemize{
 \item \code{"auto"} (default): Select the engine automatically.
-The \code{"in-memory"} engine will be selected for most cases.
-\item \code{"in-memory"}: Use the in-memory engine.
-\item \code{"streaming"}: \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}} Use the (new) streaming engine.
+In Polars 1.16, the \code{"in-memory"} engine is selected for most cases.
+Starting with Polars 2.0, the streaming engine is selected instead.
+Use \code{"in-memory"} to keep the current execution engine explicitly.
+\item \code{"in-memory"}: Use the in-memory engine. This is an escape hatch for
+queries whose incidental row order differs under streaming.
+\item \code{"streaming"}: Use the streaming engine.
 }}
 
 \item{optimizations}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}

--- a/tests/testthat/_snaps/dataframe-frame.md
+++ b/tests/testthat/_snaps/dataframe-frame.md
@@ -157,7 +157,7 @@
     Condition <lifecycle_warning_deprecated>
       Warning:
       ! The `seed_1`, `seed_2`, and `seed_3` arguments of `<dataframe>$hash_rows()` are deprecated as of polars 1.16.0.
-      i Use the `seed` argument instead.
+      i The `seed_1`, `seed_2`, and `seed_3` arguments will be removed in Polars 2.0; only `seed` will remain. Hash values may change.
 
 ---
 
@@ -166,7 +166,7 @@
     Condition <lifecycle_warning_deprecated>
       Warning:
       ! The `seed_1`, `seed_2`, and `seed_3` arguments of `<dataframe>$hash_rows()` are deprecated as of polars 1.16.0.
-      i Use the `seed` argument instead.
+      i The `seed_1`, `seed_2`, and `seed_3` arguments will be removed in Polars 2.0; only `seed` will remain. Hash values may change.
 
 ---
 
@@ -175,7 +175,7 @@
     Condition <lifecycle_warning_deprecated>
       Warning:
       ! The `seed_1`, `seed_2`, and `seed_3` arguments of `<dataframe>$hash_rows()` are deprecated as of polars 1.16.0.
-      i Use the `seed` argument instead.
+      i The `seed_1`, `seed_2`, and `seed_3` arguments will be removed in Polars 2.0; only `seed` will remain. Hash values may change.
 
 ---
 
@@ -184,7 +184,7 @@
     Condition <lifecycle_warning_deprecated>
       Warning:
       ! The `seed_1`, `seed_2`, and `seed_3` arguments of `<dataframe>$hash_rows()` are deprecated as of polars 1.16.0.
-      i Use the `seed` argument instead.
+      i The `seed_1`, `seed_2`, and `seed_3` arguments will be removed in Polars 2.0; only `seed` will remain. Hash values may change.
 
 ---
 
@@ -193,7 +193,7 @@
     Condition <lifecycle_warning_deprecated>
       Warning:
       ! The `seed_1`, `seed_2`, and `seed_3` arguments of `<dataframe>$hash_rows()` are deprecated as of polars 1.16.0.
-      i Use the `seed` argument instead.
+      i The `seed_1`, `seed_2`, and `seed_3` arguments will be removed in Polars 2.0; only `seed` will remain. Hash values may change.
 
 # unstack() works
 

--- a/tests/testthat/_snaps/expr-expr.md
+++ b/tests/testthat/_snaps/expr-expr.md
@@ -336,7 +336,7 @@
     Condition <lifecycle_warning_deprecated>
       Warning:
       ! The `seed_1`, `seed_2`, and `seed_3` arguments of `<expr>$hash()` are deprecated as of polars 1.16.0.
-      i Use the `seed` argument instead.
+      i The `seed_1`, `seed_2`, and `seed_3` arguments will be removed in Polars 2.0; only `seed` will remain. Hash values may change.
 
 ---
 
@@ -345,7 +345,7 @@
     Condition <lifecycle_warning_deprecated>
       Warning:
       ! The `seed_1`, `seed_2`, and `seed_3` arguments of `<expr>$hash()` are deprecated as of polars 1.16.0.
-      i Use the `seed` argument instead.
+      i The `seed_1`, `seed_2`, and `seed_3` arguments will be removed in Polars 2.0; only `seed` will remain. Hash values may change.
 
 ---
 
@@ -354,7 +354,7 @@
     Condition <lifecycle_warning_deprecated>
       Warning:
       ! The `seed_1`, `seed_2`, and `seed_3` arguments of `<expr>$hash()` are deprecated as of polars 1.16.0.
-      i Use the `seed` argument instead.
+      i The `seed_1`, `seed_2`, and `seed_3` arguments will be removed in Polars 2.0; only `seed` will remain. Hash values may change.
 
 ---
 
@@ -363,7 +363,7 @@
     Condition <lifecycle_warning_deprecated>
       Warning:
       ! The `seed_1`, `seed_2`, and `seed_3` arguments of `<expr>$hash()` are deprecated as of polars 1.16.0.
-      i Use the `seed` argument instead.
+      i The `seed_1`, `seed_2`, and `seed_3` arguments will be removed in Polars 2.0; only `seed` will remain. Hash values may change.
 
 ---
 
@@ -372,7 +372,7 @@
     Condition <lifecycle_warning_deprecated>
       Warning:
       ! The `seed_1`, `seed_2`, and `seed_3` arguments of `<expr>$hash()` are deprecated as of polars 1.16.0.
-      i Use the `seed` argument instead.
+      i The `seed_1`, `seed_2`, and `seed_3` arguments will be removed in Polars 2.0; only `seed` will remain. Hash values may change.
 
 # rolling_*_by only works with date, datetime, or integers
 

--- a/tests/testthat/_snaps/series-s3-base.md
+++ b/tests/testthat/_snaps/series-s3-base.md
@@ -5,7 +5,7 @@
     Condition <lifecycle_warning_deprecated>
       Warning:
       ! The `seed_1`, `seed_2`, and `seed_3` arguments of `<expr>$hash()` are deprecated as of polars 1.16.0.
-      i Use the `seed` argument instead.
+      i The `seed_1`, `seed_2`, and `seed_3` arguments will be removed in Polars 2.0; only `seed` will remain. Hash values may change.
 
 # .DollarNames(<series>)
 


### PR DESCRIPTION
## Summary

- document R Polars 1.16 as the migration bridge to 2.0 in NEWS
- list warning-free forms and semantic changes that require manual review
- clarify that additional hash seeds will be removed and hash values may change
- document the 2.0 streaming default and operations with non-guaranteed row order
- remove the experimental badge from the streaming engine to match Polars 2.0

## Tests

- `task build-documents`
- `task test-filter 'FILTER=(dataframe-frame|expr-expr|series-s3-base|lazyframe-frame)'` — 1136 passed
- `air format --check .`
- `jarl check R tests`
- `lintr::lint_package(cache = TRUE)`
- `git diff --check`
